### PR TITLE
In LowSpeedAero, alpha is NOT an output

### DIFF
--- a/aviary/subsystems/aerodynamics/gasp_based/gaspaero.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/gaspaero.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+
 import openmdao.api as om
 from openmdao.utils import cs_safe as cs
 
@@ -1371,7 +1373,7 @@ class LowSpeedAero(om.Group):
                 # so ensure this is what's passed to DragCoef
                 promotes_outputs=[("CL", "CL_full_flaps")],
             )
-            # Note: alpha is not an output
+            warnings.warn("Alpha is NOT an output from LowSpeedAero.")
         else:
             # TODO this makes "output_alpha" a bit of a misnomer, would computing an
             # alpha be useful? an issue is ground effects depend on alpha

--- a/aviary/subsystems/aerodynamics/gasp_based/gaspaero.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/gaspaero.py
@@ -1375,8 +1375,6 @@ class LowSpeedAero(om.Group):
             )
             warnings.warn("Alpha is NOT an output from LowSpeedAero.")
         else:
-            # TODO this makes "output_alpha" a bit of a misnomer, would computing an
-            # alpha be useful? an issue is ground effects depend on alpha
             self.add_subsystem(
                 "lift_coef",
                 LiftCoeff(num_nodes=nn),


### PR DESCRIPTION
### Summary

In `LowSpeedAero` (GASP based), alpha is NOT an output even though the code indicates that `output_alpha` is `True`. This was a comment and is replaced by a warning message. Currently, this option (`output_alpha == True`) is not used. If it is needed, GASP has a subroutine to compute alpha. We can implement it in Aviary.

### Related Issues

- Resolves [deprecated Aviary #343](https://github.com/OpenMDAO/Aviary_deprecated/issues/343)

### Backwards incompatibilities

None

### New Dependencies

None