### PR TITLE
Read csv extended

### DIFF
--- a/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
+++ b/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
@@ -241,7 +241,7 @@
    "id": "96ebdf23",
    "metadata": {},
    "source": [
-    "Note that we have set `meta_data` to `ExtendedMetaData` so that we can set battery related variables in the model .csv file.\n",
+    "Since this example contains new variables in the aircraft hierarchy, the metadata for those variables was added to an extended metadata dictionary. We need to pass that into load_inputs so that it can load susbsystem-specific inputs from the csv file.\n",
     "\n",
     "In the battery subsystem, the type of battery cell we use is `18650`. The option is not set in `input_file`, instead it is controlled by importing the correct battery map [here](https://github.com/OpenMDAO/Aviary/blob/1fca1c03cb2e1d6387442162e8d7dabf83eee197/aviary/examples/external_subsystems/battery/model/reg_thevenin_interp_group.py#L5)."
    ]

--- a/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
+++ b/aviary/docs/getting_started/onboarding_ext_subsystem.ipynb
@@ -205,6 +205,7 @@
    "source": [
     "from aviary.examples.external_subsystems.battery.battery_builder import BatteryBuilder\n",
     "from aviary.examples.external_subsystems.battery.battery_variables import Aircraft\n",
+    "from aviary.examples.external_subsystems.battery.battery_variable_meta_data import ExtendedMetaData\n",
     "\n",
     "battery_builder = BatteryBuilder(include_constraints=False)\n",
     "\n",
@@ -231,7 +232,8 @@
    "source": [
     "prob = av.AviaryProblem()\n",
     "\n",
-    "prob.load_inputs('models/test_aircraft/aircraft_for_bench_FwFm.csv', phase_info)"
+    "prob.load_inputs('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
+    "                 phase_info, meta_data=ExtendedMetaData)"
    ]
   },
   {
@@ -239,8 +241,9 @@
    "id": "96ebdf23",
    "metadata": {},
    "source": [
+    "Note that we have set `meta_data` to `ExtendedMetaData` so that we can set battery related variables in the model .csv file.\n",
     "\n",
-    "In the battery subsystem, the type of battery cell we use is `18650`. The option is not set in `input_file`, instead is is controlled by importing the correct battery map [here](https://github.com/OpenMDAO/Aviary/blob/1fca1c03cb2e1d6387442162e8d7dabf83eee197/aviary/examples/external_subsystems/battery/model/reg_thevenin_interp_group.py#L5)."
+    "In the battery subsystem, the type of battery cell we use is `18650`. The option is not set in `input_file`, instead it is controlled by importing the correct battery map [here](https://github.com/OpenMDAO/Aviary/blob/1fca1c03cb2e1d6387442162e8d7dabf83eee197/aviary/examples/external_subsystems/battery/model/reg_thevenin_interp_group.py#L5)."
    ]
   },
   {
@@ -755,7 +758,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/aviary/examples/external_subsystems/battery/battery_builder.py
+++ b/aviary/examples/external_subsystems/battery/battery_builder.py
@@ -173,7 +173,7 @@ class BatteryBuilder(SubsystemBuilderBase):
             Aircraft.Battery.Cell.DISCHARGE_RATE: {
                 'units': 'A',
                 'lower': 0.0,
-                'upper': 1.0,
+                'upper': 2.0,
             },
         }
 
@@ -250,7 +250,7 @@ class BatteryBuilder(SubsystemBuilderBase):
         In this case, it sets the values battery performance based on the battery cell type.
         '''
         battery_cell_info_18650 = {
-            Aircraft.Battery.Cell.DISCHARGE_RATE: [10.5, 'A'],
+            Aircraft.Battery.Cell.DISCHARGE_RATE: [2.0, 'A'],
             Aircraft.Battery.Cell.ENERGY_CAPACITY_MAX: [3.5, 'A*h'],
             Aircraft.Battery.Cell.HEAT_CAPACITY: [1020.0, 'J/(kg*K)'],
             Aircraft.Battery.Cell.MASS: [0.045, 'kg'],

--- a/aviary/examples/external_subsystems/battery/run_cruise.py
+++ b/aviary/examples/external_subsystems/battery/run_cruise.py
@@ -3,6 +3,7 @@ import aviary.api as av
 
 from aviary.examples.external_subsystems.battery.battery_builder import BatteryBuilder
 from aviary.examples.external_subsystems.battery.battery_variables import Aircraft, Mission
+from aviary.examples.external_subsystems.battery.battery_variable_meta_data import ExtendedMetaData
 
 
 battery_builder = BatteryBuilder()
@@ -16,7 +17,8 @@ prob = av.AviaryProblem()
 
 # Load aircraft and options data from user
 # Allow for user overrides here
-prob.load_inputs('models/test_aircraft/aircraft_for_bench_FwFm.csv', phase_info)
+prob.load_inputs('models/test_aircraft/aircraft_for_bench_FwFm.csv',
+                 phase_info, meta_data=ExtendedMetaData)
 
 # Preprocess inputs
 prob.check_and_preprocess_inputs()

--- a/aviary/examples/external_subsystems/battery/run_multiphase_mission.py
+++ b/aviary/examples/external_subsystems/battery/run_multiphase_mission.py
@@ -4,6 +4,7 @@ import pkg_resources
 
 from aviary.examples.external_subsystems.battery.battery_builder import BatteryBuilder
 from aviary.examples.external_subsystems.battery.battery_variables import Aircraft
+from aviary.examples.external_subsystems.battery.battery_variable_meta_data import ExtendedMetaData
 from aviary.api import default_height_energy_phase_info as phase_info
 
 
@@ -22,7 +23,7 @@ prob = AviaryProblem()
 
 # Load aircraft and options data from user
 # Allow for user overrides here
-prob.load_inputs(input_file, phase_info)
+prob.load_inputs(input_file, phase_info, meta_data=ExtendedMetaData)
 
 
 # Preprocess inputs

--- a/aviary/examples/external_subsystems/engine_NPSS/define_simple_engine_problem.py
+++ b/aviary/examples/external_subsystems/engine_NPSS/define_simple_engine_problem.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 import aviary.api as av
 
 from aviary.examples.external_subsystems.engine_NPSS.table_engine_builder import TableEngineBuilder as EngineBuilder
+from aviary.examples.external_subsystems.engine_NPSS.engine_variable_meta_data import ExtendedMetaData
 
 
 def define_aviary_NPSS_problem():
@@ -20,7 +21,7 @@ def define_aviary_NPSS_problem():
     # Allow for user overrides here
     # add engine builder
     prob.load_inputs('models/test_aircraft/aircraft_for_bench_FwFm.csv',
-                     phase_info, engine_builder=EngineBuilder())
+                     phase_info, engine_builder=EngineBuilder(), meta_data=ExtendedMetaData)
 
     prob.check_and_preprocess_inputs()
 

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -234,7 +234,7 @@ class AviaryProblem(om.Problem):
         self.regular_phases = []
         self.reserve_phases = []
 
-    def load_inputs(self, aviary_inputs, phase_info=None, engine_builder=None, verbosity=Verbosity.BRIEF):
+    def load_inputs(self, aviary_inputs, phase_info=None, engine_builder=None, verbosity=Verbosity.BRIEF, meta_data=BaseMetaData):
         """
         This method loads the aviary_values inputs and options that the
         user specifies. They could specify files to load and values to
@@ -251,7 +251,7 @@ class AviaryProblem(om.Problem):
         # Create AviaryValues object from file (or process existing AviaryValues object
         # with default values from metadata) and generate initial guesses
         aviary_inputs, initial_guesses = create_vehicle(
-            aviary_inputs, verbosity=verbosity)
+            aviary_inputs, verbosity=verbosity, meta_data=meta_data)
 
         # pull which methods will be used for subsystems and mission
         self.mission_method = mission_method = aviary_inputs.get_val(

--- a/aviary/utils/process_input_decks.py
+++ b/aviary/utils/process_input_decks.py
@@ -36,7 +36,7 @@ problem_types = {'sizing': ProblemType.SIZING,
                  'alternate': ProblemType.ALTERNATE, 'fallout': ProblemType.FALLOUT}
 
 
-def create_vehicle(vehicle_deck='', verbosity=Verbosity.BRIEF):
+def create_vehicle(vehicle_deck='', verbosity=Verbosity.BRIEF, meta_data=_MetaData):
     """
     Creates and initializes a vehicle with default or specified parameters. It sets up the aircraft values
     and initial guesses based on the input from the vehicle deck.
@@ -65,7 +65,8 @@ def create_vehicle(vehicle_deck='', verbosity=Verbosity.BRIEF):
         initial_guesses = {}
     else:
         vehicle_deck = get_path(vehicle_deck)
-        aircraft_values, initial_guesses = parse_inputs(vehicle_deck, aircraft_values)
+        aircraft_values, initial_guesses = parse_inputs(
+            vehicle_deck, aircraft_values, meta_data=meta_data)
 
     return aircraft_values, initial_guesses
 


### PR DESCRIPTION
### Summary

When adding external subsystem variables (e.g. `Aircraft.Battery.CURRENT_MAX`) to input deck (.csv file), these variables are not read in. This PR fixes this bug.

Changed the initial value and upper bound of `Aircraft.Battery.Cell.DISCHARGE_RATE` to avoid an unnecessary warning message.

### Related Issues

- Resolves [deprecated issue #423](https://github.com/OpenMDAO/Aviary_deprecated/issues/423)
- Check  [deprecated issue #319](https://github.com/OpenMDAO/Aviary_deprecated/issues/319) too

### Backwards incompatibilities

None

### New Dependencies

None