### PR TITLE
Correcting the example commands for the engine deck conversion and adding a notice for future users

### DIFF
--- a/aviary/docs/user_guide/aviary_commands.ipynb
+++ b/aviary/docs/user_guide/aviary_commands.ipynb
@@ -232,13 +232,14 @@
     "- TurboFan decks for both FLOPS and GASP can be converted\n",
     "- TurboProp decks for GASP can also be converted\n",
     "- Comments can be added using #\n",
+    "- The engine deck file that is to be converted must not have any headers\n",
     "\n",
     "\n",
     "Example usage:\n",
     "```\n",
-    "`aviary convert_engine GASP_turbofan_23k_1.eng turbofan_23k_1_lbm_s.deck GASP` Convert a GASP based turbofan\n",
-    "`aviary convert_engine turbofan_22k.eng turbofan_22k.txt FLOPS` Convert a FLOPS based turbofan\n",
-    "`aviary convert_engine turboprop_4465hp.eng turboprop_4465hp.deck GASP_TP` Convert a GASP based turboprop\n",
+    "`aviary convert_engine GASP_turbofan_23k_1.eng turbofan_23k_1_lbm_s.deck -f GASP` Convert a GASP based turbofan\n",
+    "`aviary convert_engine turbofan_22k.eng turbofan_22k.txt -f FLOPS` Convert a FLOPS based turbofan\n",
+    "`aviary convert_engine turboprop_4465hp.eng turboprop_4465hp.deck -f GASP_TP` Convert a GASP based turboprop\n",
     "```\n"
    ]
   },


### PR DESCRIPTION
The Aviary website gives instructions on how to convert an engine deck using the convert_engine command in Aviary. These commands are not entirely correct however. When running the command exactly as it is from the Aviary website (using the FLOPS conversion for example) there is an error messaged returned saying that FLOPS is not a recognized command:

![Screenshot 2024-06-24 113450](https://github.com/OpenMDAO/Aviary/assets/122938605/1ec6c598-5724-42fe-9d09-b9f76b959a14)

This happens for all conversions (FLOPS, GASP, GASP_TP). However this issue is solved when modifying the given command from the Aviary website from "aviary convert_engine turbofan_22k.eng turbofan_22k.txt FLOPS" to "aviary convert_engine turbofan_22k.eng turbofan_22k.txt -f FLOPS". The added '-f' before FLOPS allows the command to be recognized. Additionally, I added another bullet point note to the same page where it informs the user that in order for the engine conversion to work the original engine deck file must not have any headers to it. When leaving in the headers an error message is returned stating troubles with converting a string to float: 

![Screenshot 2024-06-24 113920](https://github.com/OpenMDAO/Aviary/assets/122938605/0ebc7fdd-d1c4-4ec1-a9b9-c4fdc5774041)
 
