### PR TITLE
Update doctape.py

### DIFF
--- a/aviary/utils/doctape.py
+++ b/aviary/utils/doctape.py
@@ -402,9 +402,9 @@ def glue_variable(name: str, val=None, md_code=False, display=True):
     if val is None:
         val = name
     if md_code:
-        val = Markdown('`'+val+'`')
+        val = Markdown(f'`{val}`')
     else:
-        val = Markdown(val)
+        val = Markdown(f'{val}')
 
     with io.capture_output() as captured:
         glue(name, val, display)


### PR DESCRIPTION
### Summary

allows anything with a string representation, such as Path objects and even tuples (`((1.0, 100.0), 's')`) to be passed directly as the `val` argument of `glue_variable`, without requiring the user to wrap the value in a `str()`

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None