### PR TITLE
Increased the timeout on `test_run_scripts`

### DIFF
--- a/aviary/examples/test/test_all_examples.py
+++ b/aviary/examples/test/test_all_examples.py
@@ -71,9 +71,9 @@ class RunScriptTest(unittest.TestCase):
                     run_files.append(Path(root) / file)
         return run_files
 
-    def run_script(self, script_path, max_allowable_time=180):
+    def run_script(self, script_path, max_allowable_time=300):
         """
-        Attempt to run a script with a 180-second timeout and handle errors.
+        Attempt to run a script with a 300-second timeout and handle errors.
 
         Parameters
         ----------


### PR DESCRIPTION
### Summary

After a recent update, the following test is failing due to a timeout:
```
/mdao/u/swryan/benchmark/runner/repos/Aviary/Aviary/aviary/examples/test/test_all_examples.py:RunScriptTest.test_run_scripts (script='run_2dof_reserve_mission_multiphase.py') ... FAIL (811:30:40.47, 308 MB)
Traceback (most recent call last):
  File "/mdao/u/swryan/benchmark/runner/repos/Aviary/Aviary/aviary/examples/test/test_all_examples.py", line 110, in test_run_scripts
    self.run_script(script_path)
  File "/mdao/u/swryan/benchmark/runner/repos/Aviary/Aviary/aviary/examples/test/test_all_examples.py", line 91, in run_script
    proc.wait(timeout=max_allowable_time)
  File "/mdao/u/swryan/.conda/envs/Aviary_20240420-000006/lib/python3.12/subprocess.py", line 1264, in wait
    return self._wait(timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mdao/u/swryan/.conda/envs/Aviary_20240420-000006/lib/python3.12/subprocess.py", line 2045, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['python', PosixPath('/mdao/u/swryan/benchmark/runner/repos/Aviary/Aviary/aviary/examples/reserve_missions/run_2dof_reserve_mission_multiphase.py')]' timed out after 180 seconds
```
Increasing the time limit seems to resolve the issue.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None