### PR TITLE
Fixed bug where wing area wasn't being promoted out of the mission when using tabular "FLOPS" aero.

### DIFF
--- a/aviary/subsystems/aerodynamics/aerodynamics_builder.py
+++ b/aviary/subsystems/aerodynamics/aerodynamics_builder.py
@@ -364,6 +364,26 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
                 for var in ENGINE_SIZED_INPUTS:
                     params[var] = {'shape': (num_engine_type, ), 'static_target': True}
 
+            elif method == 'tabular':
+
+                for var in TABULAR_CORE_INPUTS:
+
+                    meta = _MetaData[var]
+
+                    val = meta['default_value']
+                    if val is None:
+                        val = _unspecified
+                    units = meta['units']
+
+                    if var in aviary_inputs:
+                        try:
+                            val = aviary_inputs.get_val(var, units)
+                        except TypeError:
+                            val = aviary_inputs.get_val(var)
+
+                    params[var] = {'val': val,
+                                   'static_target': True}
+
             elif method == "low_speed":
 
                 for var in LOW_SPEED_CORE_INPUTS:
@@ -473,6 +493,10 @@ COMPUTED_CORE_INPUTS = [
     Mission.Summary.GROSS_MASS,
     Mission.Design.LIFT_COEFFICIENT,
     Mission.Design.MACH,
+]
+
+TABULAR_CORE_INPUTS = [
+    Aircraft.Wing.AREA,
 ]
 
 # Parameters for low speed aero.

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_solved_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_solved_aero_group.py
@@ -19,7 +19,6 @@ from aviary.interface.default_phase_info.height_energy import phase_info
 from aviary.variable_info.variables import Aircraft
 
 
-
 # The drag-polar-generating component reads this in, instead of computing the polars.
 polar_file = "subsystems/aerodynamics/gasp_based/data/large_single_aisle_1_aero_free_reduced_alpha.txt"
 

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_solved_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_solved_aero_group.py
@@ -3,7 +3,9 @@ This test validates passing a drag polar into the solved aero in the mission.
 Computed lift and drag should be the same as reading the same polar in from
 a file.
 """
+from copy import deepcopy
 import unittest
+
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
@@ -16,7 +18,6 @@ from aviary.utils.named_values import NamedValues
 from aviary.interface.default_phase_info.height_energy import phase_info
 from aviary.variable_info.variables import Aircraft
 
-from copy import deepcopy
 
 
 # The drag-polar-generating component reads this in, instead of computing the polars.

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
@@ -1,13 +1,16 @@
+from copy import deepcopy
 from parameterized import parameterized
 import unittest
 
 import numpy as np
 
 import openmdao.api as om
-from aviary.subsystems.atmosphere.atmosphere import Atmosphere
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
+from aviary.interface.default_phase_info.height_energy import phase_info
+from aviary.interface.methods_for_level2 import AviaryProblem
 from aviary.subsystems.aerodynamics.aerodynamics_builder import CoreAerodynamicsBuilder
+from aviary.subsystems.atmosphere.atmosphere import Atmosphere
 from aviary.subsystems.premission import CorePreMission
 from aviary.utils.test_utils.default_subsystems import get_default_premission_subsystems
 from aviary.subsystems.propulsion.utils import build_engine_deck
@@ -23,6 +26,9 @@ from aviary.variable_info.enums import LegacyCode
 FLOPS = LegacyCode.FLOPS
 GASP = LegacyCode.GASP
 
+CDI_table = "subsystems/aerodynamics/flops_based/test/large_single_aisle_1_CDI_polar.csv"
+CD0_table = "subsystems/aerodynamics/flops_based/test/large_single_aisle_1_CD0_polar.csv"
+
 
 class TabularAeroGroupFileTest(unittest.TestCase):
     # Test drag comp with data from file, structured grid
@@ -30,9 +36,6 @@ class TabularAeroGroupFileTest(unittest.TestCase):
         self.prob = om.Problem()
         aviary_options = AviaryValues()
         aviary_options.set_val(Settings.VERBOSITY, 0)
-
-        CDI_table = "subsystems/aerodynamics/flops_based/test/large_single_aisle_1_CDI_polar.csv"
-        CD0_table = "subsystems/aerodynamics/flops_based/test/large_single_aisle_1_CD0_polar.csv"
 
         kwargs = {'method': 'tabular', 'CDI_data': CDI_table,
                   'CD0_data': CD0_table}
@@ -81,6 +84,44 @@ class TabularAeroGroupFileTest(unittest.TestCase):
         assert_check_partials(
             partial_data, atol=1e-9, rtol=1e-12
         )  # check the partial derivatives
+
+    def test_parameters(self):
+
+        local_phase_info = deepcopy(phase_info)
+        core_aero =  local_phase_info['cruise']['subsystem_options']['core_aerodynamics']
+
+        core_aero['method'] = 'tabular'
+        core_aero['CDI_data'] = CDI_table
+        core_aero['CD0_data'] = CD0_table
+        local_phase_info.pop('climb')
+        local_phase_info.pop('descent')
+
+        prob = AviaryProblem()
+
+        prob.load_inputs(
+            "subsystems/aerodynamics/flops_based/test/data/high_wing_single_aisle.csv",
+            local_phase_info
+        )
+
+        # Preprocess inputs
+        prob.check_and_preprocess_inputs()
+
+        prob.add_pre_mission_systems()
+        prob.add_phases()
+        prob.add_post_mission_systems()
+
+        prob.link_phases()
+
+        prob.setup()
+
+        prob.set_initial_guesses()
+
+        print('about to run')
+        prob.run_model()
+
+        wing_area = prob.get_val("traj.cruise.rhs_all.aircraft:wing:area", units='ft**2')
+        actual_wing_area = prob.aviary_inputs.get_val(Aircraft.Wing.AREA, units='ft**2')
+        assert_near_equal(wing_area, actual_wing_area)
 
 
 class TabularAeroGroupDataTest(unittest.TestCase):

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
@@ -88,7 +88,7 @@ class TabularAeroGroupFileTest(unittest.TestCase):
     def test_parameters(self):
 
         local_phase_info = deepcopy(phase_info)
-        core_aero =  local_phase_info['cruise']['subsystem_options']['core_aerodynamics']
+        core_aero = local_phase_info['cruise']['subsystem_options']['core_aerodynamics']
 
         core_aero['method'] = 'tabular'
         core_aero['CDI_data'] = CDI_table
@@ -119,6 +119,7 @@ class TabularAeroGroupFileTest(unittest.TestCase):
         print('about to run')
         prob.run_model()
 
+        # verify that we are promoting the parameters.
         wing_area = prob.get_val("traj.cruise.rhs_all.aircraft:wing:area", units='ft**2')
         actual_wing_area = prob.aviary_inputs.get_val(Aircraft.Wing.AREA, units='ft**2')
         assert_near_equal(wing_area, actual_wing_area)


### PR DESCRIPTION
### Summary

Fixed bug where wing area wasn't being promoted out of the mission when using tabular "FLOPS" aero.

### Related Issues

- Resolves #551

### Backwards incompatibilities

None

### New Dependencies

None