### PR TITLE
Import statement using absolute path

### DIFF
--- a/aviary/docs/developer_guide/coding_standards.md
+++ b/aviary/docs/developer_guide/coding_standards.md
@@ -40,7 +40,7 @@ Function and method names, similar to variables, should be formatted in "snake c
 
 ### Import statements
 
-Autopep8 allows both absolate and relative path in `import` statements. Aviary will use absolute path option only. Following autopep8, imports should be grouped in the following order:
+Autopep8 allows both absolute and relative paths in `import` statements. Aviary will use absolute path option only. Following autopep8, imports should be grouped in the following order:
 
     1. Standard library imports.
     2. Related third party imports.

--- a/aviary/docs/developer_guide/coding_standards.md
+++ b/aviary/docs/developer_guide/coding_standards.md
@@ -38,5 +38,15 @@ Class names should be written in "[CamelCase](https://en.wikipedia.org/wiki/Came
 Function and method names, similar to variables, should be formatted in "snake case". Class methods that are not intended to be accessed outside of the class definition can append an underscore at the beginning of the method name to mark it as "private", to help other users avoid using those methods incorrectly. An example of this is:
 *def _private_method(self):*
 
+### Import statements
+
+Autopep8 allows both absolate and relative path in `import` statements. Aviary will use absolute path option only. Following autopep8, imports should be grouped in the following order:
+
+    1. Standard library imports.
+    2. Related third party imports.
+    3. Local application/library specific imports.
+
+There should be a blank line between each group of imports.
+
 ## Code Re-Use and Utility Functions
 If an identical block of code appears multiple times inside a file, consider moving it to a function to make your code cleaner. Repeated code bloats files and makes them less readable. If that function ends up being useful outside that individual file, move it to a "utils.py" file in the lowest-level directory shared by all files that need that function. If the utility function is useful across all of Aviary and is integral to the tool's operation, the aviary/utils folder is the appropriate place for it.

--- a/aviary/examples/external_subsystems/battery/model/battery_mission.py
+++ b/aviary/examples/external_subsystems/battery/model/battery_mission.py
@@ -16,8 +16,8 @@ Tarun Huria, Massimo Ceraolo, Javier Gazzarri, Robyn Jackey
 """
 
 from openmdao.api import Group
-from .cell_comp import CellComp
-from .reg_thevenin_interp_group import RegTheveninInterpGroup
+from aviary.examples.external_subsystems.battery.model.cell_comp import CellComp
+from aviary.examples.external_subsystems.battery.model.reg_thevenin_interp_group import RegTheveninInterpGroup
 
 from aviary.utils.aviary_values import AviaryValues
 from aviary.examples.external_subsystems.battery.battery_variables import Aircraft, Mission

--- a/aviary/mission/gasp_based/ode/unsteady_solved/unsteady_control_iter_group.py
+++ b/aviary/mission/gasp_based/ode/unsteady_solved/unsteady_control_iter_group.py
@@ -6,7 +6,7 @@ from aviary.constants import RHO_SEA_LEVEL_ENGLISH
 from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.variables import Dynamic
 
-from .unsteady_solved_eom import UnsteadySolvedEOM
+from aviary.mission.gasp_based.ode.unsteady_solved.unsteady_solved_eom import UnsteadySolvedEOM
 
 
 class UnsteadyControlIterGroup(om.Group):

--- a/aviary/subsystems/aerodynamics/gasp_based/flaps_model/__init__.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/flaps_model/__init__.py
@@ -1,1 +1,1 @@
-from .flaps_model import FlapsGroup
+from aviary.subsystems.aerodynamics.gasp_based.flaps_model.flaps_model import FlapsGroup

--- a/aviary/subsystems/mass/gasp_based/fixed.py
+++ b/aviary/subsystems/mass/gasp_based/fixed.py
@@ -118,7 +118,7 @@ class MassParameters(om.ExplicitComponent):
         if aviary_options.get_val(
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, units='unitless'
         ):
-            # smooth transition for c_gear_loc from .95 to 1 when gear_location varies
+            # smooth transition for c_gear_loc from 0.95 to 1 when gear_location varies
             # between 0 and 1% of span
             c_gear_loc = .95 * sigX((0.005 - gear_location)*100) + \
                 1 * sigX(100*(gear_location - 0.005))


### PR DESCRIPTION
### Summary

In some Aviary source files, some import statements for Aviary modules are relative. Some of these source files are runnable as standalone scripts - which typically do not work well with relative import statements. For this reason, I converted all relative paths to absolute paths. I also added a guideline in developer guide.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None