### PR TITLE
Adding has_diag_partials to ExecComps

### DIFF
--- a/aviary/examples/external_subsystems/engine_NPSS/NPSS_Model/DesignEngineGroup.py
+++ b/aviary/examples/external_subsystems/engine_NPSS/NPSS_Model/DesignEngineGroup.py
@@ -118,11 +118,11 @@ class DesignEngineGroup(om.Group):
                            promotes_outputs=[('Fn_SLS', Aircraft.Engine.SCALED_SLS_THRUST), ('thrust_training_data', 'Fn_train'),
                                              ('thrustmax_training_data', 'Fn_max_train'), ('Wf_training_data', 'Wf_td')])
 
-        self.add_subsystem('negative_fuel_rate', om.ExecComp('y=-x',
-                                                             x={'val': np.ones(
-                                                                 vec_size), 'units': 'lbm/s'},
-                                                             y={'val': np.ones(vec_size), 'units': 'lbm/s'},
-                                                             has_diag_partials=True,),
+        self.add_subsystem('negative_fuel_rate',
+                           om.ExecComp('y=-x',
+                                       x={'val': np.ones(vec_size), 'units': 'lbm/s'},
+                                       y={'val': np.ones(vec_size), 'units': 'lbm/s'},
+                                       has_diag_partials=True,),
                            promotes_inputs=[('x', 'Wf_td')],
                            promotes_outputs=[('y', 'Wf_inv_train')])
 

--- a/aviary/examples/external_subsystems/engine_NPSS/NPSS_Model/DesignEngineGroup.py
+++ b/aviary/examples/external_subsystems/engine_NPSS/NPSS_Model/DesignEngineGroup.py
@@ -121,7 +121,8 @@ class DesignEngineGroup(om.Group):
         self.add_subsystem('negative_fuel_rate', om.ExecComp('y=-x',
                                                              x={'val': np.ones(
                                                                  vec_size), 'units': 'lbm/s'},
-                                                             y={'val': np.ones(vec_size), 'units': 'lbm/s'}),
+                                                             y={'val': np.ones(vec_size), 'units': 'lbm/s'},
+                                                             has_diag_partials=True,),
                            promotes_inputs=[('x', 'Wf_td')],
                            promotes_outputs=[('y', 'Wf_inv_train')])
 

--- a/aviary/mission/flops_based/ode/landing_eom.py
+++ b/aviary/mission/flops_based/ode/landing_eom.py
@@ -113,7 +113,8 @@ class FlareEOM(om.Group):
             expr,
             flare_rate={'shape': 1, 'units': 'deg/s'},
             angle_of_attack_rate={'shape': nn, 'units': 'deg/s'},
-            net_alpha_rate={'shape': nn, 'units': 'deg/s'}
+            net_alpha_rate={'shape': nn, 'units': 'deg/s'},
+            has_diag_partials=True,
         )
         self.add_subsystem(
             "flare_rate",

--- a/aviary/mission/flops_based/ode/landing_ode.py
+++ b/aviary/mission/flops_based/ode/landing_ode.py
@@ -197,6 +197,7 @@ class FlareODE(om.Group):
                 v={'units': 'm/s', 'shape': nn},
                 # NOTE: FLOPS detailed takeoff stall speed is not dynamic - see above
                 v_stall={'units': 'm/s', 'shape': nn},
+                has_diag_partials=True,
             ),
             promotes_inputs=[('v', Dynamic.Mission.VELOCITY), 'v_stall'],
             promotes_outputs=['v_over_v_stall'],

--- a/aviary/mission/flops_based/ode/takeoff_ode.py
+++ b/aviary/mission/flops_based/ode/takeoff_ode.py
@@ -198,6 +198,7 @@ class TakeoffODE(om.Group):
                 v={'units': 'm/s', 'shape': nn},
                 # NOTE: FLOPS detailed takeoff stall speed is not dynamic - see above
                 v_stall={'units': 'm/s', 'shape': nn},
+                has_diag_partials=True,
             ),
             promotes_inputs=[('v', Dynamic.Mission.VELOCITY), 'v_stall'],
             promotes_outputs=['v_over_v_stall'],

--- a/aviary/subsystems/aerodynamics/flops_based/solved_alpha_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/solved_alpha_group.py
@@ -87,6 +87,7 @@ class SolvedAlphaGroup(om.Group):
                                        mass={'units': 'kg', 'shape': nn},
                                        computed_lift={'units': 'N', 'shape': nn},
                                        lift_resid={'shape': nn},
+                                       has_diag_partials=True,
                                        ),
                            promotes_inputs=[('mass', Dynamic.Mission.MASS),
                                             ('computed_lift', Dynamic.Mission.LIFT)]

--- a/aviary/subsystems/aerodynamics/flops_based/takeoff_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/takeoff_aero_group.py
@@ -155,7 +155,8 @@ class TakeoffAeroGroup(om.Group):
                 om.ExecComp(
                     f'climb_lift_coefficient = ground_effect_lift + {spoiler_lift}',
                     climb_lift_coefficient={'units': 'unitless', 'shape': nn},
-                    ground_effect_lift={'units': 'unitless', 'shape': nn}),
+                    ground_effect_lift={'units': 'unitless', 'shape': nn},
+                    has_diag_partials=True,),
                 promotes_inputs=['ground_effect_lift'],
                 promotes_outputs=['climb_lift_coefficient'])
 
@@ -170,7 +171,8 @@ class TakeoffAeroGroup(om.Group):
             om.ExecComp(
                 f,
                 climb_drag_coefficient={'units': 'unitless', 'shape': nn},
-                ground_effect_drag={'units': 'unitless', 'shape': nn}),
+                ground_effect_drag={'units': 'unitless', 'shape': nn},
+                has_diag_partials=True,),
             promotes_inputs=['ground_effect_drag'],
             promotes_outputs=['climb_drag_coefficient'])
 

--- a/aviary/subsystems/aerodynamics/gasp_based/table_based.py
+++ b/aviary/subsystems/aerodynamics/gasp_based/table_based.py
@@ -145,6 +145,7 @@ class TabularLowSpeedAero(om.Group):
                 val=8.0, units="ft", desc="Wing height above ground at 0 alt"
             ),
             hob=dict(shape=(nn,), desc="Wing height/span", units="unitless"),
+            has_diag_partials=True,
         )
         self.add_subsystem(
             "hob",

--- a/aviary/subsystems/energy/battery_builder.py
+++ b/aviary/subsystems/energy/battery_builder.py
@@ -45,7 +45,8 @@ class BatteryBuilder(SubsystemBuilderBase):
                           energy_capacity={'val': 10.0, 'units': 'kJ'},
                           cumulative_electric_energy_used={
                               'val': np.zeros(num_nodes), 'units': 'kJ'},
-                          efficiency={'val': 0.95, 'units': 'unitless'})
+                          efficiency={'val': 0.95, 'units': 'unitless'},
+                          has_diag_partials=True)
 
         battery_group.add_subsystem('state_of_charge',
                                     subsys=soc,

--- a/aviary/subsystems/propulsion/turboprop_model.py
+++ b/aviary/subsystems/propulsion/turboprop_model.py
@@ -269,14 +269,16 @@ class TurbopropMission(om.Group):
             'turboprop_thrust=turboshaft_thrust+propeller_thrust',
             turboprop_thrust={'val': np.zeros(num_nodes), 'units': 'lbf'},
             turboshaft_thrust={'val': np.zeros(num_nodes), 'units': 'lbf'},
-            propeller_thrust={'val': np.zeros(num_nodes), 'units': 'lbf'}
+            propeller_thrust={'val': np.zeros(num_nodes), 'units': 'lbf'},
+            has_diag_partials=True,
         )
 
         max_thrust_adder = om.ExecComp(
             'turboprop_thrust_max=turboshaft_thrust_max+propeller_thrust_max',
             turboprop_thrust_max={'val': np.zeros(num_nodes), 'units': 'lbf'},
             turboshaft_thrust_max={'val': np.zeros(num_nodes), 'units': 'lbf'},
-            propeller_thrust_max={'val': np.zeros(num_nodes), 'units': 'lbf'}
+            propeller_thrust_max={'val': np.zeros(num_nodes), 'units': 'lbf'},
+            has_diag_partials=True,
         )
 
         self.add_subsystem(

--- a/aviary/utils/test_utils/default_subsystems.py
+++ b/aviary/utils/test_utils/default_subsystems.py
@@ -13,8 +13,8 @@ def get_default_premission_subsystems(legacy_code, engines=None):
 
     Arguments:
     ----------
-    legacy_code : str
-        either 'FLOPS' or 'GASP'
+    legacy_code : str, LegacyCode
+        either FLOPS or GASP LegacyCode Enums, or their strings equivalents ('FLOPS', 'GASP')
     engine : <list of EngineDecks>
         List of EngineDecks
     """

--- a/aviary/utils/test_utils/default_subsystems.py
+++ b/aviary/utils/test_utils/default_subsystems.py
@@ -29,8 +29,7 @@ def get_default_premission_subsystems(legacy_code, engines=None):
 
 def get_default_mission_subsystems(legacy_code, engines=None):
     """
-    Get default mission subsystems aerodynamics and propulsion
-    in this order.
+    Get default mission subsystems aerodynamics and propulsion in this order.
 
     Arguments:
     ----------

--- a/aviary/utils/test_utils/default_subsystems.py
+++ b/aviary/utils/test_utils/default_subsystems.py
@@ -7,6 +7,17 @@ from aviary.variable_info.enums import LegacyCode
 
 
 def get_default_premission_subsystems(legacy_code, engines=None):
+    """
+    Get default premission subsystems propulsion, geometry, aerodynamics, and mass
+    in this order.
+
+    Arguments:
+    ----------
+    legacy_code : str
+        either 'FLOPS' or 'GASP'
+    engine : <list of EngineDecks>
+        List of EngineDecks
+    """
     legacy_code = LegacyCode(legacy_code)
     prop = CorePropulsionBuilder('core_propulsion', BaseMetaData, engine_models=engines)
     mass = CoreMassBuilder('core_mass', BaseMetaData, legacy_code)
@@ -17,6 +28,18 @@ def get_default_premission_subsystems(legacy_code, engines=None):
 
 
 def get_default_mission_subsystems(legacy_code, engines=None):
+    """
+    Get default mission subsystems aerodynamics and propulsion
+    in this order.
+
+    Arguments:
+    ----------
+    legacy_code : str
+        either 'FLOPS' or 'GASP'
+    engine : <list of EngineDecks>
+        List of EngineDecks
+    """
+
     legacy_code = LegacyCode(legacy_code)
     prop = CorePropulsionBuilder('core_propulsion', BaseMetaData, engine_models=engines)
     aero = CoreAerodynamicsBuilder('core_aerodynamics', BaseMetaData, legacy_code)

--- a/aviary/utils/test_utils/default_subsystems.py
+++ b/aviary/utils/test_utils/default_subsystems.py
@@ -33,8 +33,8 @@ def get_default_mission_subsystems(legacy_code, engines=None):
 
     Arguments:
     ----------
-    legacy_code : str
-        either 'FLOPS' or 'GASP'
+    legacy_code : str, LegacyCode
+        either FLOPS or GASP LegacyCode Enums, or their strings equivalents ('FLOPS', 'GASP')
     engine : <list of EngineDecks>
         List of EngineDecks
     """


### PR DESCRIPTION
### Summary

`ExecComps` that are sized to `num_nodes` should have the parameter `has_diag_partials=True` so OpenMDAO can take advantage of sparsity. This PR addresses this issue.

Couple of `ExecComps` are not updated because I am changing them to classes.

Added docstrings for `aviary/utils/test_utils/default_subsystems.py`.

### Related Issues

- Resolves #480 

### Backwards incompatibilities

None

### New Dependencies

None