### PR TITLE
Corrected error in `test_workflow_dev_deps`

### DIFF
--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -61,6 +61,14 @@ jobs:
           echo "============================================================="
           testflo . -n 1 --timeout=200 --show_skipped --coverage --coverpkg aviary
 
+      - name: Checkout actions (again)
+        if: failure()
+        uses: actions/checkout@v3
+        with:
+          sparse-checkout: |
+            .github/actions
+          path: actions
+
       - name: Send Email on failed tests
         if: failure()
         uses: ./actions/.github/actions/send_email
@@ -75,10 +83,3 @@ jobs:
               "title": "${{ github.event.pull_request.title }}",
               "action": "${{ github.event.action }}"
             }
-
-      - name: Checkout actions (again)
-        uses: actions/checkout@v3
-        with:
-          sparse-checkout: |
-            .github/actions
-          path: actions


### PR DESCRIPTION
### Summary

This fixes an error in PR #455.  

The second checkout of the `.github/actions` directory was meant to precede the attempt to use the `send_email` action.

It has also been made to execute only `if: failure()` since it is not needed for a nominal test run.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None