### PR TITLE
Rename run_aviary

### DIFF
--- a/aviary/api.py
+++ b/aviary/api.py
@@ -35,7 +35,7 @@ from aviary.interface.default_phase_info.two_dof import phase_info as default_2D
 from aviary.interface.default_phase_info.two_dof_fiti import create_2dof_based_ascent_phases, create_2dof_based_descent_phases
 from aviary.interface.default_phase_info.height_energy import phase_info as default_height_energy_phase_info
 from aviary.interface.methods_for_level1 import run_level_1
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 from aviary.interface.methods_for_level2 import AviaryProblem
 from aviary.interface.utils.check_phase_info import check_phase_info
 from aviary.utils.engine_deck_conversion import EngineDeckConverter

--- a/aviary/docs/examples/additional_flight_phases.ipynb
+++ b/aviary/docs/examples/additional_flight_phases.ipynb
@@ -223,8 +223,8 @@
    "source": [
     "import aviary.api as av\n",
     "\n",
-    "prob = av.run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
-    "                     phase_info, optimizer=\"SLSQP\", make_plots=True)"
+    "prob = av.setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
+    "                               phase_info, optimizer=\"SLSQP\", make_plots=True)"
    ]
   },
   {

--- a/aviary/docs/examples/coupled_aircraft_mission_optimization.ipynb
+++ b/aviary/docs/examples/coupled_aircraft_mission_optimization.ipynb
@@ -170,8 +170,8 @@
     "make_plots = True\n",
     "max_iter = 200\n",
     "\n",
-    "prob = av.run_aviary(aircraft_filename, phase_info, optimizer=optimizer,\n",
-    "                     make_plots=make_plots, max_iter=max_iter)"
+    "prob = av.setup_and_run_aviary(aircraft_filename, phase_info, optimizer=optimizer,\n",
+    "                               make_plots=make_plots, max_iter=max_iter)"
    ]
   },
   {
@@ -208,7 +208,7 @@
     "```\n",
     "\n",
     "When we want to add an aircraft design variable to the Aviary problem, we need to use the Level 2 interface for Aviary.\n",
-    "This means we can no longer use the all-inclusive `run_aviary` function and instead need to call its constituent methods individually.\n",
+    "This means we can no longer use the all-inclusive `setup_and_run_aviary` function and instead need to call its constituent methods individually.\n",
     "This allows us to insert a line adding the wing aspect ratio as a design variable as shown below.\n",
     "This line is highlighted with an in-line comment."
    ]
@@ -328,7 +328,7 @@
     "phase_info['descent_1']['user_options']['optimize_mach'] = True\n",
     "phase_info['descent_1']['user_options']['optimize_altitude'] = True\n",
     "\n",
-    "prob = av.run_aviary(aircraft_filename, phase_info, optimizer=optimizer,\n",
+    "prob = av.setup_and_run_aviary(aircraft_filename, phase_info, optimizer=optimizer,\n",
     "                     make_plots=make_plots, max_iter=max_iter)"
    ]
   },
@@ -362,7 +362,7 @@
     "phase_info['descent_1']['user_options']['optimize_mach'] = True\n",
     "phase_info['descent_1']['user_options']['optimize_altitude'] = True\n",
     "\n",
-    "prob = av.run_aviary(aircraft_filename, phase_info, optimizer=optimizer,\n",
+    "prob = av.setup_and_run_aviary(aircraft_filename, phase_info, optimizer=optimizer,\n",
     "                     make_plots=make_plots, max_iter=max_iter)"
    ]
   },

--- a/aviary/docs/examples/more_advanced_example.ipynb
+++ b/aviary/docs/examples/more_advanced_example.ipynb
@@ -142,8 +142,8 @@
    "source": [
     "import aviary.api as av\n",
     "\n",
-    "prob = av.run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
-    "                     phase_info, optimizer=\"SLSQP\", make_plots=True)"
+    "prob = av.setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
+    "                               phase_info, optimizer=\"SLSQP\", make_plots=True)"
    ]
   },
   {
@@ -281,8 +281,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob = av.run_aviary('modified_aircraft.csv', phase_info,\n",
-    "                     optimizer=\"SLSQP\", make_plots=True)"
+    "prob = av.setup_and_run_aviary('modified_aircraft.csv', phase_info,\n",
+    "                               optimizer=\"SLSQP\", make_plots=True)"
    ]
   },
   {
@@ -346,8 +346,8 @@
     "phase_info['cruise']['user_options']['polynomial_control_order'] = 1\n",
     "phase_info['descent_1']['user_options']['polynomial_control_order'] = 3\n",
     "\n",
-    "prob = av.run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
-    "                     phase_info, optimizer=\"IPOPT\", make_plots=True)"
+    "prob = av.setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
+    "                               phase_info, optimizer=\"IPOPT\", make_plots=True)"
    ]
   },
   {

--- a/aviary/docs/examples/simple_mission_example.ipynb
+++ b/aviary/docs/examples/simple_mission_example.ipynb
@@ -238,7 +238,7 @@
     "We'll focus on running Aviary using the Level 1 interface, which is the simplest.\n",
     "We could do this a few different ways:\n",
     "\n",
-    "- Using the command line interface (CLI) to run Aviary via `aviary run_aviary`\n",
+    "- Using the command line interface (CLI) to run Aviary via `aviary run_mission`\n",
     "- Using the Python interface to run Aviary\n",
     "\n",
     "We'll use the Python interface here, but you can use whichever method you prefer.\n",
@@ -278,8 +278,8 @@
    "source": [
     "import aviary.api as av\n",
     "\n",
-    "prob = av.run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
-    "                     phase_info, optimizer=\"SLSQP\", make_plots=True)"
+    "prob = av.setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
+    "                               phase_info, optimizer=\"SLSQP\", make_plots=True)"
    ]
   },
   {

--- a/aviary/docs/getting_started/onboarding_level2.ipynb
+++ b/aviary/docs/getting_started/onboarding_level2.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "In Level 2, we see more flexibility and additional choices. You will be exposed to some simple Python code and see how Aviary establishes a problem from beginning to end. Each step is built upon the capabilities of [Level 3](onboarding_level3). Users will be led to Level 3 in a natural way.\n",
     "\n",
-    "Level 2 is defined in the [aviary/interface/methods_for_level1.py file](https://github.com/OpenMDAO/Aviary/blob/main/aviary/interface/methods_for_level1.py) and it has a single method `run_aviary()` with a few arguments. If you examine `interface/level1.py` you see that Level 1 prepares those arguments and then call `run_aviary()`. For `aviary run_mission aircraft_for_bench_GwGm` examples, those arguments are:\n",
+    "Level 2 is defined in the [aviary/interface/methods_for_level1.py file](https://github.com/OpenMDAO/Aviary/blob/main/aviary/interface/methods_for_level1.py) and it has a single method `setup_and_run_aviary()` with a few arguments. If you examine `interface/level1.py` you see that Level 1 prepares those arguments and then call `setup_and_run_aviary()`. For `aviary run_mission aircraft_for_bench_GwGm` examples, those arguments are:\n",
     "\n",
     "- `aircraft_filename`: `aircraft_for_bench_GwGm`\n",
     "- `phase_info`: `phase_info` (loaded from `aviary/interface/default_phase_info/gasp.py`)\n",
@@ -79,7 +79,7 @@
     "from copy import deepcopy\n",
     "\n",
     "\n",
-    "# inputs that run_aviary() requires\n",
+    "# inputs that setup_and_run_aviary() requires\n",
     "aircraft_filename = \"models/test_aircraft/aircraft_for_bench_GwGm.csv\"\n",
     "optimizer = \"IPOPT\"\n",
     "analysis_scheme = av.AnalysisScheme.COLLOCATION\n",
@@ -136,13 +136,13 @@
    "id": "96066213",
    "metadata": {},
    "source": [
-    "In this code, you do the same import as `methods_for_level1.py` does and set the values of all the arguments in `run_aviary()`. Now we will go through each line in detail to explain each step:\n",
+    "In this code, you do the same import as `methods_for_level1.py` does and set the values of all the arguments in `setup_and_run_aviary()`. Now we will go through each line in detail to explain each step:\n",
     "\n",
     "## Dissection of level 2 for the same `aircraft_for_bench_GwGm` model\n",
     "\n",
     "All the methods of `prob` object (including its creation) are defined in level 3 (`methods_for_level2.py`). We now look at each of them.\n",
     "\n",
-    "We add other inputs that `run_aviary()` requires:"
+    "We add other inputs that `setup_and_run_aviary()` requires:"
    ]
   },
   {
@@ -666,7 +666,7 @@
     "    },\n",
     "}\n",
     "\n",
-    "# inputs that run_aviary() requires\n",
+    "# inputs that setup_and_run_aviary() requires\n",
     "aircraft_filename = \"models/test_aircraft/aircraft_for_bench_FwFm.csv\"\n",
     "mission_method = \"height_energy_energy\"\n",
     "mass_method = \"FLOPS\"\n",

--- a/aviary/docs/user_guide/UI_Levels.md
+++ b/aviary/docs/user_guide/UI_Levels.md
@@ -82,5 +82,5 @@ Users should provide the contents described, but can divide them into multiple f
 |:-----------------------------------------------------------:|:--------------------------------------------------------------------------------:|:-----------------------------------------------------:|
 |   csv that defines the aircraft and minimal mission options |   Python that creates an AviaryValues object that contains aircraft information  |   Python/OpenMDAO that creates an AviaryValues object |
 |                                                             |   csv files can be used to initialize this AviaryValues                          |   Python/OpenMDAO to define mission and trajectory    |
-|                                                             |   Python that calls run_aviary                                                   |   Python/OpenMDAO to create and run a problem         |
+|                                                             |   Python that calls setup_and_run_aviary                                          |   Python/OpenMDAO to create and run a problem         |
 |                                                             |   Optional additional files for external subsystems                              |   Optional additional files for external subsystems   |

--- a/aviary/docs/user_guide/examples_of_the_same_mission_at_different_UI_levels.ipynb
+++ b/aviary/docs/user_guide/examples_of_the_same_mission_at_different_UI_levels.ipynb
@@ -31,9 +31,9 @@
    "source": [
     "import aviary.api as av\n",
     "\n",
-    "prob = av.run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
-    "                     av.default_height_energy_phase_info,\n",
-    "                     max_iter=0, optimizer=\"SLSQP\", make_plots=False)"
+    "prob = av.setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
+    "                               av.default_height_energy_phase_info,\n",
+    "                               max_iter=0, optimizer=\"SLSQP\", make_plots=False)"
    ]
   },
   {

--- a/aviary/examples/level2_shooting_traj.py
+++ b/aviary/examples/level2_shooting_traj.py
@@ -13,10 +13,11 @@ from aviary.api import SGMCruise, SGMDescent
 from aviary.api import Dynamic
 
 
-def run_aviary(aircraft_filename, phase_info, optimizer=None, analysis_scheme=AnalysisScheme.COLLOCATION,
-               objective_type=None, record_filename='dymos_solution.db', restart_filename=None, max_iter=50, run_driver=True, make_plots=True):
+def setup_and_run_aviary(
+        aircraft_filename, phase_info, optimizer=None, analysis_scheme=AnalysisScheme.COLLOCATION,
+        objective_type=None, record_filename='dymos_solution.db', restart_filename=None, max_iter=50, run_driver=True, make_plots=True):
     """
-    This function runs the aviary optimization problem for the specified aircraft configuration and mission.
+    This function sets up and runs the aviary optimization problem for the specified aircraft configuration and mission.
 
     It first creates an instance of the AviaryProblem class using the given phase_info, mission_method, and mass_method.
     It then loads aircraft and options data from the user-provided aircraft_filename and checks for any clashing inputs.

--- a/aviary/examples/run_basic_aviary_example.py
+++ b/aviary/examples/run_basic_aviary_example.py
@@ -5,11 +5,12 @@ This uses the "level 1" API within Aviary.
 We use the pre-defined single aisle commercial transport aircraft definition and use a pre-defined phase_info object
 to describe the mission optimization problem to Aviary.
 This mission consists of climb, cruise, and descent phases.
-We then call the `run_aviary` function, which takes in the path to the aircraft model, the phase info, and some other options.
+We then call the `setup_and_run_aviary` function, which takes in the path to the aircraft model, the phase info, and some other options.
 This performs a coupled design-mission optimization and outputs the results from Aviary into the `reports` folder.
 """
 import aviary.api as av
 
 
-prob = av.run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv', av.default_height_energy_phase_info,
-                     optimizer="SLSQP", make_plots=True)
+prob = av.setup_and_run_aviary(
+    'models/test_aircraft/aircraft_for_bench_FwFm.csv', av.default_height_energy_phase_info,
+    optimizer="SLSQP", make_plots=True)

--- a/aviary/examples/test/test_level2_shooting_traj.py
+++ b/aviary/examples/test/test_level2_shooting_traj.py
@@ -1,5 +1,5 @@
 from aviary.api import AnalysisScheme
-from aviary.examples.level2_shooting_traj import run_aviary
+from aviary.examples.level2_shooting_traj import setup_and_run_aviary
 from aviary.interface.default_phase_info.two_dof import phase_info
 from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 import unittest
@@ -7,10 +7,10 @@ import unittest
 
 @use_tempdirs
 @require_pyoptsparse(optimizer=None)
-def test_run_aviary():
+def test_setup_and_run_aviary():
     input_deck = 'models/large_single_aisle_1/large_single_aisle_1_GwGm.csv'
-    run_aviary(input_deck, phase_info,
-               analysis_scheme=AnalysisScheme.SHOOTING, run_driver=False)
+    setup_and_run_aviary(input_deck, phase_info,
+                         analysis_scheme=AnalysisScheme.SHOOTING, run_driver=False)
 
 
 if __name__ == "__main__":

--- a/aviary/interface/methods_for_level1.py
+++ b/aviary/interface/methods_for_level1.py
@@ -11,13 +11,14 @@ from aviary.interface.methods_for_level2 import AviaryProblem
 from aviary.utils.functions import get_path
 
 
-def run_aviary(aircraft_filename, phase_info, optimizer=None,
-               analysis_scheme=AnalysisScheme.COLLOCATION, objective_type=None,
-               record_filename='dymos_solution.db', restart_filename=None, max_iter=50,
-               run_driver=True, make_plots=True, phase_info_parameterization=None,
-               optimization_history_filename=None, verbosity=Verbosity.BRIEF):
+def setup_and_run_aviary(
+        aircraft_filename, phase_info, optimizer=None,
+        analysis_scheme=AnalysisScheme.COLLOCATION, objective_type=None,
+        record_filename='dymos_solution.db', restart_filename=None, max_iter=50,
+        run_driver=True, make_plots=True, phase_info_parameterization=None,
+        optimization_history_filename=None, verbosity=Verbosity.BRIEF):
     """
-    Run the Aviary optimization problem for a specified aircraft configuration and mission.
+    Setup and run the Aviary optimization problem for a specified aircraft configuration and mission.
 
     This function creates an instance of the AviaryProblem class using provided phase information,
     mission, and mass methods. It processes aircraft and options data from the given aircraft filename,
@@ -132,7 +133,7 @@ def run_level_1(
         kwargs['phase_info_parameterization'] = getattr(
             phase_info_file, 'phase_info_parameterization', None)
 
-    prob = run_aviary(input_deck, phase_info, **kwargs)
+    prob = setup_and_run_aviary(input_deck, phase_info, **kwargs)
 
     if n2:
         outfile = os.path.join(outdir, "n2.html")

--- a/aviary/interface/test/test_basic_report.py
+++ b/aviary/interface/test/test_basic_report.py
@@ -6,7 +6,7 @@ from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 import openmdao.api as om
 
 from aviary.interface.default_phase_info.height_energy import phase_info
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 from aviary.variable_info.enums import Verbosity
 
 
@@ -14,9 +14,9 @@ from aviary.variable_info.enums import Verbosity
 class BasicReportTestCase(unittest.TestCase):
     def setUp(self):
         local_phase_info = deepcopy(phase_info)
-        self.prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
-                               local_phase_info, verbosity=Verbosity.QUIET,
-                               mission_method="FLOPS", mass_method="FLOPS", optimizer='IPOPT')
+        self.prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
+                                         local_phase_info, verbosity=Verbosity.QUIET,
+                                         mission_method="FLOPS", mass_method="FLOPS", optimizer='IPOPT')
 
     def test_text_report(self):
         self.prob.write_report('test_output.txt')

--- a/aviary/interface/test/test_height_energy_mission.py
+++ b/aviary/interface/test/test_height_energy_mission.py
@@ -6,7 +6,7 @@ from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 from openmdao.core.problem import _clear_problem_names
 from openmdao.utils.reports_system import clear_reports
 
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 from aviary.subsystems.test.test_dummy_subsystem import ArrayGuessSubsystemBuilder
 from aviary.mission.energy_phase import EnergyPhase
 from aviary.variable_info.variables import Dynamic
@@ -119,7 +119,7 @@ class AircraftMissionTestSuite(unittest.TestCase):
                 phase_info[phase]['external_subsystems'].append(subsystem_builder)
 
     def run_mission(self, phase_info, optimizer):
-        return run_aviary(
+        return setup_and_run_aviary(
             self.aircraft_definition_file, phase_info,
             make_plots=self.make_plots, max_iter=self.max_iter, optimizer=optimizer,
             optimization_history_filename="driver_test.db", verbosity=Verbosity.QUIET)
@@ -224,16 +224,16 @@ class AircraftMissionTestSuite(unittest.TestCase):
         local_phase_info = self.phase_info.copy()
         local_phase_info['climb']['phase_builder'] = EnergyPhase
 
-        run_aviary(self.aircraft_definition_file, local_phase_info,
-                   verbosity=Verbosity.QUIET, max_iter=1, optimizer='SLSQP')
+        setup_and_run_aviary(self.aircraft_definition_file, local_phase_info,
+                             verbosity=Verbosity.QUIET, max_iter=1, optimizer='SLSQP')
 
     def test_custom_phase_builder_error(self):
         local_phase_info = self.phase_info.copy()
         local_phase_info['climb']['phase_builder'] = "fake phase object"
 
         with self.assertRaises(TypeError):
-            run_aviary(self.aircraft_definition_file, local_phase_info,
-                       verbosity=Verbosity.QUIET, max_iter=1, optimizer='SLSQP')
+            setup_and_run_aviary(self.aircraft_definition_file, local_phase_info,
+                                 verbosity=Verbosity.QUIET, max_iter=1, optimizer='SLSQP')
 
 
 if __name__ == '__main__':

--- a/aviary/interface/test/test_timeseries_report.py
+++ b/aviary/interface/test/test_timeseries_report.py
@@ -6,7 +6,7 @@ from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 import openmdao.api as om
 
 from aviary.interface.default_phase_info.height_energy import phase_info
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 
 
 @use_tempdirs
@@ -17,10 +17,10 @@ class AviaryMissionTimeseries(unittest.TestCase):
     @set_env_vars(TESTFLO_RUNNING='0', OPENMDAO_REPORTS='timeseries_csv')
     def test_timeseries_report(self):
         local_phase_info = deepcopy(phase_info)
-        self.prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
-                               local_phase_info,
-                               optimizer='SLSQP',
-                               max_iter=0)
+        self.prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
+                                         local_phase_info,
+                                         optimizer='SLSQP',
+                                         max_iter=0)
 
         expected_header = [
             "time (s)", "altitude (ft)", "altitude_rate (ft/s)", "distance (m)", "drag (lbf)",

--- a/aviary/validation_cases/benchmark_tests/test_bench_FwFm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_FwFm.py
@@ -8,7 +8,7 @@ from openmdao.utils.testing_utils import require_pyoptsparse
 from openmdao.core.problem import _clear_problem_names
 
 from aviary.api import Mission
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 from aviary.variable_info.enums import Verbosity
 from aviary.validation_cases.benchmark_utils import \
     compare_against_expected_values
@@ -366,17 +366,17 @@ class TestBenchFwFmSerial(ProblemPhaseTestCase):
 
     @require_pyoptsparse(optimizer="IPOPT")
     def test_bench_FwFm_IPOPT(self):
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
-                          self.phase_info, verbosity=Verbosity.QUIET,
-                          max_iter=50, optimizer='IPOPT')
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
+                                    self.phase_info, verbosity=Verbosity.QUIET,
+                                    max_iter=50, optimizer='IPOPT')
 
         compare_against_expected_values(prob, self.expected_dict)
 
     @require_pyoptsparse(optimizer="SNOPT")
     def test_bench_FwFm_SNOPT(self):
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
-                          self.phase_info, verbosity=Verbosity.QUIET,
-                          max_iter=50, optimizer='SNOPT')
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
+                                    self.phase_info, verbosity=Verbosity.QUIET,
+                                    max_iter=50, optimizer='SNOPT')
 
         compare_against_expected_values(prob, self.expected_dict)
 
@@ -395,9 +395,9 @@ class TestBenchFwFmParallel(ProblemPhaseTestCase):
 
     @require_pyoptsparse(optimizer="SNOPT")
     def test_bench_FwFm_SNOPT_MPI(self):
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
-                          self.phase_info, verbosity=Verbosity.QUIET,
-                          max_iter=50, optimizer='SNOPT')
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwFm.csv',
+                                    self.phase_info, verbosity=Verbosity.QUIET,
+                                    max_iter=50, optimizer='SNOPT')
 
         compare_against_expected_values(prob, self.expected_dict)
 

--- a/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
@@ -6,7 +6,7 @@ from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 from openmdao.core.problem import _clear_problem_names
 
 from aviary.interface.default_phase_info.two_dof import phase_info
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 from aviary.variable_info.variables import Aircraft, Mission
 from aviary.variable_info.enums import Verbosity
 
@@ -20,8 +20,8 @@ class ProblemPhaseTestCase(unittest.TestCase):
     @require_pyoptsparse(optimizer="IPOPT")
     def bench_test_swap_3_FwGm_IPOPT(self):
         local_phase_info = deepcopy(phase_info)
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwGm.csv', local_phase_info,
-                          max_iter=100, verbosity=Verbosity.QUIET, optimizer='IPOPT')
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwGm.csv', local_phase_info,
+                                    max_iter=100, verbosity=Verbosity.QUIET, optimizer='IPOPT')
 
         rtol = 1e-2
 
@@ -44,8 +44,8 @@ class ProblemPhaseTestCase(unittest.TestCase):
     @require_pyoptsparse(optimizer="SNOPT")
     def bench_test_swap_3_FwGm_SNOPT(self):
         local_phase_info = deepcopy(phase_info)
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_FwGm.csv',
-                          local_phase_info, verbosity=Verbosity.QUIET, optimizer='SNOPT')
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_FwGm.csv',
+                                    local_phase_info, verbosity=Verbosity.QUIET, optimizer='SNOPT')
 
         rtol = 1e-2
 

--- a/aviary/validation_cases/benchmark_tests/test_bench_GwFm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_GwFm.py
@@ -12,7 +12,7 @@ from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.testing_utils import require_pyoptsparse
 from openmdao.core.problem import _clear_problem_names
 
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 from aviary.variable_info.enums import Verbosity
 from aviary.validation_cases.benchmark_utils import \
     compare_against_expected_values
@@ -361,15 +361,15 @@ class ProblemPhaseTestCase(unittest.TestCase):
 
     @require_pyoptsparse(optimizer="IPOPT")
     def bench_test_swap_1_GwFm_IPOPT(self):
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_GwFm.csv', self.phase_info,
-                          max_iter=100, optimizer='IPOPT', verbosity=Verbosity.QUIET)
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_GwFm.csv', self.phase_info,
+                                    max_iter=100, optimizer='IPOPT', verbosity=Verbosity.QUIET)
 
         compare_against_expected_values(prob, self.expected_dict)
 
     @require_pyoptsparse(optimizer="SNOPT")
     def bench_test_swap_1_GwFm_SNOPT(self):
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_GwFm.csv', self.phase_info,
-                          max_iter=50, optimizer='SNOPT', verbosity=Verbosity.QUIET)
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_GwFm.csv', self.phase_info,
+                                    max_iter=50, optimizer='SNOPT', verbosity=Verbosity.QUIET)
 
         compare_against_expected_values(prob, self.expected_dict)
 

--- a/aviary/validation_cases/benchmark_tests/test_bench_GwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_GwGm.py
@@ -6,7 +6,7 @@ from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 from openmdao.core.problem import _clear_problem_names
 
 from aviary.interface.default_phase_info.two_dof import phase_info
-from aviary.interface.methods_for_level1 import run_aviary
+from aviary.interface.methods_for_level1 import setup_and_run_aviary
 from aviary.variable_info.variables import Aircraft, Mission, Dynamic
 from aviary.variable_info.enums import AnalysisScheme, Verbosity
 
@@ -20,8 +20,8 @@ class ProblemPhaseTestCase(unittest.TestCase):
     @require_pyoptsparse(optimizer="IPOPT")
     def test_bench_GwGm(self):
         local_phase_info = deepcopy(phase_info)
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_GwGm.csv',
-                          local_phase_info, optimizer='IPOPT', verbosity=Verbosity.QUIET)
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_GwGm.csv',
+                                    local_phase_info, optimizer='IPOPT', verbosity=Verbosity.QUIET)
 
         rtol = 0.01
 
@@ -47,8 +47,8 @@ class ProblemPhaseTestCase(unittest.TestCase):
     @require_pyoptsparse(optimizer="SNOPT")
     def test_bench_GwGm_SNOPT(self):
         local_phase_info = deepcopy(phase_info)
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_GwGm.csv',
-                          local_phase_info, optimizer='SNOPT', verbosity=Verbosity.QUIET)
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_GwGm.csv',
+                                    local_phase_info, optimizer='SNOPT', verbosity=Verbosity.QUIET)
 
         rtol = 0.01
 
@@ -74,8 +74,8 @@ class ProblemPhaseTestCase(unittest.TestCase):
     @require_pyoptsparse(optimizer="SNOPT")
     def test_bench_GwGm_SNOPT_lbm_s(self):
         local_phase_info = deepcopy(phase_info)
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv',
-                          local_phase_info, optimizer='SNOPT', verbosity=Verbosity.QUIET)
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv',
+                                    local_phase_info, optimizer='SNOPT', verbosity=Verbosity.QUIET)
 
         rtol = 0.01
 
@@ -101,9 +101,9 @@ class ProblemPhaseTestCase(unittest.TestCase):
     @require_pyoptsparse(optimizer="IPOPT")
     def test_bench_GwGm_shooting(self):
         local_phase_info = deepcopy(phase_info)
-        prob = run_aviary('models/test_aircraft/aircraft_for_bench_GwGm.csv',
-                          local_phase_info, optimizer='IPOPT', run_driver=False,
-                          analysis_scheme=AnalysisScheme.SHOOTING, verbosity=Verbosity.QUIET)
+        prob = setup_and_run_aviary('models/test_aircraft/aircraft_for_bench_GwGm.csv',
+                                    local_phase_info, optimizer='IPOPT', run_driver=False,
+                                    analysis_scheme=AnalysisScheme.SHOOTING, verbosity=Verbosity.QUIET)
 
         rtol = 0.01
 


### PR DESCRIPTION
### Summary

Rename `run_aviary` to `setup_and_run_aviary` because that is what it does.

Note: it will cause backward incompatibility. Should we make this change?

### Related Issues

- Resolves #

### Backwards incompatibilities

updating the api will cause backwards incompatibility for any users currently importing run_aviary from the api

### New Dependencies

None