### PR TITLE
Rework overriding so that we still override an output even if it is not used in a premission input.

### DIFF
--- a/aviary/subsystems/test/test_premission.py
+++ b/aviary/subsystems/test/test_premission.py
@@ -207,9 +207,10 @@ class PreMissionTestCase(unittest.TestCase):
 
         # This is not in the model because it has been overridden, but is not an
         # input to any other component in the GASP premission model.
-        # assert_near_equal(
-        #   self.prob[Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY], 0, tol
-        # )  # always zero when no body tank
+        err_text = '\'<model> <class Group>: Variable "aircraft:fuel:auxiliary_fuel_capacity" not found.\''
+        with self.assertRaises(KeyError) as cm:
+            self.prob.get_val(Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY)
+        self.assertEqual(str(cm.exception), err_text)
 
         assert_near_equal(
             self.prob["fuel_mass.body_tank.extra_fuel_volume"], 0, tol

--- a/aviary/subsystems/test/test_premission.py
+++ b/aviary/subsystems/test/test_premission.py
@@ -204,9 +204,13 @@ class PreMissionTestCase(unittest.TestCase):
         )
         assert_near_equal(
             self.prob["fuel_mass.max_wingfuel_mass"], 57066.3, tol)
-        assert_near_equal(
-            self.prob[Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY], 0, tol
-        )  # always zero when no body tank
+
+        # This is not in the model because it has been overridden, but is not an
+        # input to any other component in the GASP premission model.
+        # assert_near_equal(
+        #   self.prob[Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY], 0, tol
+        # )  # always zero when no body tank
+
         assert_near_equal(
             self.prob["fuel_mass.body_tank.extra_fuel_volume"], 0, tol
         )  # always zero when no body tank

--- a/aviary/variable_info/functions.py
+++ b/aviary/variable_info/functions.py
@@ -118,13 +118,13 @@ def override_aviary_vars(group, aviary_inputs: AviaryValues,
                 continue  # don't promote it
 
             elif name in aviary_inputs:
+                val, units = aviary_inputs.get_item(name)
                 if name in all_inputs:
-                    val, units = aviary_inputs.get_item(name)
                     group.set_input_defaults(name, val=val, units=units)
 
-                    # Overridden variables are given a new name
-                    comp_promoted_outputs.append((name, f"AUTO_OVERRIDE:{name}"))
-                    overridden_outputs.append(name)
+                # Overridden variables are given a new name
+                comp_promoted_outputs.append((name, f"AUTO_OVERRIDE:{name}"))
+                overridden_outputs.append(name)
 
                 continue  # don't promote it
 


### PR DESCRIPTION
### Summary

Formerly, we were skipping any override if the output was not connected to anything else in premission. I am not sure why we were doing this, but I think we want to avoid it because it is inconsistent, and because it might miss connections with downstream external subsystems.

### Related Issues

- Resolves #513

### Backwards incompatibilities

None

### New Dependencies

None