### PR TITLE
Add useful information to e-mail when "dev_deps" workflow fails

### DIFF
--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -76,10 +76,10 @@ jobs:
           username: ${{ secrets.EMAIL_USERNAME }}
           password: ${{ secrets.EMAIL_PASSWORD }}
           to: ${{ secrets.DESTINATION_EMAIL }}
-          subject: "***Notification*** Tests failed with development versions of OpenMDAO/Dymos: ${{ env.number }}"
+          subject: "***Notification*** Tests failed with development versions of OpenMDAO/Dymos: ${{ github.run_id }}"
           body: |
             {
-              "number": "${{ github.event.pull_request.number }}",
-              "title": "${{ github.event.pull_request.title }}",
-              "action": "${{ github.event.action }}"
+              "number": "${GITHUB_RUN_ID}",
+              "title": "Test with Pre-Release OpenMDAO/Dymos",
+              "action": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -79,7 +79,6 @@ jobs:
           subject: "***Notification*** Tests failed with development versions of OpenMDAO/Dymos: ${{ github.run_id }}"
           body: |
             {
-              "number": "${GITHUB_RUN_ID}",
               "title": "Test with Pre-Release OpenMDAO/Dymos",
               "action": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }


### PR DESCRIPTION
### Summary

This is a follow up to #467, which fixed the sending of an e-mail, but that e-mail did not contain any useful information.

This adds the name of the workflow and a link to the failed run.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None