### PR TITLE
removed duplicate code and clarified error message on duration bounds

### DIFF
--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -2197,21 +2197,12 @@ class AviaryProblem(om.Problem):
         if self.mission_method is HEIGHT_ENERGY:
             # if time not in initial guesses, set it to the average of the initial_bounds and the duration_bounds
             if 'time' not in guesses:
-                initial_bounds = wrapped_convert_units(
-                    self.phase_info[phase_name]['user_options']['initial_bounds'], 's')
-                duration_bounds = wrapped_convert_units(
-                    self.phase_info[phase_name]['user_options']['duration_bounds'], 's')
-                guesses["time"] = ([np.mean(initial_bounds[0]), np.mean(
-                    duration_bounds[0])], 's')
-
-            # if time not in initial guesses, set it to the average of the initial_bounds and the duration_bounds
-            if 'time' not in guesses:
                 initial_bounds = self.phase_info[phase_name]['user_options']['initial_bounds']
                 duration_bounds = self.phase_info[phase_name]['user_options']['duration_bounds']
                 # Add a check for the initial and duration bounds, raise an error if they are not consistent
                 if initial_bounds[1] != duration_bounds[1]:
                     raise ValueError(
-                        f"Initial and duration bounds for {phase_name} are not consistent.")
+                        f"Initial and duration bounds for {phase_name} are not in the same units.")
                 guesses["time"] = ([np.mean(initial_bounds[0]), np.mean(
                     duration_bounds[0])], initial_bounds[1])
 


### PR DESCRIPTION
### Summary

Modifying the `phase_info` is one of the easiest ways to break a problem. In the long-term, we should limit interactions with phase_info to graphical-based tool for level1 and level2 users. However, for level3 users, we must rebuild phase_info to be more intuitive, systematic, and less error-prone. 

Proposed Changes with this PR:
1) New naming scheme for all elements inside of phase info. The current naming scheme was built piecemeal as additional states and controls were added to the problem. As such the naming convention of items here is inconsistent. For example,  'optimize_mach', 'mach_bounds', `initial_mach`, `final_mach`, and `fix_initial` all modify some aspect of the mach state. They should all start with `mach`. And items like `fix_initial` which modify both mach and altitude should be split into two items. Proposed changes would be that all of these names would start with `mach_X_modifier`, thus we would have `mach_optimize`, `mach_initial`, `mach_bounds`, `mach_initial_fix`.
2) There is no concise list of what options need to be called for the different ODE methods. Some methods require more inputs than others. To solve this, each ODE method must check phase_info for the minimum required list of inputs in `check_phase_info.py`. Additionally, each ODE method should list it's required inputs in the docs (https://openmdao.github.io/Aviary/getting_started/input_csv_phase_info.html). 
3) Range vs. Distance and Time vs. Duration, are actually the same item in different reference frames. Distance is measured relative to the start of the phase and range is measured relative to the start of the mission. Duration is measured relative to the start of the phase and time is measured relative to the start of the mission. Having two words for the same thing is a bit confusing. Also, it gets even worse when trying to get the user to set these values and something like `initial_guesses[`time`] is in (absolute,relative) units. Right now there is not descriptions for the user on the docs page telling them the differences between these items and describing the absolute vs. relative nature of the values that must be set for any of them.
4) You cannot set ref values for all states in the phase info, only some of them (like time). 
5) Understanding all the boundary conditions / path constraints etc is complicated, but can easily be taught with wires, pegs, and a chalkboard. We need a youtube video walkthrough on what all these different elements mean and how to use them.




### Related Issues

- Resolves #159 

### Backwards incompatibilities

None

### New Dependencies

None