### PR TITLE
Renamed NPSS builder test

### DIFF
--- a/aviary/examples/external_subsystems/engine_NPSS/define_simple_engine_problem.py
+++ b/aviary/examples/external_subsystems/engine_NPSS/define_simple_engine_problem.py
@@ -22,6 +22,8 @@ def define_aviary_NPSS_problem():
     prob.load_inputs('models/test_aircraft/aircraft_for_bench_FwFm.csv',
                      phase_info, engine_builder=EngineBuilder())
 
+    prob.check_and_preprocess_inputs()
+
     prob.add_pre_mission_systems()
 
     prob.add_phases()

--- a/aviary/examples/external_subsystems/engine_NPSS/test_NPSS_builder.py
+++ b/aviary/examples/external_subsystems/engine_NPSS/test_NPSS_builder.py
@@ -12,7 +12,7 @@ from aviary.examples.external_subsystems.engine_NPSS.define_simple_engine_proble
 
 class AviaryNPSSTestCase(unittest.TestCase):
 
-    @unittest.skipUnless(os.environ.get('NPSS_TOP', False), 'environemnt does not contain NPSS')
+    @unittest.skipUnless(os.environ.get('NPSS_TOP', False), 'environment does not contain NPSS')
     def bench_test_aviary_NPSS(self):
         prob = define_aviary_NPSS_problem()
         prob.run_aviary_problem(suppress_solver_print=True)

--- a/aviary/examples/external_subsystems/engine_NPSS/test_NPSS_builder.py
+++ b/aviary/examples/external_subsystems/engine_NPSS/test_NPSS_builder.py
@@ -10,10 +10,10 @@ from openmdao.utils.assert_utils import assert_near_equal
 from aviary.examples.external_subsystems.engine_NPSS.define_simple_engine_problem import define_aviary_NPSS_problem
 
 
-class BenchAviaryNPSS(unittest.TestCase):
+class AviaryNPSSTestCase(unittest.TestCase):
 
     @unittest.skipUnless(os.environ.get('NPSS_TOP', False), 'environemnt does not contain NPSS')
-    def test_bench_aviary_NPSS(self):
+    def bench_test_aviary_NPSS(self):
         prob = define_aviary_NPSS_problem()
         prob.run_aviary_problem(suppress_solver_print=True)
 


### PR DESCRIPTION
### Summary

Renamed the NPSS builder test case so that it runs with the other benchmark tests via `testflo --testmatch=bench_test*` (if NPSS is available)

- renamed the file `benchmark_NPSS_builder.py` to `test_NPSS_builder.py`
- renamed the `BenchAviaryNPSS` test case to `AviaryNPSSTestCase`
- renamed the `test_bench_aviary_NPSS` test function to `bench_test_aviary_NPSS`

Also:
- added a call to `check_and_preprocess_inputs` which seems to be required now



### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None