### PR TITLE
Separated testing of 'dev' versions of dependencies from the main test workflow

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -78,7 +78,7 @@ runs:
       if: inputs.PYOPTSPARSE
       shell: bash -l {0}
       run: |
-        if [[ "${{ inputs.PYOPTSPARSE }}" == "latest"]]; then
+        if [[ "${{ inputs.PYOPTSPARSE }}" == "latest" ]]; then
           echo "============================================================="
           echo "Determine which branch/version of pyoptsparse to install"
           echo "============================================================="
@@ -172,4 +172,3 @@ runs:
         name: ${{ inputs.NAME }}_environment
         path: ${{ inputs.NAME }}_environment.yml
         retention-days: 5
-        

--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -78,24 +78,16 @@ runs:
       if: inputs.PYOPTSPARSE
       shell: bash -l {0}
       run: |
+        echo "============================================================="
+        echo "Determine which branch/version of pyoptsparse to install"
+        echo "============================================================="
         if [[ "${{ inputs.PYOPTSPARSE }}" == "latest" ]]; then
-          echo "============================================================="
-          echo "Determine which branch/version of pyoptsparse to install"
-          echo "============================================================="
           function latest_version() {
             local REPO_URL=$1/releases/latest
             local LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} $REPO_URL`
             local LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,"/tag/"); print a[2]}'`
             echo $LATEST_VER
           }
-          function latest_branch() {
-            local LATEST_VER=$(latest_version $1)
-            echo git+$1@$LATEST_VER
-          }
-
-          echo "============================================================="
-          echo "Install latest pyoptsparse"
-          echo "============================================================="
           BRANCH="-b $(latest_version https://github.com/mdolab/pyoptsparse)"
         else
           BRANCH="-b ${{ inputs.PYOPTSPARSE }}"

--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -78,6 +78,29 @@ runs:
       if: inputs.PYOPTSPARSE
       shell: bash -l {0}
       run: |
+        if [[ "${{ inputs.PYOPTSPARSE }}" == "latest"]]; then
+          echo "============================================================="
+          echo "Determine which branch/version of pyoptsparse to install"
+          echo "============================================================="
+          function latest_version() {
+            local REPO_URL=$1/releases/latest
+            local LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} $REPO_URL`
+            local LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,"/tag/"); print a[2]}'`
+            echo $LATEST_VER
+          }
+          function latest_branch() {
+            local LATEST_VER=$(latest_version $1)
+            echo git+$1@$LATEST_VER
+          }
+
+          echo "============================================================="
+          echo "Install latest pyoptsparse"
+          echo "============================================================="
+          BRANCH="-b $(latest_version https://github.com/mdolab/pyoptsparse)"
+        else
+          BRANCH="-b ${{ inputs.PYOPTSPARSE }}"
+        fi
+
         echo "============================================================="
         echo "Install pyoptsparse"
         echo "============================================================="
@@ -93,7 +116,7 @@ runs:
         conda config --add channels conda-forge
 
         pip install git+https://github.com/OpenMDAO/build_pyoptsparse
-        build_pyoptsparse -v -b ${{ inputs.PYOPTSPARSE }} $SNOPT
+        build_pyoptsparse -v $BRANCH $SNOPT
 
     - name: Install OpenMDAO
       if: inputs.OPENMDAO

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           sparse-checkout: |
             .github/actions
           path: actions
-  
+
       - name: prepare_benchmark_environment
         uses: ./actions/.github/actions/prepare_environment
         with:
@@ -39,18 +39,18 @@ jobs:
             PYOPTSPARSE: 'v2.9.1'
             SNOPT: '7.7'
             OPENMDAO: 'latest'
-            DYMOS: 'latest'  
+            DYMOS: 'latest'
             SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
             SSH_KNOWN_HOSTS: ${{secrets.SSH_KNOWN_HOSTS}}
             SNOPT_LOCATION_77: ${{ secrets.SNOPT_LOCATION_77 }}
-  
+
       - name: Run benchmarks
         shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Run Benchmarks"
           echo "============================================================="
-          testflo . --testmatch=bench_test*
+          testflo . --timeout=900 --testmatch=bench_test*
 
       - name: Checkout actions (again)
         uses: actions/checkout@v3

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   pre_commit:
-    # run pre-commit checks
+
     runs-on: ubuntu-latest
 
     steps:
@@ -81,9 +81,9 @@ jobs:
           subject: "***Notification*** Tests failed with development versions of OpenMDAO/Dymos: ${{ env.number }}"
           body: |
             {
-              "number": "${{ env.number }}",
-              "title": "${{ env.title }}",
-              "action": "${{ env.action }}"
+              "number": "${{ github.event.pull_request.number }}",
+              "title": "${{ github.event.pull_request.title }}",
+              "action": "${{ github.event.action }}"
             }
 
       - name: Checkout actions (again)

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -22,7 +22,6 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    - uses: pre-commit/action@v3.0.1
 
   test_ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -3,13 +3,10 @@
 name: Aviary Tests
 
 on:
-  # Trigger on push or pull request events for the main branch
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  merge_group:
-    branches: [ main ]
+
+  # Run the workflow every Tuesday at 0400 UTC
+  schedule:
+    - cron: '1 4 * * 1,4'
 
   # Allow running the workflow manually from the Actions tab
   workflow_dispatch:
@@ -33,25 +30,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # oldest versions of openmdao/dymos
-          - NAME: oldest
-            PY: '3.9'
-            NUMPY: '1.20'
-            SCIPY: '1.6'
-            PYOPTSPARSE: 'v2.9.1'
-            SNOPT: '7.7'
-            OPENMDAO: '3.33.0'
-            DYMOS: '1.8.0'
-
-          # latest versions of openmdao/dymos
-          - NAME: latest
-            PY: '3.10'
+          # latest release of pyoptsparse
+          # development versions of openmdao/dymos
+          - NAME: dev
+            PY: 3
             NUMPY: 1
             SCIPY: 1
-            PYOPTSPARSE: 'v2.9.1'
+            PYOPTSPARSE: 'latest'
             SNOPT: '7.7'
-            OPENMDAO: 'latest'
-            DYMOS: 'latest'
+            OPENMDAO: 'dev'
+            DYMOS: 'dev'
 
     steps:
       - name: Checkout actions
@@ -83,6 +71,21 @@ jobs:
           echo "Run Tests"
           echo "============================================================="
           testflo . -n 1 --timeout=200 --show_skipped --coverage --coverpkg aviary
+
+      - name: Send Email on failed tests
+        if: failure()
+        uses: ./actions/.github/actions/send_email
+        with:
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          to: ${{ secrets.DESTINATION_EMAIL }}
+          subject: "***Notification*** Tests failed with development versions of OpenMDAO/Dymos: ${{ env.number }}"
+          body: |
+            {
+              "number": "${{ env.number }}",
+              "title": "${{ env.title }}",
+              "action": "${{ env.action }}"
+            }
 
       - name: Checkout actions (again)
         uses: actions/checkout@v3

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -13,16 +13,6 @@ on:
 
 jobs:
 
-  pre_commit:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
   test_ubuntu:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # latest release of pyoptsparse
+          # latest released version of pyoptsparse
           # development versions of openmdao/dymos
           - NAME: dev
             PY: 3

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -1,6 +1,6 @@
 # Run Tests
 
-name: Aviary Tests
+name: Test with Pre-Release OpenMDAO/Dymos
 
 on:
 

--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -1,6 +1,6 @@
 # Run Tests
 
-name: Aviary Tests
+name: Test "no dev" install
 
 on:
   # Trigger on push or pull request events for the main branch


### PR DESCRIPTION
### Summary

Separated testing of 'dev' versions of OpenMDAO/Dymos from the main test workflow.

- removed the `dev` job from the test matrix in `test_workflow`
- created a new `test_workflow_dev_deps`, which will run the `dev` job on a weekly basis
  - this workflow will run via cron on Tuesdays at 4:00AM GMT (Midnight ET)
  - this workflow tests with pre-release OpenMDAO/Dymos and the latest release of pyoptsparse
  - this workflow will send an e-mail if the tests fail
- added the option to test with the latest release version of pyoptsparse to `action.yml`
- added testflo `--timeout` argument to all workflows to guard against lockups, etc.
- changed the name of "no dev" workflow, since it had the same name as the test workflow

### Related Issues

- Resolves #454

### Backwards incompatibilities

None

### New Dependencies

None