### PR TITLE
Add option to tabular takeoff aero so landing gear drag can be excluded

### DIFF
--- a/aviary/subsystems/aerodynamics/flops_based/takeoff_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/takeoff_aero_group.py
@@ -72,6 +72,11 @@ class TakeoffAeroGroup(om.Group):
         )
 
         options.declare(
+            'landing_gear_up', default=False, types=bool,
+            desc='true for retracted landing gear'
+        )
+
+        options.declare(
             'aviary_options', types=AviaryValues,
             desc='collection of Aircraft/Mission specific options')
 
@@ -133,9 +138,11 @@ class TakeoffAeroGroup(om.Group):
             'takeoff_polar.drag_coefficient', 'ground_effect.base_drag_coefficient'
         )
 
-        gear_drag = aviary_options.get_val(Aircraft.LandingGear.DRAG_COEFFICIENT)
+        f = f'climb_drag_coefficient = ground_effect_drag'
 
-        f = f'climb_drag_coefficient = ground_effect_drag + {gear_drag}'
+        if not options['landing_gear_up']:
+            gear_drag = aviary_options.get_val(Aircraft.LandingGear.DRAG_COEFFICIENT)
+            f = f + f' + {gear_drag}'
 
         if options['use_spoilers']:
             spoiler_drag = options['spoiler_drag_coefficient']


### PR DESCRIPTION
### Summary

The FLOPS-based tabular low-speed takeoff aero group includes landing gear drag in the net drag coefficient equation but does not have an option to disable it, meaning landing gear drag is added to all segments of takeoff if a value is provided by the user. 

A gear retraction option is added to enable or disable this effect from the user-provided aerodynamics info. Note that this solution is different from legacy codes, which use cosinusoidal equations to gradually reduce drag. A more permanent solution to this issue would be to gradually decrease drag over a specified duration.

### Related Issues

- Resolves #275 

### Backwards incompatibilities

None

### New Dependencies

None