### PR TITLE
Added intermediate state output to SGM trajectories

### DIFF
--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -1042,10 +1042,32 @@ class AviaryProblem(om.Problem):
                     (phases['cruise']['ode'], Dynamic.Mission.MASS, 0,),
                 ],
                 traj_intermediate_state_output=[
-                    ('cruise', Dynamic.Mission.DISTANCE)
+                    ('cruise', Dynamic.Mission.DISTANCE),
+                    ('cruise', Dynamic.Mission.MASS),
                 ]
             )
             traj = self.model.add_subsystem('traj', full_traj)
+
+            self.model.add_subsystem(
+                'actual_descent_fuel',
+                om.ExecComp('actual_descent_fuel = traj_cruise_mass_final - traj_mass_final',
+                            actual_descent_fuel={'units': 'lbm'},
+                            traj_cruise_mass_final={'units': 'lbm'},
+                            traj_mass_final={'units': 'lbm'},
+                            ))
+
+            self.model.connect(
+                'traj.mass_final',
+                'actual_descent_fuel.traj_mass_final',
+                src_indices=[-1],
+                flat_src_indices=True,
+            )
+            self.model.connect(
+                'traj.cruise_mass_final',
+                'actual_descent_fuel.traj_cruise_mass_final',
+                src_indices=[-1],
+                flat_src_indices=True,
+            )
             return traj
 
         def add_subsystem_timeseries_outputs(phase, phase_name):

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -1041,6 +1041,9 @@ class AviaryProblem(om.Problem):
                     (phases['climb3']['ode'], Dynamic.Mission.ALTITUDE, 0,),
                     (phases['cruise']['ode'], Dynamic.Mission.MASS, 0,),
                 ],
+                traj_intermediate_state_output=[
+                    ('cruise', Dynamic.Mission.DISTANCE)
+                ]
             )
             traj = self.model.add_subsystem('traj', full_traj)
             return traj

--- a/aviary/mission/gasp_based/ode/time_integration_base_classes.py
+++ b/aviary/mission/gasp_based/ode/time_integration_base_classes.py
@@ -509,9 +509,9 @@ class SGMTrajBase(om.ExplicitComponent):
             for final_state_output in traj_final_state_output
         }
         self.traj_intermediate_state_output = {
-            intermediate_state_output: {
+            phase_name+'_'+intermediate_state_output+final_suffix: {
                 **dict(
-                    name=phase_name+'_'+intermediate_state_output,
+                    phase_name=phase_name,
                     state_name=intermediate_state_output,
                 ),
                 **self.add_output(
@@ -632,6 +632,13 @@ class SGMTrajBase(om.ExplicitComponent):
 
             t = sim_result.t[-1]
             x = sim_result.x[-1, :]
+
+            for output_name, output in self.traj_intermediate_state_output.items():
+                if output['phase_name'] == current_problem.phase_name:
+                    outputs[output_name] = sim_result.x[
+                        -1,
+                        current_problem.state_names.index(output["state_name"])
+                    ]
 
             # TODO: is there a better way to do this? Perhaps don't use for loop -- use
             # while True ?Ij

--- a/aviary/mission/gasp_based/phases/time_integration_traj.py
+++ b/aviary/mission/gasp_based/phases/time_integration_traj.py
@@ -24,6 +24,7 @@ class FlexibleTraj(TimeIntegrationTrajBase):
         super().initialize()
         self.options.declare('Phases', default=None)
         self.options.declare('promote_all_auto_ivc', default=False)
+        self.options.declare('traj_intermediate_state_output', default=None)
         self.options.declare('traj_final_state_output', default=None)
         self.options.declare('traj_promote_final_output', default=None)
         self.options.declare('traj_promote_initial_input', default=None)
@@ -47,6 +48,7 @@ class FlexibleTraj(TimeIntegrationTrajBase):
             traj_promote_initial_input=self.options['traj_promote_initial_input'],
             traj_initial_state_input=self.options['traj_initial_state_input'],
             traj_event_trigger_input=self.options['traj_event_trigger_input'],
+            traj_intermediate_state_output=self.options['traj_intermediate_state_output'],
         )
         self.declare_partials(["*"], ["*"],)
 

--- a/aviary/validation_cases/benchmark_tests/test_bench_GwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_GwGm.py
@@ -128,7 +128,7 @@ class ProblemPhaseTestCase(unittest.TestCase):
         assert_near_equal(prob.get_val(Mission.Landing.TOUCHDOWN_MASS, units='lbm'),
                           136823.47, tolerance=rtol)
 
-        assert_near_equal(prob.get_val('traj.cruise_distance_final',
+        assert_near_equal(prob.get_val('traj.cruise_' + Dynamic.Mission.DISTANCE + '_final',
                                        units='nmi'), 3668.3, tolerance=rtol)
 
 

--- a/aviary/validation_cases/benchmark_tests/test_bench_GwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_GwGm.py
@@ -7,7 +7,7 @@ from openmdao.core.problem import _clear_problem_names
 
 from aviary.interface.default_phase_info.two_dof import phase_info
 from aviary.interface.methods_for_level1 import run_aviary
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft, Mission, Dynamic
 from aviary.variable_info.enums import AnalysisScheme, Verbosity
 
 
@@ -127,6 +127,9 @@ class ProblemPhaseTestCase(unittest.TestCase):
 
         assert_near_equal(prob.get_val(Mission.Landing.TOUCHDOWN_MASS, units='lbm'),
                           136823.47, tolerance=rtol)
+
+        assert_near_equal(prob.get_val('traj.cruise_distance_final',
+                                       units='nmi'), 3668.3, tolerance=rtol)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

Adding intermediate state outputs to SGM trajectories, this allows users to specify states to be output from a phase that is not the final one.
Also included is a prototype of the ability to output non state variables mid trajectory as well.
This will eventually be used with #245 to allow users to run the estimation once in pre-mission, and then use the actual descent fuel from the trajectory for the new guess of descent fuel for the next iteration

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None