### PR TITLE
Added db filenames to run examples

### DIFF
--- a/aviary/examples/reserve_missions/run_2dof_reserve_mission_fixedrange.py
+++ b/aviary/examples/reserve_missions/run_2dof_reserve_mission_fixedrange.py
@@ -53,4 +53,4 @@ prob.setup()
 
 prob.set_initial_guesses()
 
-prob.run_aviary_problem()
+prob.run_aviary_problem(record_filename='2dof_reserve_mission_fixedrange.db')

--- a/aviary/examples/reserve_missions/run_2dof_reserve_mission_fixedtime.py
+++ b/aviary/examples/reserve_missions/run_2dof_reserve_mission_fixedtime.py
@@ -54,4 +54,4 @@ prob.setup()
 
 prob.set_initial_guesses()
 
-prob.run_aviary_problem()
+prob.run_aviary_problem(record_filename='2dof_reserve_mission_fixedtime.db')

--- a/aviary/examples/reserve_missions/run_2dof_reserve_mission_multiphase.py
+++ b/aviary/examples/reserve_missions/run_2dof_reserve_mission_multiphase.py
@@ -89,4 +89,4 @@ prob.setup()
 
 prob.set_initial_guesses()
 
-prob.run_aviary_problem()
+prob.run_aviary_problem(record_filename='2dof_reserve_mission_multiphase.db')

--- a/aviary/examples/reserve_missions/run_reserve_mission_fixedrange.py
+++ b/aviary/examples/reserve_missions/run_reserve_mission_fixedrange.py
@@ -57,4 +57,4 @@ prob.setup()
 
 prob.set_initial_guesses()
 
-prob.run_aviary_problem()
+prob.run_aviary_problem(record_filename='reserve_mission_fixedrange.db')

--- a/aviary/examples/reserve_missions/run_reserve_mission_fixedtime.py
+++ b/aviary/examples/reserve_missions/run_reserve_mission_fixedtime.py
@@ -53,4 +53,4 @@ prob.setup()
 
 prob.set_initial_guesses()
 
-prob.run_aviary_problem()
+prob.run_aviary_problem(record_filename='reserve_mission_fixedtime.db')

--- a/aviary/examples/reserve_missions/run_reserve_mission_multiphase.py
+++ b/aviary/examples/reserve_missions/run_reserve_mission_multiphase.py
@@ -176,4 +176,4 @@ prob.setup()
 
 prob.set_initial_guesses()
 
-prob.run_aviary_problem()
+prob.run_aviary_problem(record_filename='reserve_mission_multiphase.db')


### PR DESCRIPTION
### Summary

I think this should fix the nightly benchmark failures.
The error was caused by trying to read an SQL file while it was being written.
I've seen this happen before when the .db file has the same name.
By giving unique names we should sidestep this issue.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None