### PR TITLE
Smoothen minimum function in propeller performance

### DIFF
--- a/aviary/subsystems/propulsion/propeller/hamilton_standard.py
+++ b/aviary/subsystems/propulsion/propeller/hamilton_standard.py
@@ -635,7 +635,7 @@ class HamiltonStandard(om.ExplicitComponent):
             TXCLI = np.zeros(6)
             CTTT = np.zeros(4)
             XXXFT = np.zeros(4)
-            act_factor = inputs[Aircraft.Engine.PROPELLER_ACTIVITY_FACTOR]
+            act_factor = inputs[Aircraft.Engine.PROPELLER_ACTIVITY_FACTOR][0]
             for k in range(2):
                 AF_adj_CP[k], run_flag = _unint(Act_Factor_arr, AFCPC[k], act_factor)
                 AF_adj_CT[k], run_flag = _unint(Act_Factor_arr, AFCTC[k], act_factor)
@@ -667,7 +667,7 @@ class HamiltonStandard(om.ExplicitComponent):
             # flag that given lift coeff (cli) does not fall on a node point of CL_arr
             CL_tab_idx_flg = 0  # NCL_flg
             ifnd = 0
-            cli = inputs[Aircraft.Engine.PROPELLER_INTEGRATED_LIFT_COEFFICIENT]
+            cli = inputs[Aircraft.Engine.PROPELLER_INTEGRATED_LIFT_COEFFICIENT][0]
             power_coefficient = inputs['power_coefficient'][i_node]
             for ii in range(6):
                 cl_idx = ii
@@ -740,7 +740,7 @@ class HamiltonStandard(om.ExplicitComponent):
                         CL_tab_idx = CL_tab_idx+1
                     if (CL_tab_idx_flg != 1):
                         PCLI, run_flag = _unint(
-                            CL_arr[CL_tab_idx_begin:CL_tab_idx_begin+4], PXCLI[CL_tab_idx_begin:CL_tab_idx_begin+4], inputs[Aircraft.Engine.PROPELLER_INTEGRATED_LIFT_COEFFICIENT])
+                            CL_arr[CL_tab_idx_begin:CL_tab_idx_begin+4], PXCLI[CL_tab_idx_begin:CL_tab_idx_begin+4], inputs[Aircraft.Engine.PROPELLER_INTEGRATED_LIFT_COEFFICIENT][0])
                     else:
                         PCLI = PXCLI[CL_tab_idx_begin]
                         # PCLI = CLI adjustment to power_coefficient
@@ -810,7 +810,7 @@ class HamiltonStandard(om.ExplicitComponent):
                             XFFT[kl], run_flag = _biquad(comp_mach_CT_arr, 1, DMN, CTE2)
                         CL_tab_idx = CL_tab_idx + 1
                     if (CL_tab_idx_flg != 1):
-                        cli = inputs[Aircraft.Engine.PROPELLER_INTEGRATED_LIFT_COEFFICIENT]
+                        cli = inputs[Aircraft.Engine.PROPELLER_INTEGRATED_LIFT_COEFFICIENT][0]
                         TCLII, run_flag = _unint(
                             CL_arr[CL_tab_idx_begin:CL_tab_idx_begin+4], TXCLI[CL_tab_idx_begin:CL_tab_idx_begin+4], cli)
                         xft, run_flag = _unint(

--- a/aviary/subsystems/propulsion/propeller/hamilton_standard.py
+++ b/aviary/subsystems/propulsion/propeller/hamilton_standard.py
@@ -752,7 +752,7 @@ class HamiltonStandard(om.ExplicitComponent):
                     try:
                         CTT[kdx], run_flag = _unint(
                             # thrust coeff at baseline point for kdx
-                            Blade_angle_table[kdx], CT_Angle_table[idx_blade][kdx][:ang_len], BLL[kdx])
+                            Blade_angle_table[kdx][:ang_len], CT_Angle_table[idx_blade][kdx][:ang_len], BLL[kdx])
                     except IndexError:
                         raise om.AnalysisError(
                             "interp failed for CTT (thrust coefficient) in hamilton_standard.py")

--- a/aviary/subsystems/propulsion/propeller/propeller_performance.py
+++ b/aviary/subsystems/propulsion/propeller/propeller_performance.py
@@ -32,7 +32,7 @@ def smooth_min(x, b, alpha=100.0):
 
 def d_smooth_min(x, b, alpha=100.0):
     """
-    Derivative of function smooth_min
+    Derivative of function smooth_min(x)
 
     Parameters:
     x (float or array-like): First value.

--- a/aviary/subsystems/propulsion/propeller/propeller_performance.py
+++ b/aviary/subsystems/propulsion/propeller/propeller_performance.py
@@ -391,8 +391,8 @@ class AreaSquareRatio(om.ExplicitComponent):
         if smooth:
             alpha = self.options['alpha']
             sqa = smooth_min(sqa, 0.50, alpha)
-            dSQA_dNacDiam = d_smooth_min(sqa, alpha) * dSQA_dNacDiam
-            dSQA_dPropDiam = d_smooth_min(sqa, alpha) * dSQA_dPropDiam
+            dSQA_dNacDiam = d_smooth_min(sqa,  0.50, alpha) * dSQA_dNacDiam
+            dSQA_dPropDiam = d_smooth_min(sqa,  0.50, alpha) * dSQA_dPropDiam
 
         partials['sqa_array', "DiamNac"] = np.ones(nn) * dSQA_dNacDiam
         partials['sqa_array', "DiamProp"] = np.ones(nn) * dSQA_dPropDiam
@@ -454,9 +454,9 @@ class AdvanceRatio(om.ExplicitComponent):
         smooth = self.options["smooth_zje"]
         if smooth:
             alpha = self.options["alpha"]
-            djze_dsqa = d_smooth_min(sqa_array, alpha) * djze_dsqa
-            djze_dvktas = d_smooth_min(sqa_array, alpha) * djze_dvktas
-            djze_dtipspd = d_smooth_min(sqa_array, alpha) * djze_dtipspd
+            djze_dsqa = d_smooth_min(sqa_array,  0.50, alpha) * djze_dsqa
+            djze_dvktas = d_smooth_min(sqa_array,  0.50, alpha) * djze_dvktas
+            djze_dtipspd = d_smooth_min(sqa_array,  0.50, alpha) * djze_dtipspd
 
         partials["equiv_adv_ratio", "sqa_array"] = djze_dsqa
         partials["equiv_adv_ratio", "vktas"] = djze_dvktas

--- a/aviary/subsystems/propulsion/propeller/propeller_performance.py
+++ b/aviary/subsystems/propulsion/propeller/propeller_performance.py
@@ -392,8 +392,10 @@ class AreaSquareRatio(om.ExplicitComponent):
             dSQA_dNacDiam = d_smooth_min(sqa, 0.50, alpha) * dSQA_dNacDiam
             dSQA_dPropDiam = d_smooth_min(sqa, 0.50, alpha) * dSQA_dPropDiam
         else:
-            dSQA_dNacDiam = np.piecewise(sqa, [sqa < 0.5, sqa >= 0.5], [1, 0]) * dSQA_dNacDiam
-            dSQA_dPropDiam = np.piecewise(sqa, [sqa < 0.5, sqa >= 0.5], [1, 0]) * dSQA_dPropDiam
+            dSQA_dNacDiam = np.piecewise(
+                sqa, [sqa < 0.5, sqa >= 0.5], [1, 0]) * dSQA_dNacDiam
+            dSQA_dPropDiam = np.piecewise(
+                sqa, [sqa < 0.5, sqa >= 0.5], [1, 0]) * dSQA_dPropDiam
         partials['sqa_array', "DiamNac"] = dSQA_dNacDiam
         partials['sqa_array', "DiamProp"] = dSQA_dPropDiam
 

--- a/aviary/subsystems/propulsion/propeller/propeller_performance.py
+++ b/aviary/subsystems/propulsion/propeller/propeller_performance.py
@@ -13,6 +13,40 @@ from aviary.variable_info.enums import OutMachType
 from aviary.variable_info.variables import Aircraft, Dynamic
 
 
+def smooth_min(x, b, alpha=100.0):
+    """
+    Smooth approximation of the min function using the log-sum-exp trick.
+
+    Parameters:
+    x (float or array-like): First value.
+    b (float or array-like): Second value.
+    alpha (float): The smoothing factor. Higher values make it closer to the true minimum. Try between 75 and 275.
+
+    Returns:
+    float or array-like: The smooth approximation of min(x, b).
+    """
+    sum_log_exp = np.log(np.exp(np.multiply(-alpha, x)) + np.exp(np.multiply(-alpha, b)))
+    rv = -(1 / alpha) * sum_log_exp
+    return rv
+
+
+def d_smooth_min(x, b, alpha=100.0):
+    """
+    Derivative of function smooth_min
+
+    Parameters:
+    x (float or array-like): First value.
+    b (float or array-like): Second value.
+    alpha (float): The smoothing factor. Higher values make it closer to the true minimum. Try between 75 and 275.
+
+    Returns:
+    float or array-like: The smooth approximation of derivative of min(x, b).
+    """
+    d_sum_log_exp = np.exp(np.multiply(-alpha, x)) / \
+        (np.exp(np.multiply(-alpha, x)) + np.exp(np.multiply(-alpha, b)))
+    return d_sum_log_exp
+
+
 class TipSpeedLimit(om.ExplicitComponent):
     """
     Computation of propeller tip speed.
@@ -305,6 +339,130 @@ class OutMachs(om.ExplicitComponent):
                 np.sqrt(helical_mach * helical_mach - mach * mach)
 
 
+class AreaSquareRatio(om.ExplicitComponent):
+    """
+    Compute the area ratio nacelle and propeller with a maximum 0.5.
+    """
+
+    def initialize(self):
+        self.options.declare("num_nodes", types=int)
+        self.options.declare('smooth_sqa', default=True, types=bool)
+        self.options.declare('alpha', default=100.0, types=float)
+
+    def setup(self):
+        nn = self.options["num_nodes"]
+        arange = np.arange(self.options["num_nodes"])
+        self.add_input("DiamNac", val=0.0, units='ft')
+        self.add_input("DiamProp", val=0.0, units='ft')
+
+        self.add_output('sqa_array', val=np.zeros(nn), units='unitless')
+
+        self.declare_partials("sqa_array",
+                              [
+                                  "DiamNac",
+                                  "DiamProp",
+                              ],
+                              rows=arange, cols=np.zeros(nn))
+
+    def compute(self, inputs, outputs):
+        nn = self.options["num_nodes"]
+        diamNac = inputs["DiamNac"]
+        diamProp = inputs["DiamProp"]
+        sqa = diamNac**2 / diamProp**2
+
+        smooth = self.options["smooth_sqa"]
+        if smooth:
+            alpha = self.options['alpha']
+            sqa = smooth_min(sqa, 0.50, alpha)
+        else:
+            sqa = np.minimum(sqa, 0.50)
+        outputs["sqa_array"] = np.ones(nn) * sqa
+
+    def compute_partials(self, inputs, partials):
+        nn = self.options["num_nodes"]
+        diamNac = inputs["DiamNac"]
+        diamProp = inputs["DiamProp"]
+        sqa = diamNac**2 / diamProp**2
+
+        dSQA_dNacDiam = 2 * diamNac / diamProp**2
+        dSQA_dPropDiam = -2 * diamNac**2 / diamProp**3
+
+        smooth = self.options["smooth_sqa"]
+        if smooth:
+            alpha = self.options['alpha']
+            sqa = smooth_min(sqa, 0.50, alpha)
+            dSQA_dNacDiam = d_smooth_min(sqa, alpha) * dSQA_dNacDiam
+            dSQA_dPropDiam = d_smooth_min(sqa, alpha) * dSQA_dPropDiam
+
+        partials['sqa_array', "DiamNac"] = np.ones(nn) * dSQA_dNacDiam
+        partials['sqa_array', "DiamProp"] = np.ones(nn) * dSQA_dPropDiam
+
+
+class AdvanceRatio(om.ExplicitComponent):
+    """
+    Compute the advance ratio jze with a maximum 5.0.
+    """
+
+    def initialize(self):
+        self.options.declare(
+            'num_nodes', types=int, default=1,
+            desc='Number of nodes to be evaluated in the RHS')
+        self.options.declare('smooth_zje', default=True, types=bool)
+        self.options.declare('alpha', default=100.0, types=float)
+
+    def setup(self):
+        nn = self.options['num_nodes']
+        range = np.arange(nn)
+        self.add_input("vktas", val=np.zeros(nn), units='knot')
+        self.add_input("tipspd", val=np.zeros(nn), units='ft/s')
+        self.add_input("sqa_array", val=np.zeros(nn), units='unitless')
+        self.add_output("equiv_adv_ratio", val=np.zeros(nn), units='unitless')
+
+        self.declare_partials("equiv_adv_ratio",
+                              ["vktas", "tipspd"],
+                              rows=range, cols=range)
+
+        self.declare_partials("equiv_adv_ratio",
+                              ["sqa_array"],
+                              rows=range, cols=range)
+
+    def compute(self, inputs, outputs):
+        nn = self.options['num_nodes']
+        vktas = inputs["vktas"]
+        tipspd = inputs["tipspd"]
+        sqa_array = inputs["sqa_array"]
+
+        equiv_adv_ratio = (1.0 - 0.254 * sqa_array) * 5.309 * vktas / tipspd
+
+        smooth = self.options["smooth_zje"]
+        if smooth:
+            alpha = self.options['alpha']
+            jze = smooth_min(equiv_adv_ratio, np.ones(nn) * 5.0, alpha)
+        else:
+            jze = np.minimum(equiv_adv_ratio, np.ones(nn) * 5.0)
+        outputs["equiv_adv_ratio"] = jze
+
+    def compute_partials(self, inputs, partials):
+        vktas = inputs["vktas"]
+        tipspd = inputs["tipspd"]
+        sqa_array = inputs["sqa_array"]
+
+        djze_dsqa = -0.254 * 5.309 * vktas / tipspd
+        djze_dvktas = (1.0 - 0.254 * sqa_array) * 5.309 / tipspd
+        djze_dtipspd = -(1.0 - 0.254 * sqa_array) * 5.309 * vktas / tipspd**2
+
+        smooth = self.options["smooth_zje"]
+        if smooth:
+            alpha = self.options["alpha"]
+            djze_dsqa = d_smooth_min(sqa_array, alpha) * djze_dsqa
+            djze_dvktas = d_smooth_min(sqa_array, alpha) * djze_dvktas
+            djze_dtipspd = d_smooth_min(sqa_array, alpha) * djze_dtipspd
+
+        partials["equiv_adv_ratio", "sqa_array"] = djze_dsqa
+        partials["equiv_adv_ratio", "vktas"] = djze_dvktas
+        partials["equiv_adv_ratio", "tipspd"] = djze_dtipspd
+
+
 class InstallLoss(om.Group):
     """
     Compute installation loss
@@ -322,42 +480,18 @@ class InstallLoss(om.Group):
         nn = self.options['num_nodes']
         self.add_subsystem(
             name='sqa_comp',
-            subsys=om.ExecComp(
-                'sqa = minimum(DiamNac**2/DiamProp**2, 0.50)',
-                DiamNac={'val': 0, 'units': 'ft'},
-                DiamProp={'val': 0, 'units': 'ft'},
-                sqa={'units': 'unitless'},
-                has_diag_partials=True,
-            ),
+            subsys=AreaSquareRatio(num_nodes=nn, smooth_sqa=True),
             promotes_inputs=[("DiamNac", Aircraft.Nacelle.AVG_DIAMETER),
                              ("DiamProp", Aircraft.Engine.PROPELLER_DIAMETER)],
-            promotes_outputs=["sqa"],
+            promotes_outputs=["sqa_array"],
         )
 
-        # We should update these minimum calls to use a smooth minimum so that the
-        # gradient information is C1 continuous.
         self.add_subsystem(
-            name='zje_comp', subsys=om.ExecComp(
-                'equiv_adv_ratio = minimum((1.0 - 0.254 * sqa) * 5.309 * vktas/tipspd, 5.0)',
-                vktas={'units': 'knot', 'val': np.zeros(nn)},
-                tipspd={'units': 'ft/s', 'val': np.zeros(nn)},
-                sqa={'units': 'unitless'},
-                equiv_adv_ratio={'units': 'unitless', 'val': np.zeros(nn)},
-                has_diag_partials=True,),
-            promotes_inputs=["sqa", ("vktas", Dynamic.Mission.VELOCITY),
+            name='zje_comp',
+            subsys=AdvanceRatio(num_nodes=nn, smooth_zje=True),
+            promotes_inputs=["sqa_array", ("vktas", Dynamic.Mission.VELOCITY),
                              ("tipspd", Dynamic.Mission.PROPELLER_TIP_SPEED)],
-            promotes_outputs=["equiv_adv_ratio"],)
-
-        self.add_subsystem(
-            'convert_sqa',
-            om.ExecComp(
-                'sqa_array = sqa',
-                sqa={'units': 'unitless'},
-                sqa_array={'units': 'unitless', 'shape': (nn,)},
-                has_diag_partials=True,
-            ),
-            promotes_inputs=["sqa"],
-            promotes_outputs=["sqa_array"],
+            promotes_outputs=["equiv_adv_ratio"],
         )
 
         self.blockage_factor_interp = self.add_subsystem(

--- a/aviary/subsystems/propulsion/propeller/propeller_performance.py
+++ b/aviary/subsystems/propulsion/propeller/propeller_performance.py
@@ -443,6 +443,7 @@ class AdvanceRatio(om.ExplicitComponent):
         outputs["equiv_adv_ratio"] = jze
 
     def compute_partials(self, inputs, partials):
+        nn = self.options['num_nodes']
         vktas = inputs["vktas"]
         tipspd = inputs["tipspd"]
         sqa_array = inputs["sqa_array"]
@@ -454,9 +455,9 @@ class AdvanceRatio(om.ExplicitComponent):
         smooth = self.options["smooth_zje"]
         if smooth:
             alpha = self.options["alpha"]
-            djze_dsqa = d_smooth_min(sqa_array,  5.0, alpha) * djze_dsqa
-            djze_dvktas = d_smooth_min(sqa_array,  5.0, alpha) * djze_dvktas
-            djze_dtipspd = d_smooth_min(sqa_array,  5.0, alpha) * djze_dtipspd
+            djze_dsqa = d_smooth_min(sqa_array,  np.ones(nn) * 5.0, alpha) * djze_dsqa
+            djze_dvktas = d_smooth_min(sqa_array,  np.ones(nn) * 5.0, alpha) * djze_dvktas
+            djze_dtipspd = d_smooth_min(sqa_array,  np.ones(nn) * 5.0, alpha) * djze_dtipspd
 
         partials["equiv_adv_ratio", "sqa_array"] = djze_dsqa
         partials["equiv_adv_ratio", "vktas"] = djze_dvktas

--- a/aviary/subsystems/propulsion/propeller/propeller_performance.py
+++ b/aviary/subsystems/propulsion/propeller/propeller_performance.py
@@ -454,9 +454,9 @@ class AdvanceRatio(om.ExplicitComponent):
         smooth = self.options["smooth_zje"]
         if smooth:
             alpha = self.options["alpha"]
-            djze_dsqa = d_smooth_min(sqa_array,  0.50, alpha) * djze_dsqa
-            djze_dvktas = d_smooth_min(sqa_array,  0.50, alpha) * djze_dvktas
-            djze_dtipspd = d_smooth_min(sqa_array,  0.50, alpha) * djze_dtipspd
+            djze_dsqa = d_smooth_min(sqa_array,  5.0, alpha) * djze_dsqa
+            djze_dvktas = d_smooth_min(sqa_array,  5.0, alpha) * djze_dvktas
+            djze_dtipspd = d_smooth_min(sqa_array,  5.0, alpha) * djze_dtipspd
 
         partials["equiv_adv_ratio", "sqa_array"] = djze_dsqa
         partials["equiv_adv_ratio", "vktas"] = djze_dvktas

--- a/aviary/subsystems/propulsion/test/test_propeller_performance.py
+++ b/aviary/subsystems/propulsion/test/test_propeller_performance.py
@@ -532,7 +532,7 @@ class OutMachsTest(unittest.TestCase):
         assert_check_partials(partial_data, atol=1e-4, rtol=1e-4)
 
 
-class TipSpeedLimitest(unittest.TestCase):
+class TipSpeedLimittest(unittest.TestCase):
     """
     Test computation of tip speed limit in TipSpeedLimit class.
     """
@@ -628,18 +628,18 @@ class AdvanceRatioTest(unittest.TestCase):
         prob = om.Problem()
         prob.model.add_subsystem(
             "group",
-            AdvanceRatio(num_nodes=3, smooth_zje=False),
+            AdvanceRatio(num_nodes=4, smooth_zje=False),
             promotes=["*"],
         )
         prob.setup(force_alloc_complex=True)
-        prob.set_val("vktas", val=[0.1, 125., 300.], units='knot')
-        prob.set_val("tipspd", val=[800., 800., 750.], units='ft/s')
-        prob.set_val("sqa_array", val=[0.0756, 0.0756, 0.0756], units='unitless')
+        prob.set_val("vktas", val=[0.1, 125., 300., 1000.], units='knot')
+        prob.set_val("tipspd", val=[800., 800., 750., 500.], units='ft/s')
+        prob.set_val("sqa_array", val=[0.0756, 0.0756, 0.0756, 1.0], units='unitless')
         prob.run_model()
 
         equiv_adv_ratio = prob.get_val("equiv_adv_ratio", units='unitless')
         assert_near_equal(equiv_adv_ratio, [
-            0.000650881807, 0.813602259, 2.08282178], tolerance=1e-5)
+            0.000650881807, 0.813602259, 2.08282178, 5], tolerance=1e-5)
 
         partial_data = prob.check_partials(out_stream=None, method="cs")
         assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)

--- a/aviary/subsystems/propulsion/test/test_propeller_performance.py
+++ b/aviary/subsystems/propulsion/test/test_propeller_performance.py
@@ -533,7 +533,7 @@ class OutMachsTest(unittest.TestCase):
         assert_check_partials(partial_data, atol=1e-4, rtol=1e-4)
 
 
-class TipSpeedLimittest(unittest.TestCase):
+class TipSpeedLimitTest(unittest.TestCase):
     """
     Test computation of tip speed limit in TipSpeedLimit class.
     """

--- a/aviary/subsystems/propulsion/test/test_propeller_performance.py
+++ b/aviary/subsystems/propulsion/test/test_propeller_performance.py
@@ -6,10 +6,10 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from aviary.subsystems.atmosphere.atmosphere import Atmosphere
 from aviary.subsystems.propulsion.propeller.propeller_performance import (
-    OutMachs, PropellerPerformance, TipSpeedLimit,
+    OutMachs, PropellerPerformance, TipSpeedLimit, AreaSquareRatio, AdvanceRatio
 )
 from aviary.variable_info.enums import OutMachType
-from aviary.variable_info.variables import Aircraft, Dynamic
+from aviary.variable_info.variables import Aircraft, Dynamic, Settings
 from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Dynamic
 
@@ -179,6 +179,7 @@ class PropellerPerformanceTest(unittest.TestCase):
         options.set_val(Aircraft.Engine.NUM_PROPELLER_BLADES, val=4, units='unitless')
         options.set_val(Aircraft.Engine.GENERATE_FLIGHT_IDLE, False)
         options.set_val(Aircraft.Engine.USE_PROPELLER_MAP, False)
+        options.set_val(Settings.VERBOSITY, 0)
 
         prob = om.Problem()
 
@@ -507,7 +508,7 @@ class OutMachsTest(unittest.TestCase):
             minimum_step=1e-12, abs_err_tol=5.0E-4, rel_err_tol=5.0E-5)
         assert_check_partials(partial_data, atol=1e-4, rtol=1e-4)
 
-    def test_tip_mach(self):
+    def tstest_tip_mach(self):
         # Given helical Mach and Mach, compute tip Mach.
         tol = 1e-5
         prob = om.Problem()
@@ -531,7 +532,7 @@ class OutMachsTest(unittest.TestCase):
         assert_check_partials(partial_data, atol=1e-4, rtol=1e-4)
 
 
-class TipSpeedLimitTest(unittest.TestCase):
+class TipSpeedLimitest(unittest.TestCase):
     """
     Test computation of tip speed limit in TipSpeedLimit class.
     """
@@ -572,6 +573,96 @@ class TipSpeedLimitTest(unittest.TestCase):
             rel_err_tol=5.0e-5,
         )
         assert_check_partials(partial_data, atol=5e-4, rtol=1e-4)
+
+
+class SquareRatioTest(unittest.TestCase):
+    """
+    Test the computation of square ratio with a maximum
+    """
+
+    def test_sqa_ratio_1(self):
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "group",
+            AreaSquareRatio(num_nodes=3, smooth_sqa=False),
+            promotes=["*"],
+        )
+        prob.setup(force_alloc_complex=True)
+        prob.set_val("DiamNac", val=2.8875, units='ft')
+        prob.set_val("DiamProp", val=10.0, units='ft')
+        prob.run_model()
+
+        sqa_ratio = prob.get_val("sqa_array", units='unitless')
+        assert_near_equal(sqa_ratio, [
+            0.08337656, 0.08337656, 0.08337656], tolerance=1e-5)
+
+        partial_data = prob.check_partials(out_stream=None, method="cs")
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
+
+    def test_sqa_ratio_2(self):
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "group",
+            AreaSquareRatio(num_nodes=3, smooth_sqa=True),
+            promotes=["*"],
+        )
+        prob.setup(force_alloc_complex=True)
+        prob.set_val("DiamNac", val=2.8875, units='ft')
+        prob.set_val("DiamProp", val=10.0, units='ft')
+        prob.run_model()
+
+        sqa_ratio = prob.get_val("sqa_array", units='unitless')
+        assert_near_equal(sqa_ratio, [
+            0.08337656, 0.08337656, 0.08337656], tolerance=1e-5)
+
+        partial_data = prob.check_partials(out_stream=None, method="cs")
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
+
+
+class AdvanceRatioTest(unittest.TestCase):
+    """
+    Test the computation of advanced ratio with a maximum
+    """
+
+    def test_zje_1(self):
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "group",
+            AdvanceRatio(num_nodes=3, smooth_zje=False),
+            promotes=["*"],
+        )
+        prob.setup(force_alloc_complex=True)
+        prob.set_val("vktas", val=[0.1, 125., 300.], units='knot')
+        prob.set_val("tipspd", val=[800., 800., 750.], units='ft/s')
+        prob.set_val("sqa_array", val=[0.0756, 0.0756, 0.0756], units='unitless')
+        prob.run_model()
+
+        equiv_adv_ratio = prob.get_val("equiv_adv_ratio", units='unitless')
+        assert_near_equal(equiv_adv_ratio, [
+            0.000650881807, 0.813602259, 2.08282178], tolerance=1e-5)
+
+        partial_data = prob.check_partials(out_stream=None, method="cs")
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
+
+    def test_zje_2(self):
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "group",
+            AdvanceRatio(num_nodes=3, smooth_zje=True),
+            promotes=["*"],
+        )
+        prob.setup(force_alloc_complex=True)
+        prob.set_val("vktas", val=[0.1, 125., 300.], units='knot')
+        prob.set_val("tipspd", val=[800., 800., 750.], units='ft/s')
+        prob.set_val("sqa_array", val=[0.0756, 0.0756, 0.0756], units='unitless')
+        prob.run_model()
+
+        equiv_adv_ratio = prob.get_val("equiv_adv_ratio", units='unitless')
+        assert_near_equal(equiv_adv_ratio, [
+            0.000650881807, 0.813602259, 2.08282178], tolerance=1e-5)
+
+        partial_data = prob.check_partials(out_stream=None, method="cs")
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
 
 if __name__ == "__main__":

--- a/aviary/subsystems/propulsion/test/test_propeller_performance.py
+++ b/aviary/subsystems/propulsion/test/test_propeller_performance.py
@@ -508,7 +508,7 @@ class OutMachsTest(unittest.TestCase):
             minimum_step=1e-12, abs_err_tol=5.0E-4, rel_err_tol=5.0E-5)
         assert_check_partials(partial_data, atol=1e-4, rtol=1e-4)
 
-    def tstest_tip_mach(self):
+    def test_tip_mach(self):
         # Given helical Mach and Mach, compute tip Mach.
         tol = 1e-5
         prob = om.Problem()


### PR DESCRIPTION
### Summary

Currently, there are two uses of `min()` function in `InstallLoss` class. That results in the discontinuity of partial derivatives. These two min() functions are replaced by a smoothed minimum function using the log-sum-exp trick. The new function along with its derivative are added to `aviary/subsystems/propulsion/propeller/propeller_performance.py` because it is not used anywhere else. The smoothing factor `alpha` is set to `100.0`. It is tested that this factor should be limited to between 75 and 275. Otherwise, a few unit tests will fail.

`aviary/subsystems/propulsion/propeller/hamilton_standard.py` is updated at a few places to avoid a few `numpy` warnings and to fix a bug.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None