### PR TITLE
fixed bugs related to specifying phase_info from the CLI

### DIFF
--- a/aviary/interface/methods_for_level1.py
+++ b/aviary/interface/methods_for_level1.py
@@ -2,11 +2,13 @@
 This file contains functions needed to run Aviary using the Level 1 interface.
 """
 import os
+from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 import openmdao.api as om
 from aviary.variable_info.enums import AnalysisScheme, Verbosity
 from aviary.interface.methods_for_level2 import AviaryProblem
+from aviary.utils.functions import get_path
 
 
 def run_aviary(aircraft_filename, phase_info, optimizer=None,
@@ -121,6 +123,14 @@ def run_level_1(
     #     kwargs['optimizer'] = 'IPOPT'
     # else:
     kwargs['optimizer'] = optimizer
+
+    if isinstance(phase_info, str):
+        phase_info_path = get_path(phase_info)
+        phase_info_file = SourceFileLoader(
+            "phase_info_file", str(phase_info_path)).load_module()
+        phase_info = getattr(phase_info_file, 'phase_info')
+        kwargs['phase_info_parameterization'] = getattr(
+            phase_info_file, 'phase_info_parameterization', None)
 
     prob = run_aviary(input_deck, phase_info, **kwargs)
 

--- a/aviary/interface/test/test_cmd_entry_points.py
+++ b/aviary/interface/test/test_cmd_entry_points.py
@@ -34,9 +34,9 @@ class CommandEntryPointsTestCases(unittest.TestCase):
             ' --optimizer IPOPT --max_iter 1 --shooting'
         self.run_and_test_cmd(cmd)
 
-    @require_pyoptsparse(optimizer="SNOPT")
+    @require_pyoptsparse(optimizer="IPOPT")
     def bench_test_phase_info_cmd(self):
-        cmd = 'aviary run_mission models/test_aircraft/aircraft_for_bench_GwGm.csv --optimizer SNOPT --max_iter 1' \
+        cmd = 'aviary run_mission models/test_aircraft/aircraft_for_bench_GwGm.csv --optimizer IPOPT --max_iter 1' \
             ' --phase_info interface/default_phase_info/two_dof.py'
         self.run_and_test_cmd(cmd)
 

--- a/aviary/interface/test/test_cmd_entry_points.py
+++ b/aviary/interface/test/test_cmd_entry_points.py
@@ -34,6 +34,12 @@ class CommandEntryPointsTestCases(unittest.TestCase):
             ' --optimizer IPOPT --max_iter 1 --shooting'
         self.run_and_test_cmd(cmd)
 
+    @require_pyoptsparse(optimizer="SNOPT")
+    def bench_test_phase_info_cmd(self):
+        cmd = 'aviary run_mission models/test_aircraft/aircraft_for_bench_GwGm.csv --optimizer SNOPT --max_iter 1' \
+            ' --phase_info interface/default_phase_info/two_dof.py'
+        self.run_and_test_cmd(cmd)
+
     def test_diff_configuration_conversion(self):
         filepath = pkg_resources.resource_filename('aviary',
                                                    'models/test_aircraft/converter_configuration_test_data_GwGm.dat')

--- a/aviary/utils/functions.py
+++ b/aviary/utils/functions.py
@@ -357,11 +357,14 @@ def get_path(path: [str, Path], verbose: bool = False) -> Path:
 
     # If the path still doesn't exist, attempt to find it in the models directory.
     if not path.exists():
-        hangar_based_path = get_model(original_path)
-        if verbose:
-            print(
-                f"Unable to locate '{aviary_based_path}' as an Aviary package path, checking built-in models")
-        path = hangar_based_path
+        try:
+            hangar_based_path = get_model(original_path)
+            if verbose:
+                print(
+                    f"Unable to locate '{aviary_based_path}' as an Aviary package path, checking built-in models")
+            path = hangar_based_path
+        except FileNotFoundError:
+            pass
 
     # If the path still doesn't exist in any of the prioritized locations, raise an error.
     if not path.exists():


### PR DESCRIPTION
### Summary

phase_info was being treated as a dict when it was passed to run_aviary
added a preprocessor to run_level_1 that extracts phase_info and phase_info_parameterization (if present) from the file path that is specified through the CLI and then passes them to run_aviary.
Also prevented the FileNotFoundError raised in get_model from causing get_path to fail prematurely.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None