### PR TITLE
Revert "Adding notification for PR reviews"

### DIFF
--- a/.github/workflows/notify_teams.yml
+++ b/.github/workflows/notify_teams.yml
@@ -5,9 +5,6 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, reopened, assigned, closed, ready_for_review, converted_to_draft, review_requested]
-  pull_request_review:
-    types: [submitted, edited]
-
 
 
 jobs:
@@ -141,40 +138,5 @@ jobs:
               "title": "${{ env.title }}",
               "action": "${{ env.action }}"
             }
-
-  send_email_on_review:
-    if: (github.event.action == 'submitted' || github.event.action == 'edited') && github.event.review.state == 'APPROVED'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout actions
-        uses: actions/checkout@v3
-        with:
-          sparse-checkout: |
-            .github/actions
-          path: actions
-          
-      - name: Get PR Data
-        run: |
-          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-          echo "title=${{ github.event.pull_request.title }}" >> $GITHUB_ENV
-          echo "user=${{ github.event.review.user.login }}" >> $GITHUB_ENV
-          echo "status=${{ github.event.review.state }}" >> $GITHUB_ENV
-
-      - name: Send Email on PR Review
-        uses: ./actions/.github/actions/send_email
-        with:
-          username: ${{ secrets.EMAIL_USERNAME }}
-          password: ${{ secrets.EMAIL_PASSWORD }}
-          to: ${{ secrets.DESTINATION_EMAIL }}
-          subject: "***Notification*** Reviewed Pull Request: ${{ env.number }}"
-          body: |
-            {
-              "number": "${{ env.number }}",
-              "title": "${{ env.title }}",
-              "action": "${{ env.action }}",
-              "user": "${{ env.user }}",
-              "status": "${{ env.status }}"
-            }
-          
 
           


### PR DESCRIPTION
Reverts OpenMDAO/Aviary#185
pull-request-review runs in the forked repository, not the main repository, so it does not have access to the necessary secrets.

We could setup a workaround if desired.
https://stackoverflow.com/questions/67247752/how-to-use-secret-in-pull-request-review-similar-to-pull-request-target