### PR TITLE
Fix for some intermittent failures due to active reports.

### DIFF
--- a/aviary/interface/test/test_height_energy_mission.py
+++ b/aviary/interface/test/test_height_energy_mission.py
@@ -4,6 +4,7 @@ import subprocess
 
 from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 from openmdao.core.problem import _clear_problem_names
+from openmdao.utils.reports_system import clear_reports
 
 from aviary.interface.methods_for_level1 import run_aviary
 from aviary.subsystems.test.test_dummy_subsystem import ArrayGuessSubsystemBuilder
@@ -103,7 +104,9 @@ class AircraftMissionTestSuite(unittest.TestCase):
         self.make_plots = False
         self.max_iter = 100
 
-        _clear_problem_names()  # need to reset these to simulate separate runs
+        # need to reset these to simulate separate runs
+        _clear_problem_names()
+        clear_reports()
 
     def add_external_subsystem(self, phase_info, subsystem_builder):
         """


### PR DESCRIPTION
### Summary

This test runs through the level 1 interface, so all the problems use the same name. When we clear the problem names, the report registry is not getting cleared out.  It probably should be cleared out by OpenMDAO when we call `_clear_problem_names`, but such is the risk of using private functions. Until that is fixed in openmdao, we can manually make the call to `clear_reports` in our test setup.

Note: if you run with testflo and have enough procs, you probably never saw this error.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None