### PR TITLE
Fix for failing tests.

### DIFF
--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -240,7 +240,8 @@ class AviaryProblem(om.Problem):
         self.regular_phases = []
         self.reserve_phases = []
 
-    def load_inputs(self, aviary_inputs, phase_info=None, engine_builders=None, meta_data=BaseMetaData, verbosity=None):
+    def load_inputs(self, aviary_inputs, phase_info=None, engine_builders=None, meta_data=BaseMetaData,
+                    verbosity=None):
         """
         This method loads the aviary_values inputs and options that the
         user specifies. They could specify files to load and values to
@@ -264,7 +265,8 @@ class AviaryProblem(om.Problem):
 
         if mission_method is TWO_DEGREES_OF_FREEDOM or mass_method is GASP:
             aviary_inputs = update_GASP_options(aviary_inputs)
-        initial_guesses = initial_guessing(aviary_inputs, initial_guesses)
+        initial_guesses = initial_guessing(aviary_inputs, initial_guesses,
+                                           engine_builders)
         self.aviary_inputs = aviary_inputs
         self.initial_guesses = initial_guesses
 

--- a/aviary/utils/process_input_decks.py
+++ b/aviary/utils/process_input_decks.py
@@ -1,10 +1,10 @@
 """
-This module, process_input_decks.py, is responsible for reading vehicle input decks, initializing options, 
+This module, process_input_decks.py, is responsible for reading vehicle input decks, initializing options,
 and setting initial guesses for aircraft design parameters. It works primarily with .csv files,
-allowing for the specification of units, comments, and lists within these files. 
+allowing for the specification of units, comments, and lists within these files.
 
 The module supports various functions like creating a vehicle, parsing input files, updating options based
-on inputs, and handling initial guesses for different aircraft design aspects. It heavily relies on the 
+on inputs, and handling initial guesses for different aircraft design aspects. It heavily relies on the
 aviary and openMDAO libraries for processing and interpreting the aircraft design parameters.
 
 Functions:
@@ -197,7 +197,7 @@ def parse_inputs(vehicle_deck, aircraft_values: AviaryValues = None, initial_gue
 
 def update_GASP_options(aircraft_values: AviaryValues):
     """
-    Updates options based on the current values in aircraft_values. This function also handles special cases 
+    Updates options based on the current values in aircraft_values. This function also handles special cases
     and prints debug information if the debug mode is active.
 
     Parameters
@@ -241,7 +241,7 @@ def update_GASP_options(aircraft_values: AviaryValues):
 
 def update_dependent_options(aircraft_values: AviaryValues, dependent_options):
     """
-    Updates options that are dependent on the value of an input variable or option. The function iterates 
+    Updates options that are dependent on the value of an input variable or option. The function iterates
     through each dependent option and sets its value based on the current aircraft values.
 
     Parameters
@@ -271,18 +271,26 @@ def update_dependent_options(aircraft_values: AviaryValues, dependent_options):
     return aircraft_values
 
 
-def initial_guessing(aircraft_values: AviaryValues, initial_guesses):
+def initial_guessing(aircraft_values: AviaryValues, initial_guesses, engine_builders):
     """
     Sets initial guesses for various aircraft parameters based on the current problem type, aircraft values,
     and other factors. It calculates and sets values like takeoff mass, cruise mass, flight duration, etc.
 
     Parameters
     ----------
-    aircraft_values (AviaryValues): An instance of AviaryValues containing current aircraft values.
+    aircraft_values : AviaryValues
+        An instance of AviaryValues containing current aircraft values.
+
+    initial_guesses : dict
+        Initial guesses.
+
+    engine_builders : list or None
+        List of engine builders. This is needed if there are multiple engine models.
 
     Returns
     -------
-    tuple: Updated aircraft values and initial guesses.
+    tuple
+        Updated aircraft values and initial guesses.
     """
     problem_type = aircraft_values.get_val(Settings.PROBLEM_TYPE)
     num_pax = aircraft_values.get_val(Aircraft.CrewPayload.NUM_PASSENGERS)
@@ -366,8 +374,17 @@ def initial_guessing(aircraft_values: AviaryValues, initial_guesses):
         initial_guesses['flight_duration'] = initial_guesses['flight_duration'] * \
             (60 * 60)
 
-    total_thrust = aircraft_values.get_val(
+    try:
+        total_thrust = aircraft_values.get_val(
         Aircraft.Engine.SCALED_SLS_THRUST, 'lbf') * aircraft_values.get_val(Aircraft.Engine.NUM_ENGINES)
+    except KeyError:
+        # Multi-engine-model case. Get thrust from the engine decks instead.
+        total_thrust = 0
+        for model in engine_builders:
+            thrust = model.get_val(Aircraft.Engine.SCALED_SLS_THRUST, 'lbf')
+            num_engines = model.get_val(Aircraft.Engine.NUM_ENGINES)
+            total_thrust += thrust * num_engines
+
     gamma_guess = np.arcsin(.5*total_thrust / mission_mass)
     avg_speed_guess = (.5 * 667 * cruise_mach)  # kts
 

--- a/aviary/utils/process_input_decks.py
+++ b/aviary/utils/process_input_decks.py
@@ -376,7 +376,7 @@ def initial_guessing(aircraft_values: AviaryValues, initial_guesses, engine_buil
 
     try:
         total_thrust = aircraft_values.get_val(
-        Aircraft.Engine.SCALED_SLS_THRUST, 'lbf') * aircraft_values.get_val(Aircraft.Engine.NUM_ENGINES)
+            Aircraft.Engine.SCALED_SLS_THRUST, 'lbf') * aircraft_values.get_val(Aircraft.Engine.NUM_ENGINES)
     except KeyError:
         # Multi-engine-model case. Get thrust from the engine decks instead.
         total_thrust = 0

--- a/aviary/validation_cases/benchmark_tests/test_bench_multiengine.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_multiengine.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 import unittest
 
+import openmdao.api as om
 from openmdao.core.problem import _clear_problem_names
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
@@ -37,6 +38,7 @@ local_phase_info['descent']['user_options']['use_polynomial_control'] = True
 class MultiengineTestcase(unittest.TestCase):
 
     def setUp(self):
+        om.clear_reports()
         _clear_problem_names()  # need to reset these to simulate separate runs
 
     @require_pyoptsparse(optimizer="SNOPT")


### PR DESCRIPTION
### Summary

Fix for the failing multi-engine tests. They had previously failed during initial condition preparations because, when there are multiple engine models, the thrust is found in the engine builders, not in the aviary inputs. With this change, the thrust from all engines is used to later guess at gamma.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None