### PR TITLE
Point CI to the previous openmdao release until we have things fixed. Also, keep numpy less than 2.

### DIFF
--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -38,7 +38,8 @@ jobs:
             SCIPY: 1
             PYOPTSPARSE: 'v2.9.1'
             SNOPT: '7.7'
-            OPENMDAO: 'latest'
+            #OPENMDAO: 'latest'
+            OPENMDAO: '3.34.2'
             DYMOS: 'latest'
             SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
             SSH_KNOWN_HOSTS: ${{secrets.SSH_KNOWN_HOSTS}}

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -38,7 +38,8 @@ jobs:
             SCIPY: 1
             PYOPTSPARSE: 'v2.9.1'
             SNOPT: '7.7'
-            OPENMDAO: 'latest'
+            #OPENMDAO: 'latest'
+            OPENMDAO: '3.34.2'
             DYMOS: 'latest'  
             SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
             SSH_KNOWN_HOSTS: ${{secrets.SSH_KNOWN_HOSTS}}

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -50,7 +50,8 @@ jobs:
             SCIPY: 1
             PYOPTSPARSE: 'v2.9.1'
             SNOPT: '7.7'
-            OPENMDAO: 'latest'
+            #OPENMDAO: 'latest'
+            OPENMDAO: '3.34.2'
             DYMOS: 'latest'
 
     steps:

--- a/.github/workflows/test_workflow_dev_deps.yml
+++ b/.github/workflows/test_workflow_dev_deps.yml
@@ -27,7 +27,8 @@ jobs:
             SCIPY: 1
             PYOPTSPARSE: 'latest'
             SNOPT: '7.7'
-            OPENMDAO: 'dev'
+            #OPENMDAO: 'dev'
+            OPENMDAO: '3.34.2'
             DYMOS: 'dev'
 
     steps:

--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -28,6 +28,7 @@ jobs:
           # latest versions of openmdao/dymos
           - NAME: latest
             PY: 3
+            NUMPY: 1
 
     steps:
       - name: Display run details
@@ -67,6 +68,9 @@ jobs:
           echo "============================================================="
           echo "Install Aviary"
           echo "============================================================="
+          echo ""
+          echo "Temporarilly install specific versions for now."
+          pip install openmdao==3.34.2 numpy<2
           pip install packaging
           pip install .[all]
 

--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -28,7 +28,6 @@ jobs:
           # latest versions of openmdao/dymos
           - NAME: latest
             PY: 3
-            NUMPY: 1
 
     steps:
       - name: Display run details

--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -68,8 +68,9 @@ jobs:
           echo "Install Aviary"
           echo "============================================================="
           echo ""
-          echo "Temporarilly install specific versions for now."
-          pip install openmdao==3.34.2 numpy<2
+          echo "Temporarily install specific versions for now."
+          pip install "numpy<2"
+          pip install "openmdao==3.34.2"
           pip install packaging
           pip install .[all]
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "dymos>=1.8.1",
         "hvplot",
         "importlib_resources",
-        "numpy",
+        "numpy<2",
         "matplotlib",
         "pandas",
         "panel>=1.0.0",


### PR DESCRIPTION
### Summary

Point CI to the previous openmdao release until we have things fixed. Also, keep numpy less than 2.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None