### PR TITLE
Added subsystems_options combability to propulsion builder

### DIFF
--- a/aviary/subsystems/propulsion/engine_deck.py
+++ b/aviary/subsystems/propulsion/engine_deck.py
@@ -774,7 +774,7 @@ class EngineDeck(EngineModel):
         # Re-normalize throttle since "dummy" idle values were used
         self._normalize_throttle()
 
-    def build_pre_mission(self, aviary_inputs) -> om.ExplicitComponent:
+    def build_pre_mission(self, aviary_inputs, **kwargs) -> om.ExplicitComponent:
         """
         Build components to be added to pre-mission propulsion subsystem.
 
@@ -825,7 +825,7 @@ class EngineDeck(EngineModel):
 
         return engine
 
-    def build_mission(self, num_nodes, aviary_inputs) -> om.Group:
+    def build_mission(self, num_nodes, aviary_inputs, **kwargs) -> om.Group:
         """
         Creates interpolator objects to be added to mission-level propulsion subsystem.
         Interpolators must be re-generated for each ODE due to potentialy different

--- a/aviary/subsystems/propulsion/engine_model.py
+++ b/aviary/subsystems/propulsion/engine_model.py
@@ -62,7 +62,7 @@ class EngineModel(SubsystemBuilderBase):
         """
         self._preprocess_inputs()
 
-    def build_pre_mission(self, aviary_inputs):
+    def build_pre_mission(self, aviary_inputs, **kwargs):
         """
         Build an OpenMDAO system for the pre-mission computations of the engine model,
         such as sizing.
@@ -79,7 +79,7 @@ class EngineModel(SubsystemBuilderBase):
         """
         return None
 
-    def build_mission(self, num_nodes, aviary_inputs):
+    def build_mission(self, num_nodes, aviary_inputs, **kwargs):
         """
         Build an OpenMDAO system for the mission computations of the engine model.
 
@@ -97,7 +97,7 @@ class EngineModel(SubsystemBuilderBase):
         raise NotImplementedError('build_mission() is a required method but has not '
                                   f'been implemented in EngineModel <{self.name}>')
 
-    def build_post_mission(self, aviary_inputs):
+    def build_post_mission(self, aviary_inputs, **kwargs):
         """
         Build an OpenMDAO system for the post-mission computations of the engine model.
 

--- a/aviary/subsystems/propulsion/propulsion_builder.py
+++ b/aviary/subsystems/propulsion/propulsion_builder.py
@@ -110,14 +110,20 @@ class CorePropulsionBuilder(PropulsionBuilderBase):
 
         self.engine_models = engine_models
 
-    def build_pre_mission(self, aviary_inputs):
-        return PropulsionPreMission(aviary_options=aviary_inputs,
-                                    engine_models=self.engine_models)
+    def build_pre_mission(self, aviary_inputs, **kwargs):
+        return PropulsionPreMission(
+            aviary_options=aviary_inputs,
+            engine_models=self.engine_models,
+            engine_options=kwargs
+        )
 
     def build_mission(self, num_nodes, aviary_inputs, **kwargs):
-        return PropulsionMission(num_nodes=num_nodes,
-                                 aviary_options=aviary_inputs,
-                                 engine_models=self.engine_models)
+        return PropulsionMission(
+            num_nodes=num_nodes,
+            aviary_options=aviary_inputs,
+            engine_models=self.engine_models,
+            engine_options=kwargs
+        )
 
     # NOTE untested!
     def get_states(self):

--- a/aviary/subsystems/propulsion/propulsion_premission.py
+++ b/aviary/subsystems/propulsion/propulsion_premission.py
@@ -21,15 +21,26 @@ class PropulsionPreMission(om.Group):
             types=AviaryValues,
             desc='collection of Aircraft/Mission specific options',
         )
+
         self.options.declare(
             'engine_models', types=list, desc='list of EngineModels on aircraft'
         )
+
+        # engine options is optional
+        self.options.declare(
+            'engine_options',
+            types=dict,
+            default={},
+            desc='dictionary of options for each EngineModel'
+        )
+
         add_aviary_option(self, Aircraft.Engine.NUM_ENGINES)
         add_aviary_option(self, Settings.VERBOSITY)
 
     def setup(self):
-        options = self.options['aviary_options']
+        aviary_options = self.options['aviary_options']
         engine_models = self.options['engine_models']
+        engine_options = self.options['engine_options']
         num_engine_type = len(engine_models)
 
         # Each engine model pre_mission component only needs to accept and output single
@@ -38,7 +49,10 @@ class PropulsionPreMission(om.Group):
         # each component here
         # Promotions are handled in configure()
         for engine in engine_models:
-            subsys = engine.build_pre_mission(options)
+            options = {}
+            if engine.name in engine_options:
+                options = engine_options[engine.name]
+            subsys = engine.build_pre_mission(aviary_options, **options)
             if subsys:
                 if num_engine_type > 1:
                     proms = None


### PR DESCRIPTION
### Summary

Adds `**kwargs` support to `build_mission()`, `build_premission()` so `subsystem_options` in `phase_info` can be passed down into individual engines

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None