### PR TITLE
A couple more fixes for MPI execution.

### DIFF
--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -111,7 +111,7 @@ class AviaryGroup(om.Group):
 
         # We can call list_inputs on the groups.
         for system in self.system_iter(recurse=False, typ=om.Group):
-            var_abs = system.list_inputs(out_stream=None)
+            var_abs = system.list_inputs(out_stream=None, val=False)
             var_prom = [v['prom_name'] for k, v in var_abs]
             all_prom_inputs.extend(var_prom)
 

--- a/aviary/interface/reports.py
+++ b/aviary/interface/reports.py
@@ -206,6 +206,10 @@ def timeseries_csv(prob, **kwargs):
         includes='*timeseries*', out_stream=None, return_format='dict', units=True)
     phase_names = prob.model.traj._phases.keys()
 
+    # There are no more collective calls, so we can exit.
+    if MPI and MPI.COMM_WORLD.rank != 0:
+        return
+
     timeseries_outputs = {value['prom_name']: value for key,
                           value in timeseries_outputs.items()}
 
@@ -249,9 +253,6 @@ def timeseries_csv(prob, **kwargs):
         timeseries_data[variable_name]['val'] = val_full_traj
         timeseries_data[variable_name]['units'] = units
         timeseries_data[variable_name]['shape'] = val_full_traj.shape
-
-    if MPI and MPI.COMM_WORLD.rank != 0:
-        return
 
     # Create a DataFrame from timeseries_data
     df_data = {variable_name: pd.Series(timeseries_data[variable_name]['val'].flatten())


### PR DESCRIPTION
### Summary

1. We were getting an exception when configuring TACS, which has distributed variables. The ultimate bug is on the openmdao side, but we are able to sidestep it in Aviary by telling list_outputs not to gather the input values, since we were not using them anyway.
2. We were seeing an exception on ranks 1+ when printing the timeseries report. This was fixed by letting the non-zero ranks exit after the last collective call, so that they didn't try to interact with an empty dictionary.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None