### PR TITLE
Clarify draw_mission outputted dict format

### DIFF
--- a/aviary/docs/examples/intro.md
+++ b/aviary/docs/examples/intro.md
@@ -4,8 +4,7 @@
 
 Aviary provides a range of built-in examples that serve as both regression tests and demonstrations of the tool's capabilities.
 These examples showcase various full mission analysis and optimization problems, incorporating different subsystem analyses from FLOPS and GASP.
-You can find these examples [here](https://github.com/OpenMDAO/Aviary/tree/main/aviary/validation_cases/benchmark_tests), especially the files that start `test_swap`.
-These cases highlight Aviary's ability to replicate GASP and FLOPS capabilities, as well as use both code's methods in a single analysis.
+You can find these examples [here](https://github.com/OpenMDAO/Aviary/tree/main/aviary/examples).
 
 In addition to the examples for core Aviary, we also provide some examples for using external subsystems.
 These are contained in the `aviary/examples/external_subsystems` folder.

--- a/aviary/docs/user_guide/drawing_and_running_simple_missions.md
+++ b/aviary/docs/user_guide/drawing_and_running_simple_missions.md
@@ -73,6 +73,8 @@ When using the outputted `phase_info` dict in a mission simulation, you can modi
 The `phase_info` dictionary makes some assumptions about different settings which you can also modify.
 For example, the time duration of each phase is controlled by the optimizer if `fix_duration` is False, though this can be changed to True to fix the duration of each phase.
 
+If you don't have the [black](https://pypi.org/project/black/) python autoformatter installed, your output may look slightly different - as long as you see confirmation that your phase info has been saved, your mission profile was successfully created.
+
 ## Running a Mission Simulation
 
 After generating the flight profile, use the `run_mission` command to simulate the mission.

--- a/aviary/interface/graphical_input.py
+++ b/aviary/interface/graphical_input.py
@@ -334,8 +334,14 @@ class IntegratedPlottingApp(tk.Tk):
             'button_release_event', self.on_release)
 
         # Done button
-        self.done_button = tk.Button(checkbox_frame, text="Done", command=self.on_done)
+        self.done_button = tk.Button(
+            checkbox_frame, text="Output phase_info object", command=self.on_done)
         self.done_button.pack(side='top', pady=10)
+
+        # add a note that if you don't have the black package installed your phase_info file might be formatted unclearly
+        # wrap text to fit in the window
+        tk.Label(checkbox_frame, text="Note: If 'black' is not installed, the outputted phase_info dict may not be returned in an easy-to-read format.",
+                 wraplength=200, justify='left').pack(side='top', pady=10)
 
         # Help button
         self.help_button = tk.Button(checkbox_frame, text="Help", command=self.show_help)


### PR DESCRIPTION
### Summary

Add note in the GUI and in another doc location that `black` helps the output be more readable.
Made the `done` button more explanative: `Output phase_info object`

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None