### PR TITLE
Refactor level2 to eliminate the input_sink and set all input defaults in the top group's configure method.

### DIFF
--- a/aviary/docs/getting_started/onboarding_level2.ipynb
+++ b/aviary/docs/getting_started/onboarding_level2.ipynb
@@ -550,8 +550,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Zero Fuel Mass (lbm)\",\n",
-    "      prob.get_val(Aircraft.Design.ZERO_FUEL_MASS, units='lbm'))\n",
     "print(\"Mission.Objectives.FUEL\",\n",
     "      prob.get_val(Mission.Objectives.FUEL, units='unitless'))\n",
     "print(\"Mission.Design.FUEL_MASS\",\n",
@@ -889,7 +887,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -903,7 +901,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -134,7 +134,7 @@ class AviaryGroup(om.Group):
         all_prom_inputs = []
 
         # Find promoted name of every input in the model.
-        for system in self.system_iter(recurse=False):
+        for system in self.system_iter(recurse=False, typ=om.Group):
             var_abs = system.list_inputs(out_stream=None)
             var_prom = [v['prom_name'] for k, v in var_abs]
             all_prom_inputs.extend(var_prom)

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -118,6 +118,7 @@ class AviaryGroup(om.Group):
     method. This assures that we only call set_input_defaults on variables
     that are present in the model.
     """
+
     def initialize(self):
         self.options.declare(
             'aviary_options', types=AviaryValues,

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -1825,7 +1825,6 @@ class AviaryProblem(om.Problem):
         # "input variable '...' promoted using '*' was already promoted using 'aircraft:*'
         with warnings.catch_warnings():
 
-            # Set initial default values for all LEAPS aircraft variables.
             self.model.options['aviary_options'] = self.aviary_inputs
             self.model.options['aviary_metadata'] = self.meta_data
 

--- a/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
@@ -13,7 +13,7 @@ from aviary.variable_info.variables import Aircraft, Mission
 class ProblemPhaseTestCase(unittest.TestCase):
 
     @require_pyoptsparse(optimizer="IPOPT")
-    def bench_test_swap_3_FwGm(self):
+    def bench_test_swap_3_FwGm_IPOPT(self):
         local_phase_info = deepcopy(phase_info)
         prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwGm.csv',
                           local_phase_info, optimizer='IPOPT')
@@ -64,4 +64,4 @@ class ProblemPhaseTestCase(unittest.TestCase):
 if __name__ == "__main__":
     # unittest.main()
     test = ProblemPhaseTestCase()
-    test.bench_test_swap_3_FwGm_SNOPT()
+    test.bench_test_swap_3_FwGm_IPOPT()

--- a/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
@@ -64,4 +64,4 @@ class ProblemPhaseTestCase(unittest.TestCase):
 if __name__ == "__main__":
     # unittest.main()
     test = ProblemPhaseTestCase()
-    test.bench_test_swap_3_FwGm_IPOPT()
+    test.bench_test_swap_3_FwGm_SNOPT()

--- a/aviary/validation_cases/benchmark_tests/test_subsystems_within_a_mission.py
+++ b/aviary/validation_cases/benchmark_tests/test_subsystems_within_a_mission.py
@@ -74,7 +74,7 @@ class TestSubsystemsMission(unittest.TestCase):
 
         prob.add_design_variables()
 
-        prob.add_objective('fuel')
+        prob.add_objective('fuel_burned')
 
         prob.setup()
 


### PR DESCRIPTION
### Summary

Prior to this change, the level 2 interface handled setting the model's input defaults by a call to a utility function right before setup. Since at this point, it isn't possible to figure out what inputs are in the model, we called set_input_defaults on everything in the aircraft metadata. Unfortunately, if you promote an input that isn't in the model, OpenMDAO raises an error. Our original workaround was to create the "input_sink" component, which contained almost every variable in the metadata dictionary. This approach caused other problems that we have gradually discovered...

This PR is a re-implementation, where we delay calling set_input_defaults until the top group's configure method. At this point, we know all of our subsystem's inputs and can query them, so we no longer need the input_sink.

1. Removed the "input_sink" component from the AviaryProblem interface.
2. Implemented a custom top level group (AviaryGroup) with a configure method that handles setting the input defaults.
3. Fixed a test that added an objective that didn't exist in the model.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None