### PR TITLE
Add units to components

### DIFF
--- a/aviary/subsystems/geometry/flops_based/canard.py
+++ b/aviary/subsystems/geometry/flops_based/canard.py
@@ -18,11 +18,11 @@ class Canard(om.ExplicitComponent):
             desc='collection of Aircraft/Mission specific options')
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Canard.AREA)
-        add_aviary_input(self, Aircraft.Canard.THICKNESS_TO_CHORD)
-        add_aviary_input(self, Aircraft.Canard.WETTED_AREA_SCALER)
+        add_aviary_input(self, Aircraft.Canard.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Canard.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.Canard.WETTED_AREA_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Canard.WETTED_AREA)
+        add_aviary_output(self, Aircraft.Canard.WETTED_AREA, units='ft**2')
 
     def setup_partials(self):
         self.declare_partials(

--- a/aviary/subsystems/geometry/flops_based/characteristic_lengths.py
+++ b/aviary/subsystems/geometry/flops_based/characteristic_lengths.py
@@ -21,60 +21,68 @@ class CharacteristicLengths(om.ExplicitComponent):
 
         self.add_input(Names.CROOT, 0.0, units='unitless')
 
-        add_aviary_input(self, Aircraft.Canard.AREA)
-        add_aviary_input(self, Aircraft.Canard.ASPECT_RATIO)
+        add_aviary_input(self, Aircraft.Canard.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Canard.ASPECT_RATIO, units='unitless')
         # add_aviary_input(self, Aircraft.Canard.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.Canard.LAMINAR_FLOW_UPPER, 0.0)
-        add_aviary_input(self, Aircraft.Canard.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.Canard.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
         # add_aviary_input(self, Aircraft.Fuselage.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.Fuselage.LAMINAR_FLOW_UPPER, 0.0)
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.ASPECT_RATIO)
+        add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.ASPECT_RATIO, units='unitless')
         # add_aviary_input(self, Aircraft.HorizontalTail.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.HorizontalTail.LAMINAR_FLOW_UPPER, 0.0)
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH, shape=num_engine_type)
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
+                         shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH,
+                         shape=num_engine_type, units='ft')
         # add_aviary_input(self, Aircraft.Nacelle.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.Nacelle.LAMINAR_FLOW_UPPER, 0.0)
 
-        add_aviary_input(self, Aircraft.VerticalTail.AREA)
-        add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO)
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO, units='unitless')
         # add_aviary_input(self, Aircraft.VerticalTail.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.VerticalTail.LAMINAR_FLOW_UPPER, 0.0)
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
         # add_aviary_input(self, Aircraft.Wing.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.Wing.LAMINAR_FLOW_UPPER, 0.0)
 
-        add_aviary_output(self, Aircraft.Canard.CHARACTERISTIC_LENGTH)
-        add_aviary_output(self, Aircraft.Canard.FINENESS)
+        add_aviary_output(self, Aircraft.Canard.CHARACTERISTIC_LENGTH,
+                          units='ft')
+        add_aviary_output(self, Aircraft.Canard.FINENESS, units='unitless')
 
-        add_aviary_output(self, Aircraft.Fuselage.CHARACTERISTIC_LENGTH)
-        add_aviary_output(self, Aircraft.Fuselage.FINENESS)
+        add_aviary_output(self, Aircraft.Fuselage.CHARACTERISTIC_LENGTH,
+                          units='ft')
+        add_aviary_output(self, Aircraft.Fuselage.FINENESS, units='unitless')
 
-        add_aviary_output(self, Aircraft.HorizontalTail.CHARACTERISTIC_LENGTH)
-        add_aviary_output(self, Aircraft.HorizontalTail.FINENESS)
+        add_aviary_output(self, Aircraft.HorizontalTail.CHARACTERISTIC_LENGTH,
+                          units='ft')
+        add_aviary_output(self, Aircraft.HorizontalTail.FINENESS, units='unitless')
 
         add_aviary_output(self, Aircraft.Nacelle.CHARACTERISTIC_LENGTH,
-                          shape=num_engine_type)
-        add_aviary_output(self, Aircraft.Nacelle.FINENESS, shape=num_engine_type)
+                          shape=num_engine_type, units='ft')
+        add_aviary_output(self, Aircraft.Nacelle.FINENESS,
+                          shape=num_engine_type, units='unitless')
 
-        add_aviary_output(self, Aircraft.VerticalTail.CHARACTERISTIC_LENGTH)
-        add_aviary_output(self, Aircraft.VerticalTail.FINENESS)
+        add_aviary_output(self, Aircraft.VerticalTail.CHARACTERISTIC_LENGTH,
+                          units='ft')
+        add_aviary_output(self, Aircraft.VerticalTail.FINENESS, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.CHARACTERISTIC_LENGTH)
-        add_aviary_output(self, Aircraft.Wing.FINENESS)
+        add_aviary_output(self, Aircraft.Wing.CHARACTERISTIC_LENGTH,
+                          units='ft')
+        add_aviary_output(self, Aircraft.Wing.FINENESS, units='unitless')
 
     def setup_partials(self):
         self._setup_partials_wing()

--- a/aviary/subsystems/geometry/flops_based/characteristic_lengths.py
+++ b/aviary/subsystems/geometry/flops_based/characteristic_lengths.py
@@ -36,7 +36,8 @@ class CharacteristicLengths(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.HorizontalTail.ASPECT_RATIO, units='unitless')
         # add_aviary_input(self, Aircraft.HorizontalTail.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.HorizontalTail.LAMINAR_FLOW_UPPER, 0.0)
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
 
         add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
                          shape=num_engine_type, units='ft')
@@ -49,7 +50,8 @@ class CharacteristicLengths(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO, units='unitless')
         # add_aviary_input(self, Aircraft.VerticalTail.LAMINAR_FLOW_LOWER, 0.0)
         # add_aviary_input(self, Aircraft.VerticalTail.LAMINAR_FLOW_UPPER, 0.0)
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
 
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')

--- a/aviary/subsystems/geometry/flops_based/fuselage.py
+++ b/aviary/subsystems/geometry/flops_based/fuselage.py
@@ -16,12 +16,12 @@ class FuselagePrelim(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
 
-        add_aviary_output(self, Aircraft.Fuselage.AVG_DIAMETER)
-        add_aviary_output(self, Aircraft.Fuselage.PLANFORM_AREA)
+        add_aviary_output(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
+        add_aviary_output(self, Aircraft.Fuselage.PLANFORM_AREA, units='ft**2')
 
     def setup_partials(self):
         self.declare_partials(of=[Aircraft.Fuselage.AVG_DIAMETER],

--- a/aviary/subsystems/geometry/flops_based/nacelle.py
+++ b/aviary/subsystems/geometry/flops_based/nacelle.py
@@ -18,13 +18,16 @@ class Nacelles(om.ExplicitComponent):
 
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH, shape=num_engine_type)
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
+                         shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH,
+                         shape=num_engine_type, units='ft')
         add_aviary_input(self, Aircraft.Nacelle.WETTED_AREA_SCALER,
-                         shape=num_engine_type)
+                         shape=num_engine_type, units='unitless')
 
-        add_aviary_output(self, Aircraft.Nacelle.TOTAL_WETTED_AREA)
-        add_aviary_output(self, Aircraft.Nacelle.WETTED_AREA, shape=num_engine_type)
+        add_aviary_output(self, Aircraft.Nacelle.TOTAL_WETTED_AREA, units='ft**2')
+        add_aviary_output(self, Aircraft.Nacelle.WETTED_AREA,
+                          shape=num_engine_type, units='ft**2')
 
     def setup_partials(self):
         # derivatives w.r.t vectorized engine inputs have known sparsity pattern

--- a/aviary/subsystems/geometry/flops_based/prep_geom.py
+++ b/aviary/subsystems/geometry/flops_based/prep_geom.py
@@ -122,19 +122,22 @@ class _Prelim(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.HorizontalTail.ASPECT_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO, units='unitless')
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
 
         add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.VerticalTail.TAPER_RATIO, units='unitless')
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
 
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT, units='ft**2')
         # NOTE: FLOPS/aviary1 calculate span locally
         add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
         add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD,
+                         units='unitless')
 
         self.add_output(Names.CROOT, 1.0, units='unitless')
         self.add_output(Names.CROOTB, 1.0, units='unitless')
@@ -567,12 +570,15 @@ class _Tail(om.ExplicitComponent):
 
         add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION,
+                         units='unitless')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA_SCALER,
+                         units='unitless')
 
         add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
-        add_aviary_input(self, Aircraft.VerticalTail.WETTED_AREA_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.WETTED_AREA_SCALER,
+                         units='unitless')
 
         add_aviary_output(self, Aircraft.HorizontalTail.WETTED_AREA, units='ft**2')
         add_aviary_output(self, Aircraft.VerticalTail.WETTED_AREA, units='ft**2')
@@ -727,10 +733,13 @@ class _Fuselage(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
         add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA_SCALER, units='unitless')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION,
+                         units='unitless')
 
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
 
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
@@ -738,7 +747,8 @@ class _Fuselage(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
 
         add_aviary_output(self, Aircraft.Fuselage.CROSS_SECTION, units='ft**2')
-        add_aviary_output(self, Aircraft.Fuselage.DIAMETER_TO_WING_SPAN, units='unitless')
+        add_aviary_output(self, Aircraft.Fuselage.DIAMETER_TO_WING_SPAN,
+                          units='unitless')
         add_aviary_output(self, Aircraft.Fuselage.LENGTH_TO_DIAMETER, units='unitless')
         add_aviary_output(self, Aircraft.Fuselage.WETTED_AREA, units='ft**2')
 

--- a/aviary/subsystems/geometry/flops_based/prep_geom.py
+++ b/aviary/subsystems/geometry/flops_based/prep_geom.py
@@ -116,25 +116,25 @@ class _Prelim(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Wing.SPAN_EFFICIENCY_REDUCTION)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_input(self, Aircraft.VerticalTail.AREA)
-        add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.VerticalTail.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT, units='ft**2')
         # NOTE: FLOPS/aviary1 calculate span locally
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
 
         self.add_output(Names.CROOT, 1.0, units='unitless')
         self.add_output(Names.CROOTB, 1.0, units='unitless')
@@ -490,10 +490,10 @@ class _Wing(om.ExplicitComponent):
         self.add_input(Names.XDX, 0.0, units='unitless')
         self.add_input(Names.XMULT, 0.0, units='unitless')
 
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.WETTED_AREA_SCALER)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.WETTED_AREA_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.WETTED_AREA)
+        add_aviary_output(self, Aircraft.Wing.WETTED_AREA, units='ft**2')
 
     def setup_partials(self):
         self.declare_partials(
@@ -565,17 +565,17 @@ class _Tail(om.ExplicitComponent):
         self.add_input(Names.XMULTH, 0.0, units='unitless')
         self.add_input(Names.XMULTV, 0.0, units='unitless')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.AREA)
+        add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION)
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA_SCALER)
+        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA_SCALER, units='unitless')
 
-        add_aviary_input(self, Aircraft.VerticalTail.AREA)
-        add_aviary_input(self, Aircraft.VerticalTail.WETTED_AREA_SCALER)
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.VerticalTail.WETTED_AREA_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.HorizontalTail.WETTED_AREA)
-        add_aviary_output(self, Aircraft.VerticalTail.WETTED_AREA)
+        add_aviary_output(self, Aircraft.HorizontalTail.WETTED_AREA, units='ft**2')
+        add_aviary_output(self, Aircraft.VerticalTail.WETTED_AREA, units='ft**2')
 
     def setup_partials(self):
         self.declare_partials(
@@ -723,24 +723,24 @@ class _Fuselage(om.ExplicitComponent):
         self.add_input(Names.CROTVT, 0.0, units='unitless')
         self.add_input(Names.CRTHTB, 0.0, units='unitless')
 
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA_SCALER)
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA_SCALER, units='unitless')
 
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD)
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION)
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
 
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_output(self, Aircraft.Fuselage.CROSS_SECTION)
-        add_aviary_output(self, Aircraft.Fuselage.DIAMETER_TO_WING_SPAN)
-        add_aviary_output(self, Aircraft.Fuselage.LENGTH_TO_DIAMETER)
-        add_aviary_output(self, Aircraft.Fuselage.WETTED_AREA)
+        add_aviary_output(self, Aircraft.Fuselage.CROSS_SECTION, units='ft**2')
+        add_aviary_output(self, Aircraft.Fuselage.DIAMETER_TO_WING_SPAN, units='unitless')
+        add_aviary_output(self, Aircraft.Fuselage.LENGTH_TO_DIAMETER, units='unitless')
+        add_aviary_output(self, Aircraft.Fuselage.WETTED_AREA, units='ft**2')
 
     def setup_partials(self):
         self.declare_partials(

--- a/aviary/subsystems/geometry/flops_based/wetted_area_total.py
+++ b/aviary/subsystems/geometry/flops_based/wetted_area_total.py
@@ -11,14 +11,14 @@ class TotalWettedArea(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Canard.WETTED_AREA)
-        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA)
-        add_aviary_input(self, Aircraft.Nacelle.TOTAL_WETTED_AREA)
-        add_aviary_input(self, Aircraft.VerticalTail.WETTED_AREA)
-        add_aviary_input(self, Aircraft.Wing.WETTED_AREA)
+        add_aviary_input(self, Aircraft.Canard.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Nacelle.TOTAL_WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.VerticalTail.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.WETTED_AREA, units='ft**2')
 
-        add_aviary_output(self, Aircraft.Design.TOTAL_WETTED_AREA)
+        add_aviary_output(self, Aircraft.Design.TOTAL_WETTED_AREA, units='ft**2')
 
     def setup_partials(self):
         self.declare_partials('*', '*', val=1.0)

--- a/aviary/subsystems/geometry/flops_based/wing.py
+++ b/aviary/subsystems/geometry/flops_based/wing.py
@@ -14,11 +14,11 @@ class WingPrelim(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.GLOVE_AND_BAT, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
 
-        add_aviary_output(self, Aircraft.Wing.ASPECT_RATIO)
+        add_aviary_output(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/geometry/gasp_based/electric.py
+++ b/aviary/subsystems/geometry/gasp_based/electric.py
@@ -17,11 +17,11 @@ class CableSize(om.ExplicitComponent):
         total_num_wing_engines = self.options[Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES]
 
         add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS,
-                         shape=int(total_num_wing_engines/2))
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
+                         shape=int(total_num_wing_engines/2), units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
 
-        add_aviary_output(self, Aircraft.Electrical.HYBRID_CABLE_LENGTH)
+        add_aviary_output(self, Aircraft.Electrical.HYBRID_CABLE_LENGTH, units='ft')
 
         self.declare_partials(
             Aircraft.Electrical.HYBRID_CABLE_LENGTH,

--- a/aviary/subsystems/geometry/gasp_based/empennage.py
+++ b/aviary/subsystems/geometry/gasp_based/empennage.py
@@ -33,13 +33,13 @@ class TailVolCoef(om.ExplicitComponent):
         else:
             self.k = [0.43, 0.38, 0.85]
 
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION)
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
 
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
 
         self.add_input("cab_w", 13.1, units="ft", desc="SWF: Cabin width")
 
-        add_aviary_input(self, Aircraft.Wing.AREA)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
 
         self.add_input("wing_ref", 12.615, units="ft",
                        desc=(

--- a/aviary/subsystems/geometry/gasp_based/empennage.py
+++ b/aviary/subsystems/geometry/gasp_based/empennage.py
@@ -33,7 +33,8 @@ class TailVolCoef(om.ExplicitComponent):
         else:
             self.k = [0.43, 0.38, 0.85]
 
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION,
+                         units='unitless')
 
         add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
 

--- a/aviary/subsystems/geometry/gasp_based/engine.py
+++ b/aviary/subsystems/geometry/gasp_based/engine.py
@@ -18,18 +18,20 @@ class EngineSize(om.ExplicitComponent):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
         add_aviary_input(self, Aircraft.Engine.REFERENCE_DIAMETER,
-                         shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Engine.SCALE_FACTOR, shape=num_engine_type)
+                         shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Engine.SCALE_FACTOR,
+                         shape=num_engine_type, units='unitless')
         add_aviary_input(self, Aircraft.Nacelle.CORE_DIAMETER_RATIO,
-                         shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Nacelle.FINENESS, shape=num_engine_type)
+                         shape=num_engine_type, units='unitless')
+        add_aviary_input(self, Aircraft.Nacelle.FINENESS,
+                         shape=num_engine_type, units='unitless')
 
         add_aviary_output(self, Aircraft.Nacelle.AVG_DIAMETER,
-                          shape=num_engine_type)
+                          shape=num_engine_type, units='ft')
         add_aviary_output(self, Aircraft.Nacelle.AVG_LENGTH,
-                          shape=num_engine_type)
+                          shape=num_engine_type, units='ft')
         add_aviary_output(self, Aircraft.Nacelle.SURFACE_AREA,
-                          shape=num_engine_type)
+                          shape=num_engine_type, units='ft**2')
 
     def setup_partials(self):
         # derivatives w.r.t vectorized engine inputs have known sparsity pattern

--- a/aviary/subsystems/geometry/gasp_based/fuselage.py
+++ b/aviary/subsystems/geometry/gasp_based/fuselage.py
@@ -23,8 +23,8 @@ class FuselageParameters(om.ExplicitComponent):
 
     def setup(self):
 
-        add_aviary_input(self, Aircraft.Fuselage.DELTA_DIAMETER)
-        add_aviary_input(self, Aircraft.Fuselage.PILOT_COMPARTMENT_LENGTH)
+        add_aviary_input(self, Aircraft.Fuselage.DELTA_DIAMETER, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.PILOT_COMPARTMENT_LENGTH, units='ft')
 
         add_aviary_output(self, Aircraft.Fuselage.AVG_DIAMETER, units='inch')
         self.add_output("cabin_height", val=0, units="ft", desc="HC: height of cabin")
@@ -100,17 +100,17 @@ class FuselageSize(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.NOSE_FINENESS)
+        add_aviary_input(self, Aircraft.Fuselage.NOSE_FINENESS, units='unitless')
         self.add_input("nose_height", val=0, units="ft", desc="HN: height of nose")
-        add_aviary_input(self, Aircraft.Fuselage.PILOT_COMPARTMENT_LENGTH)
+        add_aviary_input(self, Aircraft.Fuselage.PILOT_COMPARTMENT_LENGTH, units='ft')
         self.add_input("cabin_len", val=0, units="ft", desc="LC: length of cabin")
-        add_aviary_input(self, Aircraft.Fuselage.TAIL_FINENESS)
+        add_aviary_input(self, Aircraft.Fuselage.TAIL_FINENESS, units='unitless')
         self.add_input("cabin_height", val=0, units="ft", desc="HC: height of cabin")
-        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA_SCALER)
+        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_output(self, Aircraft.Fuselage.WETTED_AREA)
-        add_aviary_output(self, Aircraft.TailBoom.LENGTH)
+        add_aviary_output(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_output(self, Aircraft.Fuselage.WETTED_AREA, units='ft**2')
+        add_aviary_output(self, Aircraft.TailBoom.LENGTH, units='ft')
 
         self.declare_partials(
             Aircraft.Fuselage.LENGTH,

--- a/aviary/subsystems/geometry/gasp_based/non_dimensional_conversion.py
+++ b/aviary/subsystems/geometry/gasp_based/non_dimensional_conversion.py
@@ -14,16 +14,16 @@ class StrutCalcs(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Wing.HAS_STRUT)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.SPAN)
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
 
         if self.options[Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED]:
-            add_aviary_input(self, Aircraft.Strut.ATTACHMENT_LOCATION)
-            add_aviary_output(
-                self, Aircraft.Strut.ATTACHMENT_LOCATION_DIMENSIONLESS)
+            add_aviary_input(self, Aircraft.Strut.ATTACHMENT_LOCATION, units='ft')
+            add_aviary_output(self, Aircraft.Strut.ATTACHMENT_LOCATION_DIMENSIONLESS,
+                              units='unitless')
         else:
-            add_aviary_input(
-                self, Aircraft.Strut.ATTACHMENT_LOCATION_DIMENSIONLESS)
-            add_aviary_output(self, Aircraft.Strut.ATTACHMENT_LOCATION)
+            add_aviary_input(self, Aircraft.Strut.ATTACHMENT_LOCATION_DIMENSIONLESS,
+                             units='unitless')
+            add_aviary_output(self, Aircraft.Strut.ATTACHMENT_LOCATION, units='ft')
 
     def setup_partials(self):
 
@@ -70,14 +70,14 @@ class FoldCalcs(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Wing.FOLD_DIMENSIONAL_LOCATION_SPECIFIED)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.SPAN)
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
 
         if self.options[Aircraft.Wing.FOLD_DIMENSIONAL_LOCATION_SPECIFIED]:
-            add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN)
-            add_aviary_output(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS)
+            add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN, units='ft')
+            add_aviary_output(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS, units='unitless')
         else:
-            add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS)
-            add_aviary_output(self, Aircraft.Wing.FOLDED_SPAN)
+            add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS, units='unitless')
+            add_aviary_output(self, Aircraft.Wing.FOLDED_SPAN, units='ft')
 
     def setup_partials(self):
 

--- a/aviary/subsystems/geometry/gasp_based/non_dimensional_conversion.py
+++ b/aviary/subsystems/geometry/gasp_based/non_dimensional_conversion.py
@@ -74,9 +74,11 @@ class FoldCalcs(om.ExplicitComponent):
 
         if self.options[Aircraft.Wing.FOLD_DIMENSIONAL_LOCATION_SPECIFIED]:
             add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN, units='ft')
-            add_aviary_output(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS, units='unitless')
+            add_aviary_output(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS,
+                              units='unitless')
         else:
-            add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS, units='unitless')
+            add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN_DIMENSIONLESS,
+                             units='unitless')
             add_aviary_output(self, Aircraft.Wing.FOLDED_SPAN, units='ft')
 
     def setup_partials(self):

--- a/aviary/subsystems/geometry/gasp_based/strut.py
+++ b/aviary/subsystems/geometry/gasp_based/strut.py
@@ -13,17 +13,17 @@ class StrutGeom(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Strut.AREA_RATIO)
-        add_aviary_input(self, Aircraft.Strut.ATTACHMENT_LOCATION)
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Strut.AREA_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Strut.ATTACHMENT_LOCATION, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
 
         self.add_output(
             "strut_y", val=30, units="ft", desc="YSTRUT: attachment location of strut"
         )
-        add_aviary_output(self, Aircraft.Strut.LENGTH)
-        add_aviary_output(self, Aircraft.Strut.AREA)
-        add_aviary_output(self, Aircraft.Strut.CHORD)
+        add_aviary_output(self, Aircraft.Strut.LENGTH, units='ft')
+        add_aviary_output(self, Aircraft.Strut.AREA, units='ft**2')
+        add_aviary_output(self, Aircraft.Strut.CHORD, units='ft')
 
     def setup_partials(self):
 

--- a/aviary/subsystems/geometry/gasp_based/wing.py
+++ b/aviary/subsystems/geometry/gasp_based/wing.py
@@ -95,7 +95,8 @@ class WingParameters(om.ExplicitComponent):
         if not self.options[Aircraft.Wing.HAS_FOLD]:
 
             add_aviary_input(self, Aircraft.Fuel.WING_FUEL_FRACTION, units='unitless')
-            add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX, units='ft**3')
+            add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX,
+                              units='ft**3')
 
             self.declare_partials(
                 Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX,
@@ -114,7 +115,8 @@ class WingParameters(om.ExplicitComponent):
         add_aviary_output(self, Aircraft.Wing.CENTER_CHORD, units='ft')
         add_aviary_output(self, Aircraft.Wing.AVERAGE_CHORD, units='ft')
         add_aviary_output(self, Aircraft.Wing.ROOT_CHORD, units='ft')
-        add_aviary_output(self, Aircraft.Wing.THICKNESS_TO_CHORD_UNWEIGHTED, units='unitless')
+        add_aviary_output(self, Aircraft.Wing.THICKNESS_TO_CHORD_UNWEIGHTED,
+                          units='unitless')
         add_aviary_output(self, Aircraft.Wing.LEADING_EDGE_SWEEP, units='rad')
 
         self.declare_partials(

--- a/aviary/subsystems/geometry/gasp_based/wing.py
+++ b/aviary/subsystems/geometry/gasp_based/wing.py
@@ -17,12 +17,12 @@ class WingSize(om.ExplicitComponent):
 
     def setup(self):
 
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Wing.LOADING)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.LOADING, units='lbf/ft**2')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.AREA)
-        add_aviary_output(self, Aircraft.Wing.SPAN)
+        add_aviary_output(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_output(self, Aircraft.Wing.SPAN, units='ft')
 
         self.declare_partials(
             Aircraft.Wing.AREA, [Mission.Design.GROSS_MASS, Aircraft.Wing.LOADING]
@@ -83,19 +83,19 @@ class WingParameters(om.ExplicitComponent):
 
     def setup(self):
 
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.SWEEP)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT)
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_TIP)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SWEEP, units='deg')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_TIP, units='unitless')
 
         if not self.options[Aircraft.Wing.HAS_FOLD]:
 
-            add_aviary_input(self, Aircraft.Fuel.WING_FUEL_FRACTION)
-            add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX)
+            add_aviary_input(self, Aircraft.Fuel.WING_FUEL_FRACTION, units='unitless')
+            add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX, units='ft**3')
 
             self.declare_partials(
                 Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX,
@@ -111,11 +111,11 @@ class WingParameters(om.ExplicitComponent):
                 ],
             )
 
-        add_aviary_output(self, Aircraft.Wing.CENTER_CHORD)
-        add_aviary_output(self, Aircraft.Wing.AVERAGE_CHORD)
-        add_aviary_output(self, Aircraft.Wing.ROOT_CHORD)
-        add_aviary_output(self, Aircraft.Wing.THICKNESS_TO_CHORD_UNWEIGHTED)
-        add_aviary_output(self, Aircraft.Wing.LEADING_EDGE_SWEEP)
+        add_aviary_output(self, Aircraft.Wing.CENTER_CHORD, units='ft')
+        add_aviary_output(self, Aircraft.Wing.AVERAGE_CHORD, units='ft')
+        add_aviary_output(self, Aircraft.Wing.ROOT_CHORD, units='ft')
+        add_aviary_output(self, Aircraft.Wing.THICKNESS_TO_CHORD_UNWEIGHTED, units='unitless')
+        add_aviary_output(self, Aircraft.Wing.LEADING_EDGE_SWEEP, units='rad')
 
         self.declare_partials(
             Aircraft.Wing.CENTER_CHORD,
@@ -537,18 +537,18 @@ class WingFold(om.ExplicitComponent):
 
             add_aviary_input(self, Aircraft.Wing.FOLDED_SPAN)
 
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_TIP)
-        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_FRACTION)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_TIP, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_FRACTION, units='unitless')
 
         self.add_output("nonfolded_taper_ratio", val=0.1, units="unitless",
                         desc="SLM_NF: taper ratio between wing root and fold location",
                         )
 
-        add_aviary_output(self, Aircraft.Wing.FOLDING_AREA)
+        add_aviary_output(self, Aircraft.Wing.FOLDING_AREA, units='ft**2')
 
         self.add_output("nonfolded_wing_area", val=150, units="ft**2",
                         desc="SW_NF: wing area of part of wings that does not fold",
@@ -560,7 +560,7 @@ class WingFold(om.ExplicitComponent):
                         desc="AR_NF: aspect ratio of non-folding part of wing",
                         )
 
-        add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX)
+        add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX, units='ft**3')
 
         self.declare_partials(
             "nonfolded_taper_ratio",

--- a/aviary/subsystems/mass/flops_based/air_conditioning.py
+++ b/aviary/subsystems/mass/flops_based/air_conditioning.py
@@ -19,12 +19,12 @@ class TransportAirCondMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.AirConditioning.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Avionics.MASS)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT)
-        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA)
+        add_aviary_input(self, Aircraft.AirConditioning.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Avionics.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA, units='ft**2')
 
-        add_aviary_output(self, Aircraft.AirConditioning.MASS)
+        add_aviary_output(self, Aircraft.AirConditioning.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')
@@ -80,9 +80,9 @@ class AltAirCondMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.Design.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.AirConditioning.MASS_SCALER)
+        add_aviary_input(self, Aircraft.AirConditioning.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.AirConditioning.MASS)
+        add_aviary_output(self, Aircraft.AirConditioning.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of=Aircraft.AirConditioning.MASS, wrt='*')

--- a/aviary/subsystems/mass/flops_based/anti_icing.py
+++ b/aviary/subsystems/mass/flops_based/anti_icing.py
@@ -23,13 +23,14 @@ class AntiIcingMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.AntiIcing.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.SWEEP)
+        add_aviary_input(self, Aircraft.AntiIcing.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
+                         shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.SWEEP, units='deg')
 
-        add_aviary_output(self, Aircraft.AntiIcing.MASS)
+        add_aviary_output(self, Aircraft.AntiIcing.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")

--- a/aviary/subsystems/mass/flops_based/apu.py
+++ b/aviary/subsystems/mass/flops_based/apu.py
@@ -15,10 +15,10 @@ class TransportAPUMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.Design.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.APU.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA)
+        add_aviary_input(self, Aircraft.APU.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA, units='ft**2')
 
-        add_aviary_output(self, Aircraft.APU.MASS)
+        add_aviary_output(self, Aircraft.APU.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/avionics.py
+++ b/aviary/subsystems/mass/flops_based/avionics.py
@@ -16,11 +16,11 @@ class TransportAvionicsMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.NUM_FLIGHT_CREW)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Avionics.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA)
-        add_aviary_input(self, Mission.Design.RANGE)
+        add_aviary_input(self, Aircraft.Avionics.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA, units='ft**2')
+        add_aviary_input(self, Mission.Design.RANGE, units='NM')
 
-        add_aviary_output(self, Aircraft.Avionics.MASS)
+        add_aviary_output(self, Aircraft.Avionics.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/canard.py
+++ b/aviary/subsystems/mass/flops_based/canard.py
@@ -12,12 +12,12 @@ class CanardMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Canard.AREA)
-        add_aviary_input(self, Aircraft.Canard.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Canard.MASS_SCALER)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Canard.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Canard.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Canard.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Canard.MASS)
+        add_aviary_output(self, Aircraft.Canard.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")

--- a/aviary/subsystems/mass/flops_based/cargo.py
+++ b/aviary/subsystems/mass/flops_based/cargo.py
@@ -22,13 +22,13 @@ class CargoMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.WING_CARGO)
-        add_aviary_input(self, Aircraft.CrewPayload.MISC_CARGO)
-        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_MASS)
-        add_aviary_output(self, Aircraft.CrewPayload.BAGGAGE_MASS)
-        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS)
-        add_aviary_output(self, Aircraft.CrewPayload.CARGO_MASS)
-        add_aviary_output(self, Aircraft.CrewPayload.TOTAL_PAYLOAD_MASS)
+        add_aviary_input(self, Aircraft.CrewPayload.WING_CARGO, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.MISC_CARGO, units='lbm')
+        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.CrewPayload.BAGGAGE_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.CrewPayload.CARGO_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.CrewPayload.TOTAL_PAYLOAD_MASS, units='lbm')
 
     def setup_partials(self):
 

--- a/aviary/subsystems/mass/flops_based/cargo_containers.py
+++ b/aviary/subsystems/mass/flops_based/cargo_containers.py
@@ -14,7 +14,8 @@ class TransportCargoContainersMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.CrewPayload.CARGO_MASS, units='lbm')
         add_aviary_input(self, Aircraft.CrewPayload.BAGGAGE_MASS, units='lbm')
 

--- a/aviary/subsystems/mass/flops_based/cargo_containers.py
+++ b/aviary/subsystems/mass/flops_based/cargo_containers.py
@@ -14,11 +14,11 @@ class TransportCargoContainersMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS_SCALER)
-        add_aviary_input(self, Aircraft.CrewPayload.CARGO_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.BAGGAGE_MASS)
+        add_aviary_input(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.CrewPayload.CARGO_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.BAGGAGE_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS)
+        add_aviary_output(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/crew.py
+++ b/aviary/subsystems/mass/flops_based/crew.py
@@ -18,9 +18,9 @@ class NonFlightCrewMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.NUM_GALLEY_CREW)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS_SCALER)
+        add_aviary_input(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS)
+        add_aviary_output(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(
@@ -74,9 +74,9 @@ class FlightCrewMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.LandingGear.CARRIER_BASED)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS_SCALER)
+        add_aviary_input(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS)
+        add_aviary_output(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(

--- a/aviary/subsystems/mass/flops_based/crew.py
+++ b/aviary/subsystems/mass/flops_based/crew.py
@@ -18,7 +18,8 @@ class NonFlightCrewMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.NUM_GALLEY_CREW)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS_SCALER,
+                         units='unitless')
 
         add_aviary_output(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS, units='lbm')
 
@@ -74,7 +75,8 @@ class FlightCrewMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.LandingGear.CARRIER_BASED)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS_SCALER,
+                         units='unitless')
 
         add_aviary_output(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS, units='lbm')
 

--- a/aviary/subsystems/mass/flops_based/electrical.py
+++ b/aviary/subsystems/mass/flops_based/electrical.py
@@ -20,11 +20,11 @@ class ElectricalMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Propulsion.TOTAL_NUM_ENGINES)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
-        add_aviary_input(self, Aircraft.Electrical.MASS_SCALER)
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
+        add_aviary_input(self, Aircraft.Electrical.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Electrical.MASS)
+        add_aviary_output(self, Aircraft.Electrical.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of='*', wrt='*')
@@ -81,9 +81,9 @@ class AltElectricalMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.Design.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Electrical.MASS_SCALER)
+        add_aviary_input(self, Aircraft.Electrical.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Electrical.MASS)
+        add_aviary_output(self, Aircraft.Electrical.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of='*', wrt='*')

--- a/aviary/subsystems/mass/flops_based/empty_margin.py
+++ b/aviary/subsystems/mass/flops_based/empty_margin.py
@@ -13,7 +13,8 @@ class EmptyMassMargin(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Propulsion.MASS, units='lbm')
         add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
         add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS, units='lbm')
-        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN_SCALER,
+                         units='unitless')
 
         add_aviary_output(self, Aircraft.Design.EMPTY_MASS_MARGIN, units='lbm')
 

--- a/aviary/subsystems/mass/flops_based/empty_margin.py
+++ b/aviary/subsystems/mass/flops_based/empty_margin.py
@@ -10,12 +10,12 @@ class EmptyMassMargin(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Propulsion.MASS)
-        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS)
-        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN_SCALER)
+        add_aviary_input(self, Aircraft.Propulsion.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Design.EMPTY_MASS_MARGIN)
+        add_aviary_output(self, Aircraft.Design.EMPTY_MASS_MARGIN, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/engine.py
+++ b/aviary/subsystems/mass/flops_based/engine.py
@@ -24,12 +24,16 @@ class EngineMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Engine.MASS_SCALER, shape=num_engine_type)
+        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type,
+                         units='lbf')
+        add_aviary_input(self, Aircraft.Engine.MASS_SCALER, shape=num_engine_type,
+                         units='unitless')
 
-        add_aviary_output(self, Aircraft.Engine.MASS, shape=num_engine_type)
-        add_aviary_output(self, Aircraft.Engine.ADDITIONAL_MASS, shape=num_engine_type)
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_MASS)
+        add_aviary_output(self, Aircraft.Engine.MASS, shape=num_engine_type,
+                          units='lbm')
+        add_aviary_output(self, Aircraft.Engine.ADDITIONAL_MASS, shape=num_engine_type,
+                          units='lbm')
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_MASS, units='lbm')
 
     def compute(self, inputs, outputs):
         options = self.options

--- a/aviary/subsystems/mass/flops_based/engine_controls.py
+++ b/aviary/subsystems/mass/flops_based/engine_controls.py
@@ -27,9 +27,9 @@ class TransportEngineCtrlsMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Propulsion.TOTAL_NUM_ENGINES)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST)
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST, units='lbf')
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS)
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS,

--- a/aviary/subsystems/mass/flops_based/engine_controls.py
+++ b/aviary/subsystems/mass/flops_based/engine_controls.py
@@ -29,7 +29,8 @@ class TransportEngineCtrlsMass(om.ExplicitComponent):
     def setup(self):
         add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST, units='lbf')
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS,
+                          units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS,

--- a/aviary/subsystems/mass/flops_based/engine_oil.py
+++ b/aviary/subsystems/mass/flops_based/engine_oil.py
@@ -69,9 +69,11 @@ class AltEngineOilMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.Design.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER,
+                         units='unitless')
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS,
+                          units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/engine_oil.py
+++ b/aviary/subsystems/mass/flops_based/engine_oil.py
@@ -24,7 +24,8 @@ class TransportEngineOilMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Propulsion.TOTAL_NUM_ENGINES)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST, units='lbf')
 
         add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS, units='lbm')

--- a/aviary/subsystems/mass/flops_based/engine_oil.py
+++ b/aviary/subsystems/mass/flops_based/engine_oil.py
@@ -24,10 +24,10 @@ class TransportEngineOilMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Propulsion.TOTAL_NUM_ENGINES)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST)
+        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST, units='lbf')
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS)
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')
@@ -69,9 +69,9 @@ class AltEngineOilMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.Design.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER)
+        add_aviary_input(self, Aircraft.Propulsion.ENGINE_OIL_MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS)
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/engine_pod.py
+++ b/aviary/subsystems/mass/flops_based/engine_pod.py
@@ -22,20 +22,25 @@ class EnginePodMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Electrical.MASS)
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS)
-        add_aviary_input(self, Aircraft.Hydraulics.MASS)
-        add_aviary_input(self, Aircraft.Instruments.MASS)
-        add_aviary_input(self, Aircraft.Nacelle.MASS, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS)
-        add_aviary_input(self, Aircraft.Engine.MASS, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_STARTER_MASS)
+        add_aviary_input(self, Aircraft.Electrical.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Hydraulics.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Instruments.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Nacelle.MASS, shape=num_engine_type,
+                         units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS,
+                         units='lbm')
+        add_aviary_input(self, Aircraft.Engine.MASS, shape=num_engine_type, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_STARTER_MASS, units='lbm')
         add_aviary_input(self, Aircraft.Engine.THRUST_REVERSERS_MASS,
-                         shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST)
+                         shape=num_engine_type, units='lbm')
+        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type,
+                         units='lbf')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST,
+                         units='lbf')
 
-        add_aviary_output(self, Aircraft.Engine.POD_MASS, shape=num_engine_type)
+        add_aviary_output(self, Aircraft.Engine.POD_MASS, shape=num_engine_type,
+                          units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/fin.py
+++ b/aviary/subsystems/mass/flops_based/fin.py
@@ -15,12 +15,12 @@ class FinMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Fins.NUM_FINS)
 
     def setup(self):
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Fins.AREA)
-        add_aviary_input(self, Aircraft.Fins.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Fins.MASS_SCALER)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fins.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Fins.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Fins.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Fins.MASS)
+        add_aviary_output(self, Aircraft.Fins.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")

--- a/aviary/subsystems/mass/flops_based/fuel_capacity.py
+++ b/aviary/subsystems/mass/flops_based/fuel_capacity.py
@@ -38,9 +38,9 @@ class FuselageFuelCapacity(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY),
-        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_CAPACITY),
-        add_aviary_output(self, Aircraft.Fuel.FUSELAGE_FUEL_CAPACITY),
+        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm'),
+        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_CAPACITY, units='lbm'),
+        add_aviary_output(self, Aircraft.Fuel.FUSELAGE_FUEL_CAPACITY, units='lbm'),
 
     def setup_partials(self):
         self.declare_partials(
@@ -62,10 +62,10 @@ class AuxFuelCapacity(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY),
-        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_CAPACITY),
-        add_aviary_input(self, Aircraft.Fuel.FUSELAGE_FUEL_CAPACITY),
-        add_aviary_output(self, Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY),
+        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm'),
+        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_CAPACITY, units='lbm'),
+        add_aviary_input(self, Aircraft.Fuel.FUSELAGE_FUEL_CAPACITY, units='lbm'),
+        add_aviary_output(self, Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY, units='lbm'),
 
     def setup_partials(self):
         self.declare_partials(
@@ -91,10 +91,10 @@ class TotalFuelCapacity(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_CAPACITY),
-        add_aviary_input(self, Aircraft.Fuel.FUSELAGE_FUEL_CAPACITY),
-        add_aviary_input(self, Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY),
-        add_aviary_output(self, Aircraft.Fuel.TOTAL_CAPACITY),
+        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_CAPACITY, units='lbm'),
+        add_aviary_input(self, Aircraft.Fuel.FUSELAGE_FUEL_CAPACITY, units='lbm'),
+        add_aviary_input(self, Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY, units='lbm'),
+        add_aviary_output(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm'),
 
     def setup_partials(self):
         self.declare_partials(
@@ -120,18 +120,18 @@ class WingFuelCapacity(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.DENSITY_RATIO)
-        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY)
-        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY_AREA)
-        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY_TERM_A)
-        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY_TERM_B)
-        add_aviary_input(self, Aircraft.Fuel.CAPACITY_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD)
+        add_aviary_input(self, Aircraft.Fuel.DENSITY_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY, units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY_AREA, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY_TERM_A, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.WING_REF_CAPACITY_TERM_B, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.CAPACITY_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
 
-        add_aviary_output(self, Aircraft.Fuel.WING_FUEL_CAPACITY)
+        add_aviary_output(self, Aircraft.Fuel.WING_FUEL_CAPACITY, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/fuel_system.py
+++ b/aviary/subsystems/mass/flops_based/fuel_system.py
@@ -19,10 +19,10 @@ class TransportFuelSystemMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY)
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm')
 
-        add_aviary_output(self, Aircraft.Fuel.FUEL_SYSTEM_MASS)
+        add_aviary_output(self, Aircraft.Fuel.FUEL_SYSTEM_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')
@@ -64,10 +64,10 @@ class AltFuelSystemMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Fuel.NUM_TANKS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY)
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER)
+        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Fuel.FUEL_SYSTEM_MASS)
+        add_aviary_output(self, Aircraft.Fuel.FUEL_SYSTEM_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/furnishings.py
+++ b/aviary/subsystems/mass/flops_based/furnishings.py
@@ -20,12 +20,12 @@ class TransportFurnishingsGroupMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Fuselage.NUM_FUSELAGES)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Furnishings.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuselage.PASSENGER_COMPARTMENT_LENGTH)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT)
+        add_aviary_input(self, Aircraft.Furnishings.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.PASSENGER_COMPARTMENT_LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT, units='ft')
 
-        add_aviary_output(self, Aircraft.Furnishings.MASS)
+        add_aviary_output(self, Aircraft.Furnishings.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of=Aircraft.Furnishings.MASS, wrt='*')
@@ -100,15 +100,15 @@ class BWBFurnishingsGroupMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Fuselage.MILITARY_CARGO_FLOOR)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Furnishings.MASS_SCALER)
-        add_aviary_input(self, Aircraft.BWB.CABIN_AREA)
+        add_aviary_input(self, Aircraft.Furnishings.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.BWB.CABIN_AREA, units='ft**2')
 
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
 
-        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT)
-        add_aviary_input(self, Aircraft.BWB.PASSENGER_LEADING_EDGE_SWEEP)
+        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT, units='ft')
+        add_aviary_input(self, Aircraft.BWB.PASSENGER_LEADING_EDGE_SWEEP, units='deg')
 
-        add_aviary_output(self, Aircraft.Furnishings.MASS)
+        add_aviary_output(self, Aircraft.Furnishings.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of=Aircraft.Furnishings.MASS, wrt='*')
@@ -232,9 +232,9 @@ class AltFurnishingsGroupMassBase(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.Design.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Furnishings.MASS_SCALER)
+        add_aviary_input(self, Aircraft.Furnishings.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Furnishings.MASS_BASE)
+        add_aviary_output(self, Aircraft.Furnishings.MASS_BASE, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of=Aircraft.Furnishings.MASS_BASE, wrt='*')
@@ -265,12 +265,12 @@ class AltFurnishingsGroupMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Furnishings.MASS_BASE)
-        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.MASS)
-        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE)
+        add_aviary_input(self, Aircraft.Furnishings.MASS_BASE, units='lbm')
+        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE, units='lbm')
 
-        add_aviary_output(self, Aircraft.Furnishings.MASS)
+        add_aviary_output(self, Aircraft.Furnishings.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(

--- a/aviary/subsystems/mass/flops_based/furnishings.py
+++ b/aviary/subsystems/mass/flops_based/furnishings.py
@@ -21,7 +21,8 @@ class TransportFurnishingsGroupMass(om.ExplicitComponent):
 
     def setup(self):
         add_aviary_input(self, Aircraft.Furnishings.MASS_SCALER, units='unitless')
-        add_aviary_input(self, Aircraft.Fuselage.PASSENGER_COMPARTMENT_LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.PASSENGER_COMPARTMENT_LENGTH,
+                         units='ft')
         add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
         add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT, units='ft')
 

--- a/aviary/subsystems/mass/flops_based/fuselage.py
+++ b/aviary/subsystems/mass/flops_based/fuselage.py
@@ -20,11 +20,11 @@ class TransportFuselageMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Propulsion.TOTAL_NUM_FUSELAGE_ENGINES)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_input(self, Aircraft.Fuselage.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
 
-        add_aviary_output(self, Aircraft.Fuselage.MASS)
+        add_aviary_output(self, Aircraft.Fuselage.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Fuselage.MASS, "*")
@@ -79,12 +79,12 @@ class AltFuselageMass(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
+        add_aviary_input(self, Aircraft.Fuselage.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_HEIGHT, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
 
-        add_aviary_output(self, Aircraft.Fuselage.MASS)
+        add_aviary_output(self, Aircraft.Fuselage.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of='*', wrt='*')

--- a/aviary/subsystems/mass/flops_based/horizontal_tail.py
+++ b/aviary/subsystems/mass/flops_based/horizontal_tail.py
@@ -12,12 +12,12 @@ class HorizontalTailMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.HorizontalTail.AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.HorizontalTail.MASS_SCALER)
+        add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.HorizontalTail.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.HorizontalTail.MASS)
+        add_aviary_output(self, Aircraft.HorizontalTail.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")
@@ -62,10 +62,10 @@ class AltHorizontalTailMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.HorizontalTail.AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.MASS_SCALER)
+        add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.HorizontalTail.MASS)
+        add_aviary_output(self, Aircraft.HorizontalTail.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")

--- a/aviary/subsystems/mass/flops_based/hydraulics.py
+++ b/aviary/subsystems/mass/flops_based/hydraulics.py
@@ -27,13 +27,13 @@ class TransportHydraulicsGroupMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA)
-        add_aviary_input(self, Aircraft.Hydraulics.SYSTEM_PRESSURE)
-        add_aviary_input(self, Aircraft.Hydraulics.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.VAR_SWEEP_MASS_PENALTY)
+        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Hydraulics.SYSTEM_PRESSURE, units='psi')
+        add_aviary_input(self, Aircraft.Hydraulics.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.VAR_SWEEP_MASS_PENALTY, units='unitless')
 
-        add_aviary_output(self, Aircraft.Hydraulics.MASS)
+        add_aviary_output(self, Aircraft.Hydraulics.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')
@@ -101,13 +101,13 @@ class AltHydraulicsGroupMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD)
-        add_aviary_input(self, Aircraft.VerticalTail.AREA)
-        add_aviary_input(self, Aircraft.Hydraulics.MASS_SCALER)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Hydraulics.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Hydraulics.MASS)
+        add_aviary_output(self, Aircraft.Hydraulics.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/hydraulics.py
+++ b/aviary/subsystems/mass/flops_based/hydraulics.py
@@ -103,7 +103,8 @@ class AltHydraulicsGroupMass(om.ExplicitComponent):
     def setup(self):
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA, units='ft**2')
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
         add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.Hydraulics.MASS_SCALER, units='unitless')
 

--- a/aviary/subsystems/mass/flops_based/instruments.py
+++ b/aviary/subsystems/mass/flops_based/instruments.py
@@ -23,10 +23,10 @@ class TransportInstrumentMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA)
-        add_aviary_input(self, Aircraft.Instruments.MASS_SCALER)
+        add_aviary_input(self, Aircraft.Fuselage.PLANFORM_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Instruments.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Instruments.MASS, 0.0)
+        add_aviary_output(self, Aircraft.Instruments.MASS, units='lbm')
 
         self.declare_partials("*", "*")
 

--- a/aviary/subsystems/mass/flops_based/landing_gear.py
+++ b/aviary/subsystems/mass/flops_based/landing_gear.py
@@ -20,9 +20,11 @@ class LandingGearMass(om.ExplicitComponent):
 
     def setup(self):
         add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH, units='inch')
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH, units='inch')
-        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Design.TOUCHDOWN_MASS, units='lbm')
 
         add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS, units='lbm')
@@ -127,9 +129,11 @@ class AltLandingGearMass(om.ExplicitComponent):
 
     def setup(self):
         add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH, units='inch')
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH, units='inch')
-        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
 
         add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS, units='lbm')
@@ -263,13 +267,13 @@ class MainGearLength(om.ExplicitComponent):
 
         add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
         add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
+                         shape=num_engine_type, units='ft')
         if any(num_wing_engines) > 0:
             add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS,
-                             #val=np.zeros((num_engine_type, int(num_wing_engines[0] / 2))),
                              shape=(num_engine_type, int(num_wing_engines[0]/2)),
                              units='unitless')
-        else: # this case is not tested
+        else:  # this case is not tested
             add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS, units='unitless')
         add_aviary_input(self, Aircraft.Wing.DIHEDRAL, units='deg')
         add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')

--- a/aviary/subsystems/mass/flops_based/landing_gear.py
+++ b/aviary/subsystems/mass/flops_based/landing_gear.py
@@ -19,14 +19,14 @@ class LandingGearMass(om.ExplicitComponent):
     # equations
 
     def setup(self):
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH)
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER)
-        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH)
-        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Design.TOUCHDOWN_MASS)
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH, units='inch')
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH, units='inch')
+        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Design.TOUCHDOWN_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS)
-        add_aviary_output(self, Aircraft.LandingGear.NOSE_GEAR_MASS)
+        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.LandingGear.NOSE_GEAR_MASS, units='lbm')
 
         # TODO landing weight is not a landing_gear component level variable
         # self.add_input('aircraft:landing_gear:weights:landing_weight', val=0.0, desc='design landing weight', units='lbf')
@@ -126,14 +126,14 @@ class AltLandingGearMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH)
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER)
-        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH)
-        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH, units='inch')
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH, units='inch')
+        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS)
-        add_aviary_output(self, Aircraft.LandingGear.NOSE_GEAR_MASS)
+        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.LandingGear.NOSE_GEAR_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.LandingGear.MAIN_GEAR_MASS, [
@@ -235,8 +235,8 @@ class NoseGearLength(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH)
-        add_aviary_output(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH)
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH, units='inch')
+        add_aviary_output(self, Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH, units='inch')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.LandingGear.NOSE_GEAR_OLEO_LENGTH,
@@ -261,20 +261,20 @@ class MainGearLength(om.ExplicitComponent):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
         num_wing_engines = self.options[Aircraft.Engine.NUM_WING_ENGINES]
 
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH)
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type)
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.MAX_WIDTH, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type, units='ft')
         if any(num_wing_engines) > 0:
-            # XJ: shape=(num_engine_type, int(num_wing_engines[0]/2))
-            add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS, val=np.zeros(
-                (num_engine_type, int(num_wing_engines[0] / 2))))
-        else:
             add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS,
-                             val=[[0.0]])
-        add_aviary_input(self, Aircraft.Wing.DIHEDRAL)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
+                             #val=np.zeros((num_engine_type, int(num_wing_engines[0] / 2))),
+                             shape=(num_engine_type, int(num_wing_engines[0]/2)),
+                             units='unitless')
+        else: # this case is not tested
+            add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.DIHEDRAL, units='deg')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
 
-        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH)
+        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH, units='inch')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/landing_mass.py
+++ b/aviary/subsystems/mass/flops_based/landing_mass.py
@@ -11,10 +11,10 @@ class LandingTakeoffMassRatio(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Mission.Summary.CRUISE_MACH)
-        add_aviary_input(self, Mission.Design.RANGE)
+        add_aviary_input(self, Mission.Summary.CRUISE_MACH, units='unitless')
+        add_aviary_input(self, Mission.Design.RANGE, units='NM')
 
-        add_aviary_output(self, Aircraft.Design.LANDING_TO_TAKEOFF_MASS_RATIO)
+        add_aviary_output(self, Aircraft.Design.LANDING_TO_TAKEOFF_MASS_RATIO, units='unitless')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/landing_mass.py
+++ b/aviary/subsystems/mass/flops_based/landing_mass.py
@@ -14,7 +14,8 @@ class LandingTakeoffMassRatio(om.ExplicitComponent):
         add_aviary_input(self, Mission.Summary.CRUISE_MACH, units='unitless')
         add_aviary_input(self, Mission.Design.RANGE, units='NM')
 
-        add_aviary_output(self, Aircraft.Design.LANDING_TO_TAKEOFF_MASS_RATIO, units='unitless')
+        add_aviary_output(self, Aircraft.Design.LANDING_TO_TAKEOFF_MASS_RATIO,
+                          units='unitless')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/mass_summation.py
+++ b/aviary/subsystems/mass/flops_based/mass_summation.py
@@ -80,18 +80,18 @@ class StructureMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Canard.MASS)
-        add_aviary_input(self, Aircraft.Fins.MASS)
-        add_aviary_input(self, Aircraft.Fuselage.MASS)
-        add_aviary_input(self, Aircraft.HorizontalTail.MASS)
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS)
-        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS)
-        add_aviary_input(self, Aircraft.Nacelle.MASS, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Paint.MASS)
-        add_aviary_input(self, Aircraft.VerticalTail.MASS)
-        add_aviary_input(self, Aircraft.Wing.MASS)
+        add_aviary_input(self, Aircraft.Canard.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fins.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuselage.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.HorizontalTail.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.LandingGear.NOSE_GEAR_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Nacelle.MASS, shape=num_engine_type, units='lbm')
+        add_aviary_input(self, Aircraft.Paint.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.VerticalTail.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.STRUCTURE_MASS)
+        add_aviary_output(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
 
     def setup_partials(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
@@ -120,12 +120,12 @@ class StructureMass(om.ExplicitComponent):
 class PropulsionMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_MISC_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_THRUST_REVERSERS_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_MASS)
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_MISC_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_THRUST_REVERSERS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Propulsion.MASS)
+        add_aviary_output(self, Aircraft.Propulsion.MASS, units='lbm')
 
     def setup_partials(self):
         prop_wrt = [
@@ -149,18 +149,18 @@ class PropulsionMass(om.ExplicitComponent):
 class SystemsEquipMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.AirConditioning.MASS)
-        add_aviary_input(self, Aircraft.AntiIcing.MASS)
-        add_aviary_input(self, Aircraft.APU.MASS)
-        add_aviary_input(self, Aircraft.Avionics.MASS)
-        add_aviary_input(self, Aircraft.Electrical.MASS)
-        add_aviary_input(self, Aircraft.Furnishings.MASS)
-        add_aviary_input(self, Aircraft.Hydraulics.MASS)
-        add_aviary_input(self, Aircraft.Instruments.MASS)
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS)
-        add_aviary_input(self, Aircraft.Design.EXTERNAL_SUBSYSTEMS_MASS)
+        add_aviary_input(self, Aircraft.AirConditioning.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.AntiIcing.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.APU.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Avionics.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Electrical.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Furnishings.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Hydraulics.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Instruments.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.EXTERNAL_SUBSYSTEMS_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.SYSTEMS_EQUIP_MASS)
+        add_aviary_output(self, Aircraft.Design.SYSTEMS_EQUIP_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Design.SYSTEMS_EQUIP_MASS, '*', val=1)
@@ -186,18 +186,18 @@ class SystemsEquipMass(om.ExplicitComponent):
 class AltSystemsEquipMassBase(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.AirConditioning.MASS)
-        add_aviary_input(self, Aircraft.AntiIcing.MASS)
-        add_aviary_input(self, Aircraft.APU.MASS)
-        add_aviary_input(self, Aircraft.Avionics.MASS)
-        add_aviary_input(self, Aircraft.Electrical.MASS)
-        add_aviary_input(self, Aircraft.Furnishings.MASS_BASE)
-        add_aviary_input(self, Aircraft.Hydraulics.MASS)
-        add_aviary_input(self, Aircraft.Instruments.MASS)
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS)
-        add_aviary_input(self, Aircraft.Design.EXTERNAL_SUBSYSTEMS_MASS)
+        add_aviary_input(self, Aircraft.AirConditioning.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.AntiIcing.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.APU.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Avionics.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Electrical.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Furnishings.MASS_BASE, units='lbm')
+        add_aviary_input(self, Aircraft.Hydraulics.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Instruments.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.EXTERNAL_SUBSYSTEMS_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE)
+        add_aviary_output(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE, '*', val=1)
@@ -223,11 +223,11 @@ class AltSystemsEquipMassBase(om.ExplicitComponent):
 class AltSystemsEquipMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE)
-        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.MASS)
+        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE, units='lbm')
+        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.SYSTEMS_EQUIP_MASS)
+        add_aviary_output(self, Aircraft.Design.SYSTEMS_EQUIP_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(
@@ -255,12 +255,12 @@ class AltSystemsEquipMass(om.ExplicitComponent):
 class EmptyMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN)
-        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.MASS)
-        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS)
+        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN, units='lbm')
+        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.EMPTY_MASS)
+        add_aviary_output(self, Aircraft.Design.EMPTY_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Design.EMPTY_MASS, '*', val=1)
@@ -278,12 +278,12 @@ class EmptyMass(om.ExplicitComponent):
 class AltEmptyMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN)
-        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.MASS)
-        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE)
+        add_aviary_input(self, Aircraft.Design.EMPTY_MASS_MARGIN, units='lbm')
+        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.SYSTEMS_EQUIP_MASS_BASE, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.EMPTY_MASS)
+        add_aviary_output(self, Aircraft.Design.EMPTY_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Design.EMPTY_MASS,
@@ -308,15 +308,15 @@ class AltEmptyMass(om.ExplicitComponent):
 class OperatingMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS)
-        add_aviary_input(self, Aircraft.Design.EMPTY_MASS)
-        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS)
+        add_aviary_input(self, Aircraft.CrewPayload.CARGO_CONTAINER_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.NON_FLIGHT_CREW_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.FLIGHT_CREW_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.EMPTY_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.OPERATING_MASS)
+        add_aviary_output(self, Aircraft.Design.OPERATING_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Design.OPERATING_MASS, '*', val=1)
@@ -338,12 +338,12 @@ class OperatingMass(om.ExplicitComponent):
 class ZeroFuelMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.BAGGAGE_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.CARGO_MASS)
-        add_aviary_input(self, Aircraft.Design.OPERATING_MASS)
+        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.BAGGAGE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.CARGO_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.OPERATING_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.ZERO_FUEL_MASS)
+        add_aviary_output(self, Aircraft.Design.ZERO_FUEL_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Aircraft.Design.ZERO_FUEL_MASS, '*', val=1)
@@ -361,10 +361,10 @@ class ZeroFuelMass(om.ExplicitComponent):
 class FuelMass(om.ExplicitComponent):
 
     def setup(self):
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Design.ZERO_FUEL_MASS)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.ZERO_FUEL_MASS, units='lbm')
 
-        add_aviary_output(self, Mission.Design.FUEL_MASS)
+        add_aviary_output(self, Mission.Design.FUEL_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(Mission.Design.FUEL_MASS,

--- a/aviary/subsystems/mass/flops_based/mass_summation.py
+++ b/aviary/subsystems/mass/flops_based/mass_summation.py
@@ -122,7 +122,8 @@ class PropulsionMass(om.ExplicitComponent):
     def setup(self):
         add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS, units='lbm')
         add_aviary_input(self, Aircraft.Propulsion.TOTAL_MISC_MASS, units='lbm')
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_THRUST_REVERSERS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_THRUST_REVERSERS_MASS,
+                         units='lbm')
         add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_MASS, units='lbm')
 
         add_aviary_output(self, Aircraft.Propulsion.MASS, units='lbm')

--- a/aviary/subsystems/mass/flops_based/misc_engine.py
+++ b/aviary/subsystems/mass/flops_based/misc_engine.py
@@ -24,12 +24,13 @@ class EngineMiscMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Engine.ADDITIONAL_MASS, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Propulsion.MISC_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_STARTER_MASS)
+        add_aviary_input(self, Aircraft.Engine.ADDITIONAL_MASS,
+                         shape=num_engine_type, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.MISC_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_STARTER_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_MISC_MASS)
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_MISC_MASS, units='lbm')
 
         self.declare_partials(
             of=Aircraft.Propulsion.TOTAL_MISC_MASS,

--- a/aviary/subsystems/mass/flops_based/misc_engine.py
+++ b/aviary/subsystems/mass/flops_based/misc_engine.py
@@ -27,7 +27,8 @@ class EngineMiscMass(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Engine.ADDITIONAL_MASS,
                          shape=num_engine_type, units='lbm')
         add_aviary_input(self, Aircraft.Propulsion.MISC_MASS_SCALER, units='unitless')
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_CONTROLS_MASS,
+                         units='lbm')
         add_aviary_input(self, Aircraft.Propulsion.TOTAL_STARTER_MASS, units='lbm')
 
         add_aviary_output(self, Aircraft.Propulsion.TOTAL_MISC_MASS, units='lbm')

--- a/aviary/subsystems/mass/flops_based/nacelle.py
+++ b/aviary/subsystems/mass/flops_based/nacelle.py
@@ -25,12 +25,12 @@ class NacelleMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Nacelle.MASS_SCALER, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type)
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH, shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.MASS_SCALER, shape=num_engine_type, units='unitless')
+        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type, units='lbf')
 
-        add_aviary_output(self, Aircraft.Nacelle.MASS, shape=num_engine_type)
+        add_aviary_output(self, Aircraft.Nacelle.MASS, shape=num_engine_type, units='lbm')
 
     def setup_partials(self):
         # derivatives w.r.t vectorized engine inputs have known sparsity pattern

--- a/aviary/subsystems/mass/flops_based/nacelle.py
+++ b/aviary/subsystems/mass/flops_based/nacelle.py
@@ -25,12 +25,17 @@ class NacelleMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type, units='ft')
-        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH, shape=num_engine_type, units='ft')
-        add_aviary_input(self, Aircraft.Nacelle.MASS_SCALER, shape=num_engine_type, units='unitless')
-        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type, units='lbf')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
+                         shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_LENGTH,
+                         shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.MASS_SCALER,
+                         shape=num_engine_type, units='unitless')
+        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST,
+                         shape=num_engine_type, units='lbf')
 
-        add_aviary_output(self, Aircraft.Nacelle.MASS, shape=num_engine_type, units='lbm')
+        add_aviary_output(self, Aircraft.Nacelle.MASS,
+                          shape=num_engine_type, units='lbm')
 
     def setup_partials(self):
         # derivatives w.r.t vectorized engine inputs have known sparsity pattern

--- a/aviary/subsystems/mass/flops_based/paint.py
+++ b/aviary/subsystems/mass/flops_based/paint.py
@@ -10,10 +10,10 @@ class PaintMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Design.TOTAL_WETTED_AREA)
-        add_aviary_input(self, Aircraft.Paint.MASS_PER_UNIT_AREA)
+        add_aviary_input(self, Aircraft.Design.TOTAL_WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Paint.MASS_PER_UNIT_AREA, units='lbm/ft**2')
 
-        add_aviary_output(self, Aircraft.Paint.MASS)
+        add_aviary_output(self, Aircraft.Paint.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/passenger_service.py
+++ b/aviary/subsystems/mass/flops_based/passenger_service.py
@@ -23,10 +23,10 @@ class PassengerServiceMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_SCALER)
-        add_aviary_input(self, Mission.Design.RANGE)
+        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Mission.Design.RANGE, units='NM')
 
-        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS)
+        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')
@@ -97,9 +97,9 @@ class AltPassengerServiceMass(om.ExplicitComponent):
 
     def setup(self):
         add_aviary_input(
-            self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_SCALER, val=1.)
+            self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS, val=0.0)
+        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials('*', '*')

--- a/aviary/subsystems/mass/flops_based/passenger_service.py
+++ b/aviary/subsystems/mass/flops_based/passenger_service.py
@@ -23,7 +23,8 @@ class PassengerServiceMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Mission.Design.RANGE, units='NM')
 
         add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS, units='lbm')

--- a/aviary/subsystems/mass/flops_based/starter.py
+++ b/aviary/subsystems/mass/flops_based/starter.py
@@ -24,9 +24,9 @@ class TransportStarterMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type)
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type, units='ft')
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_STARTER_MASS)
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_STARTER_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")

--- a/aviary/subsystems/mass/flops_based/starter.py
+++ b/aviary/subsystems/mass/flops_based/starter.py
@@ -24,7 +24,8 @@ class TransportStarterMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER, shape=num_engine_type, units='ft')
+        add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
+                         shape=num_engine_type, units='ft')
 
         add_aviary_output(self, Aircraft.Propulsion.TOTAL_STARTER_MASS, units='lbm')
 

--- a/aviary/subsystems/mass/flops_based/surface_controls.py
+++ b/aviary/subsystems/mass/flops_based/surface_controls.py
@@ -15,13 +15,13 @@ class SurfaceControlMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO)
-        add_aviary_input(self, Aircraft.Wing.AREA)
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
 
-        add_aviary_output(self, Aircraft.Wing.SURFACE_CONTROL_MASS)
-        add_aviary_output(self, Aircraft.Wing.CONTROL_SURFACE_AREA, val=2)
+        add_aviary_output(self, Aircraft.Wing.SURFACE_CONTROL_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Wing.CONTROL_SURFACE_AREA, units='ft**2')
 
         self.declare_partials(Aircraft.Wing.SURFACE_CONTROL_MASS, '*')
         self.declare_partials(Aircraft.Wing.CONTROL_SURFACE_AREA, [
@@ -89,15 +89,15 @@ class AltSurfaceControlMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER, val=1.0)
-        add_aviary_input(self, Aircraft.Wing.AREA, val=0.0)
-        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO, val=0.0)
-        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA, val=0.0)
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, val=0.0)
-        add_aviary_input(self, Aircraft.VerticalTail.AREA, val=0.0)
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
 
-        add_aviary_output(self, Aircraft.Wing.CONTROL_SURFACE_AREA, val=2)
-        add_aviary_output(self, Aircraft.Wing.SURFACE_CONTROL_MASS, val=0.0)
+        add_aviary_output(self, Aircraft.Wing.CONTROL_SURFACE_AREA, units='ft**2')
+        add_aviary_output(self, Aircraft.Wing.SURFACE_CONTROL_MASS, units='lbm')
 
         self.declare_partials('*', '*')
 

--- a/aviary/subsystems/mass/flops_based/surface_controls.py
+++ b/aviary/subsystems/mass/flops_based/surface_controls.py
@@ -15,9 +15,11 @@ class SurfaceControlMass(om.ExplicitComponent):
         add_aviary_option(self, Mission.Constraints.MAX_MACH)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
-        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
 
         add_aviary_output(self, Aircraft.Wing.SURFACE_CONTROL_MASS, units='lbm')
@@ -89,11 +91,14 @@ class AltSurfaceControlMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
-        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA_RATIO,
+                         units='unitless')
         add_aviary_input(self, Aircraft.HorizontalTail.WETTED_AREA, units='ft**2')
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
         add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
 
         add_aviary_output(self, Aircraft.Wing.CONTROL_SURFACE_AREA, units='ft**2')

--- a/aviary/subsystems/mass/flops_based/thrust_reverser.py
+++ b/aviary/subsystems/mass/flops_based/thrust_reverser.py
@@ -28,14 +28,14 @@ class ThrustReverserMass(om.ExplicitComponent):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
         add_aviary_input(
-            self, Aircraft.Engine.THRUST_REVERSERS_MASS_SCALER, shape=num_engine_type)
+            self, Aircraft.Engine.THRUST_REVERSERS_MASS_SCALER, shape=num_engine_type, units='unitless')
         add_aviary_input(
-            self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type)
+            self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type, units='lbf')
 
         add_aviary_output(
-            self, Aircraft.Engine.THRUST_REVERSERS_MASS, shape=num_engine_type)
+            self, Aircraft.Engine.THRUST_REVERSERS_MASS, shape=num_engine_type, units='lbm')
         add_aviary_output(
-            self, Aircraft.Propulsion.TOTAL_THRUST_REVERSERS_MASS)
+            self, Aircraft.Propulsion.TOTAL_THRUST_REVERSERS_MASS, units='lbm')
 
     def setup_partials(self):
         # derivatives w.r.t vectorized engine inputs have known sparsity pattern

--- a/aviary/subsystems/mass/flops_based/unusable_fuel.py
+++ b/aviary/subsystems/mass/flops_based/unusable_fuel.py
@@ -25,14 +25,14 @@ class TransportUnusableFuelMass(om.ExplicitComponent):
 
     def setup(self):
         add_aviary_input(
-            self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuel.DENSITY_RATIO)
-        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST)
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_output(self, Aircraft.Fuel.TOTAL_VOLUME)
+            self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.DENSITY_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_SCALED_SLS_THRUST, units='lbf')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_output(self, Aircraft.Fuel.TOTAL_VOLUME, units='galUS')
 
-        add_aviary_output(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS)
+        add_aviary_output(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS, units='lbm')
 
     def setup_partials(self):
 
@@ -112,11 +112,11 @@ class AltUnusableFuelMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_SCALER, val=1.0)
+        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_SCALER, units='unitless')
 
-        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, 0.0)
+        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm')
 
-        add_aviary_output(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS, 0.0)
+        add_aviary_output(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials(of='*', wrt='*')

--- a/aviary/subsystems/mass/flops_based/vertical_tail.py
+++ b/aviary/subsystems/mass/flops_based/vertical_tail.py
@@ -15,12 +15,12 @@ class VerticalTailMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.VerticalTail.NUM_TAILS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.VerticalTail.AREA, val=0.0)
-        add_aviary_input(self, Aircraft.VerticalTail.TAPER_RATIO, val=0.0)
-        add_aviary_input(self, Aircraft.VerticalTail.MASS_SCALER)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.VerticalTail.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.VerticalTail.MASS)
+        add_aviary_output(self, Aircraft.VerticalTail.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")
@@ -74,11 +74,11 @@ class AltVerticalTailMass(om.ExplicitComponent):
     '''
 
     def setup(self):
-        add_aviary_input(self, Aircraft.VerticalTail.AREA, val=0.0)
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
 
-        add_aviary_input(self, Aircraft.VerticalTail.MASS_SCALER, val=1.0)
+        add_aviary_input(self, Aircraft.VerticalTail.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.VerticalTail.MASS, val=0.0)
+        add_aviary_output(self, Aircraft.VerticalTail.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")

--- a/aviary/subsystems/mass/flops_based/wing_common.py
+++ b/aviary/subsystems/mass/flops_based/wing_common.py
@@ -16,23 +16,23 @@ class WingBendingMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Fuselage.NUM_FUSELAGES)
 
     def setup(self):
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Wing.COMPOSITE_FRACTION)
-        add_aviary_input(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.LOAD_FRACTION)
-        add_aviary_input(self, Aircraft.Wing.MISC_MASS)
-        add_aviary_input(self, Aircraft.Wing.MISC_MASS_SCALER)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.COMPOSITE_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.LOAD_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.MISC_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.MISC_MASS_SCALER, units='unitless')
         add_aviary_input(self, Aircraft.Wing.SHEAR_CONTROL_MASS)
-        add_aviary_input(self, Aircraft.Wing.SHEAR_CONTROL_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.SWEEP)
-        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.VAR_SWEEP_MASS_PENALTY)
+        add_aviary_input(self, Aircraft.Wing.SHEAR_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.SWEEP, units='deg')
+        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.VAR_SWEEP_MASS_PENALTY, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.BENDING_MATERIAL_MASS)
+        add_aviary_output(self, Aircraft.Wing.BENDING_MATERIAL_MASS, units='lbm')
 
         self.A1 = 8.80
         self.A2 = 6.25
@@ -212,12 +212,12 @@ class WingShearControlMass(om.ExplicitComponent):
             desc='Aircfaft type: Tranpsport, HWB, or GA')
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.COMPOSITE_FRACTION)
-        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Wing.SHEAR_CONTROL_MASS_SCALER)
+        add_aviary_input(self, Aircraft.Wing.COMPOSITE_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.CONTROL_SURFACE_AREA, units='ft**2')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.SHEAR_CONTROL_MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.SHEAR_CONTROL_MASS)
+        add_aviary_output(self, Aircraft.Wing.SHEAR_CONTROL_MASS, units='lbm')
 
         if (
             (self.options['aircraft_type'] == 'Transport')
@@ -286,11 +286,11 @@ class WingMiscMass(om.ExplicitComponent):
             desc='Aircfaft type: Tranpsport, HWB, or GA')
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.COMPOSITE_FRACTION)
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.MISC_MASS_SCALER)
+        add_aviary_input(self, Aircraft.Wing.COMPOSITE_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.MISC_MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.MISC_MASS)
+        add_aviary_output(self, Aircraft.Wing.MISC_MASS, units='lbm')
 
         if (
             (self.options['aircraft_type'] == 'Transport')
@@ -334,13 +334,13 @@ class WingTotalMass(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_MASS)
-        add_aviary_input(self, Aircraft.Wing.SHEAR_CONTROL_MASS)
-        add_aviary_input(self, Aircraft.Wing.MISC_MASS)
-        add_aviary_input(self, Aircraft.Wing.BWB_AFTBODY_MASS)
-        add_aviary_input(self, Aircraft.Wing.MASS_SCALER)
+        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.SHEAR_CONTROL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.MISC_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.BWB_AFTBODY_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.MASS_SCALER, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.MASS)
+        add_aviary_output(self, Aircraft.Wing.MASS, units='lbm')
 
     def setup_partials(self):
         self.declare_partials("*", "*")

--- a/aviary/subsystems/mass/flops_based/wing_common.py
+++ b/aviary/subsystems/mass/flops_based/wing_common.py
@@ -17,9 +17,11 @@ class WingBendingMass(om.ExplicitComponent):
 
     def setup(self):
         add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
-        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_FACTOR, units='unitless')
-        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.BENDING_MATERIAL_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Wing.COMPOSITE_FRACTION, units='unitless')
         add_aviary_input(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR, units='unitless')
         add_aviary_input(self, Aircraft.Wing.LOAD_FRACTION, units='unitless')

--- a/aviary/subsystems/mass/flops_based/wing_detailed.py
+++ b/aviary/subsystems/mass/flops_based/wing_detailed.py
@@ -34,29 +34,29 @@ class DetailedWingBendingFact(om.ExplicitComponent):
         # wing_location_default[:] = [np.array([0]*int(num)) for num in num_wing_engines/2]
 
         add_aviary_input(self, Aircraft.Wing.LOAD_PATH_SWEEP_DIST,
-                         shape=num_input_stations - 1)
+                         shape=num_input_stations - 1, units='deg')
         add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_DIST,
-                         shape=num_input_stations)
+                         shape=num_input_stations, units='unitless')
         add_aviary_input(self, Aircraft.Wing.CHORD_PER_SEMISPAN_DIST,
-                         shape=num_input_stations)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Engine.POD_MASS, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO_REF)
-        add_aviary_input(self, Aircraft.Wing.STRUT_BRACING_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR)
+                         shape=num_input_stations, units='unitless')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Engine.POD_MASS, shape=num_engine_type, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO_REF, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.STRUT_BRACING_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR, units='unitless')
 
         if total_num_wing_engines > 0:
             add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS,
-                             shape=int(total_num_wing_engines/2))
+                             shape=int(total_num_wing_engines/2), units='unitless')
         else:
-            add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS)
+            add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS, units='unitless')
 
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_REF)
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_REF, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.BENDING_MATERIAL_FACTOR)
-        add_aviary_output(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR)
+        add_aviary_output(self, Aircraft.Wing.BENDING_MATERIAL_FACTOR, units='unitless')
+        add_aviary_output(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR, units='unitless')
 
     def setup_partials(self):
         # TODO: Analytic derivs will be challenging, but possible.

--- a/aviary/subsystems/mass/flops_based/wing_detailed.py
+++ b/aviary/subsystems/mass/flops_based/wing_detailed.py
@@ -40,11 +40,13 @@ class DetailedWingBendingFact(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Wing.CHORD_PER_SEMISPAN_DIST,
                          shape=num_input_stations, units='unitless')
         add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
-        add_aviary_input(self, Aircraft.Engine.POD_MASS, shape=num_engine_type, units='lbm')
+        add_aviary_input(self, Aircraft.Engine.POD_MASS,
+                         shape=num_engine_type, units='lbm')
         add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO_REF, units='unitless')
         add_aviary_input(self, Aircraft.Wing.STRUT_BRACING_FACTOR, units='unitless')
-        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR,
+                         units='unitless')
 
         if total_num_wing_engines > 0:
             add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS,

--- a/aviary/subsystems/mass/flops_based/wing_simple.py
+++ b/aviary/subsystems/mass/flops_based/wing_simple.py
@@ -20,7 +20,8 @@ class SimpleWingBendingFact(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
         add_aviary_input(self, Aircraft.Wing.STRUT_BRACING_FACTOR, units='unitless')
-        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.Wing.SWEEP, units='deg')
 

--- a/aviary/subsystems/mass/flops_based/wing_simple.py
+++ b/aviary/subsystems/mass/flops_based/wing_simple.py
@@ -15,17 +15,17 @@ class SimpleWingBendingFact(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD)
-        add_aviary_input(self, Aircraft.Wing.STRUT_BRACING_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.Wing.SWEEP)
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.STRUT_BRACING_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AEROELASTIC_TAILORING_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SWEEP, units='deg')
 
-        add_aviary_output(self, Aircraft.Wing.BENDING_MATERIAL_FACTOR)
-        add_aviary_output(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR)
+        add_aviary_output(self, Aircraft.Wing.BENDING_MATERIAL_FACTOR, units='unitless')
+        add_aviary_output(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR, units='unitless')
 
     def setup_partials(self):
         self.declare_partials(

--- a/aviary/subsystems/mass/gasp_based/design_load.py
+++ b/aviary/subsystems/mass/gasp_based/design_load.py
@@ -26,11 +26,11 @@ class LoadSpeeds(om.ExplicitComponent):
 
     def setup(self):
 
-        add_aviary_input(self, Aircraft.Design.MAX_STRUCTURAL_SPEED)
+        add_aviary_input(self, Aircraft.Design.MAX_STRUCTURAL_SPEED, units='mi/h')
 
         if self.options[Aircraft.Design.PART25_STRUCTURAL_CATEGORY] < 3:
 
-            add_aviary_input(self, Aircraft.Wing.LOADING)
+            add_aviary_input(self, Aircraft.Wing.LOADING, units='lbf/ft**2')
 
         self.add_output("max_airspeed", units="kn",
                         desc="VM0: maximum operating equivalent airspeed")
@@ -606,11 +606,11 @@ class LiftCurveSlopeAtCruise(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.Wing.SWEEP, units="rad")
-        add_aviary_input(self, Mission.Design.MACH)
+        add_aviary_input(self, Mission.Design.MACH, units='unitless')
 
-        add_aviary_output(self, Aircraft.Design.LIFT_CURVE_SLOPE)
+        add_aviary_output(self, Aircraft.Design.LIFT_CURVE_SLOPE, units='1/rad')
 
         self.declare_partials(Aircraft.Design.LIFT_CURVE_SLOPE, "*")
 
@@ -644,8 +644,8 @@ class LoadFactors(om.ExplicitComponent):
     """
 
     def initialize(self):
-        add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES)
-        add_aviary_option(self, Aircraft.Design.ULF_CALCULATED_FROM_MANEUVER)
+        add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, units='unitless')
+        add_aviary_option(self, Aircraft.Design.ULF_CALCULATED_FROM_MANEUVER, units='unitless')
 
     def setup(self):
 
@@ -659,10 +659,10 @@ class LoadFactors(om.ExplicitComponent):
         self.add_input("max_maneuver_factor", val=0.72, units="unitless",
                        desc="EMLF: maximum maneuver load factor, units are in g`s")
 
-        add_aviary_input(self, Aircraft.Wing.AVERAGE_CHORD)
-        add_aviary_input(self, Aircraft.Design.LIFT_CURVE_SLOPE)
+        add_aviary_input(self, Aircraft.Wing.AVERAGE_CHORD, units='ft')
+        add_aviary_input(self, Aircraft.Design.LIFT_CURVE_SLOPE, units='1/rad')
 
-        add_aviary_output(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR)
+        add_aviary_output(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR, units='unitless')
 
         self.declare_partials(Aircraft.Wing.ULTIMATE_LOAD_FACTOR, "*")
 

--- a/aviary/subsystems/mass/gasp_based/design_load.py
+++ b/aviary/subsystems/mass/gasp_based/design_load.py
@@ -644,8 +644,8 @@ class LoadFactors(om.ExplicitComponent):
     """
 
     def initialize(self):
-        add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, units='unitless')
-        add_aviary_option(self, Aircraft.Design.ULF_CALCULATED_FROM_MANEUVER, units='unitless')
+        add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES)
+        add_aviary_option(self, Aircraft.Design.ULF_CALCULATED_FROM_MANEUVER)
 
     def setup(self):
 

--- a/aviary/subsystems/mass/gasp_based/equipment_and_useful_load.py
+++ b/aviary/subsystems/mass/gasp_based/equipment_and_useful_load.py
@@ -25,43 +25,40 @@ class EquipAndUsefulLoadMass(om.ExplicitComponent):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
         add_aviary_input(
-            self, Aircraft.AirConditioning.MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.AntiIcing.MASS)
-        add_aviary_input(self, Aircraft.APU.MASS)
-        add_aviary_input(self, Aircraft.Avionics.MASS)
-        add_aviary_input(
-            self, Aircraft.CrewPayload.CATERING_ITEMS_MASS_PER_PASSENGER)
-        add_aviary_input(self, Aircraft.Design.EMERGENCY_EQUIPMENT_MASS)
-        add_aviary_input(self, Aircraft.Furnishings.MASS)
-        add_aviary_input(
-            self, Aircraft.Hydraulics.FLIGHT_CONTROL_MASS_COEFFICIENT)
-        add_aviary_input(
-            self, Aircraft.Hydraulics.GEAR_MASS_COEFFICIENT)
-        add_aviary_input(
-            self, Aircraft.Instruments.MASS_COEFFICIENT)
-        add_aviary_input(
-            self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_PER_PASSENGER)
-        add_aviary_input(
-            self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT)
-        add_aviary_input(
-            self, Aircraft.CrewPayload.WATER_MASS_PER_OCCUPANT)
+            self, Aircraft.AirConditioning.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.AntiIcing.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.APU.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Avionics.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.CATERING_ITEMS_MASS_PER_PASSENGER,
+                         units='lbm')
+        add_aviary_input(self, Aircraft.Design.EMERGENCY_EQUIPMENT_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Furnishings.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Hydraulics.FLIGHT_CONTROL_MASS_COEFFICIENT,
+                         units='unitless')
+        add_aviary_input(self, Aircraft.Hydraulics.GEAR_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Instruments.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_PER_PASSENGER,
+                         units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.CrewPayload.WATER_MASS_PER_OCCUPANT)
 
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.LandingGear.TOTAL_MASS)
-        add_aviary_input(self, Aircraft.Controls.TOTAL_MASS)
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.HorizontalTail.AREA)
-        add_aviary_input(self, Aircraft.VerticalTail.AREA)
-        add_aviary_input(self, Aircraft.Fuselage.PRESSURE_DIFFERENTIAL)
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
-        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_FRACTION)
-        add_aviary_input(self, Aircraft.Design.EXTERNAL_SUBSYSTEMS_MASS)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.LandingGear.TOTAL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Controls.TOTAL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Fuselage.PRESSURE_DIFFERENTIAL, units='psi')
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
+        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST,
+                         shape=num_engine_type, units='lbf')
+        add_aviary_input(self, Aircraft.Fuel.WING_FUEL_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.Design.EXTERNAL_SUBSYSTEMS_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.FIXED_USEFUL_LOAD)
-        add_aviary_output(self, Aircraft.Design.FIXED_EQUIPMENT_MASS)
+        add_aviary_output(self, Aircraft.Design.FIXED_USEFUL_LOAD, units='lbm')
+        add_aviary_output(self, Aircraft.Design.FIXED_EQUIPMENT_MASS, units='lbm')
 
         self.declare_partials(Aircraft.Design.FIXED_USEFUL_LOAD, '*')
         self.declare_partials(Aircraft.Design.FIXED_EQUIPMENT_MASS, '*')

--- a/aviary/subsystems/mass/gasp_based/equipment_and_useful_load.py
+++ b/aviary/subsystems/mass/gasp_based/equipment_and_useful_load.py
@@ -35,11 +35,13 @@ class EquipAndUsefulLoadMass(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Furnishings.MASS, units='lbm')
         add_aviary_input(self, Aircraft.Hydraulics.FLIGHT_CONTROL_MASS_COEFFICIENT,
                          units='unitless')
-        add_aviary_input(self, Aircraft.Hydraulics.GEAR_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Hydraulics.GEAR_MASS_COEFFICIENT,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Instruments.MASS_COEFFICIENT, units='unitless')
         add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_SERVICE_MASS_PER_PASSENGER,
                          units='lbm')
-        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT,
+                         units='unitless')
         add_aviary_input(self, Aircraft.CrewPayload.WATER_MASS_PER_OCCUPANT)
 
         add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')

--- a/aviary/subsystems/mass/gasp_based/fixed.py
+++ b/aviary/subsystems/mass/gasp_based/fixed.py
@@ -861,22 +861,27 @@ class TailMass(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.VerticalTail.SWEEP, units="rad")
         add_aviary_input(self, Aircraft.VerticalTail.SPAN, units='ft')
         add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
-        add_aviary_input(self, Aircraft.HorizontalTail.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.MASS_COEFFICIENT,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
         add_aviary_input(self, Aircraft.HorizontalTail.SPAN, units='ft')
-        add_aviary_input(self, Aircraft.LandingGear.TAIL_HOOK_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.TAIL_HOOK_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.VerticalTail.MASS_COEFFICIENT, units='unitless')
         add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
         add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
         self.add_input("min_dive_vel", val=200, units="kn", desc="VDMIN: dive velocity")
         add_aviary_input(self, Aircraft.HorizontalTail.MOMENT_ARM, units='ft')
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
         add_aviary_input(self, Aircraft.HorizontalTail.ROOT_CHORD, units='ft')
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION,
+                         units='unitless')
         add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.VerticalTail.MOMENT_ARM, units='ft')
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD,
+                         units='unitless')
         add_aviary_input(self, Aircraft.VerticalTail.ROOT_CHORD, units='ft')
 
         self.add_output("loc_MAC_vtail", val=0, units="ft",
@@ -1477,7 +1482,8 @@ class HighLiftMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Wing.NUM_FLAP_SEGMENTS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.HIGH_LIFT_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.HIGH_LIFT_MASS_COEFFICIENT,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
         add_aviary_input(self, Aircraft.Wing.SLAT_CHORD_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.Wing.FLAP_CHORD_RATIO, units='unitless')
@@ -1955,8 +1961,10 @@ class ControlMass(om.ExplicitComponent):
                          units='unitless')
         add_aviary_input(self, Aircraft.Controls.STABILITY_AUGMENTATION_SYSTEM_MASS,
                          units='lbm')
-        add_aviary_input(self, Aircraft.Controls.COCKPIT_CONTROL_MASS_SCALER, units='unitless')
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Controls.COCKPIT_CONTROL_MASS_SCALER,
+                         units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Controls.STABILITY_AUGMENTATION_SYSTEM_MASS_SCALER,
                          units='unitless')
         add_aviary_input(self, Aircraft.Controls.CONTROL_MASS_INCREMENT, units='lbm')

--- a/aviary/subsystems/mass/gasp_based/fixed.py
+++ b/aviary/subsystems/mass/gasp_based/fixed.py
@@ -27,25 +27,25 @@ class MassParameters(om.ExplicitComponent):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
         add_aviary_input(self, Aircraft.Wing.SWEEP, units='rad')
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.ASPECT_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
 
         self.add_input("max_mach", val=0.9, units="unitless",
                        desc="EMM0: maximum operating mach number")
 
-        add_aviary_input(
-            self, Aircraft.Strut.ATTACHMENT_LOCATION_DIMENSIONLESS)
+        add_aviary_input(self, Aircraft.Strut.ATTACHMENT_LOCATION_DIMENSIONLESS,
+                         units='unitless')
 
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_LOCATION)
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_LOCATION, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.MATERIAL_FACTOR)
+        add_aviary_output(self, Aircraft.Wing.MATERIAL_FACTOR, units='unitless')
         self.add_output("c_strut_braced", val=0, units="unitless",
                         desc="SKSTR: reduction in bending moment factor for strut braced wing")
         self.add_output("c_gear_loc", val=0, units="unitless",
                         desc="SKGEAR: landing gear location factor")
         add_aviary_output(self, Aircraft.Engine.POSITION_FACTOR,
-                          shape=num_engine_type)
+                          shape=num_engine_type, units='unitless')
         self.add_output("half_sweep", val=0, units="rad",
                         desc="SWC2: wing chord half sweep angle")
 
@@ -238,12 +238,12 @@ class PayloadMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.CrewPayload.Design.NUM_PASSENGERS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.CrewPayload.CARGO_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.Design.CARGO_MASS)
-        add_aviary_input(self, Aircraft.CrewPayload.Design.MAX_CARGO_MASS)
+        add_aviary_input(self, Aircraft.CrewPayload.CARGO_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.Design.CARGO_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.CrewPayload.Design.MAX_CARGO_MASS, units='lbm')
 
-        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS)
-        add_aviary_output(self, Aircraft.CrewPayload.TOTAL_PAYLOAD_MASS)
+        add_aviary_output(self, Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.CrewPayload.TOTAL_PAYLOAD_MASS, units='lbm')
 
         self.add_output(
             "payload_mass_des", val=0, units="lbm", desc="WPLDES: design payload"
@@ -295,7 +295,7 @@ class ElectricAugmentationMass(om.ExplicitComponent):
         self.add_input("safety_factor", val=1.33, units="unitless",
                        desc="REDUNCY: cable mass redundancy/safety factor")
 
-        add_aviary_input(self, Aircraft.Electrical.HYBRID_CABLE_LENGTH)
+        add_aviary_input(self, Aircraft.Electrical.HYBRID_CABLE_LENGTH, units='ft')
 
         self.add_input("wire_area", val=0.0015, units="ft**2",
                        desc="ACSWIRE: cross sectional area of electrical augmentation system wire")
@@ -511,25 +511,26 @@ class EngineMass(om.ExplicitComponent):
         total_num_engines = self.options[Aircraft.Propulsion.TOTAL_NUM_ENGINES]
 
         add_aviary_input(self, Aircraft.Engine.MASS_SPECIFIC,
-                         shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST, shape=num_engine_type)
+                         shape=num_engine_type, units='lbm/lbf')
+        add_aviary_input(self, Aircraft.Engine.SCALED_SLS_THRUST,
+                         shape=num_engine_type, units='lbf')
         add_aviary_input(self, Aircraft.Nacelle.MASS_SPECIFIC,
-                         shape=num_engine_type)
+                         shape=num_engine_type, units='lbm/ft**2')
         add_aviary_input(self, Aircraft.Nacelle.SURFACE_AREA,
-                         shape=num_engine_type)
+                         shape=num_engine_type, units='ft**2')
         add_aviary_input(self, Aircraft.Engine.PYLON_FACTOR,
-                         shape=num_engine_type)
+                         shape=num_engine_type, units='unitless')
         add_aviary_input(self, Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
-                         val=np.full(num_engine_type, 0.14))
+                         val=np.full(num_engine_type, 0.0))
         add_aviary_input(self, Aircraft.Engine.MASS_SCALER,
-                         shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Propulsion.MISC_MASS_SCALER)
+                         shape=num_engine_type, units='unitless')
+        add_aviary_input(self, Aircraft.Propulsion.MISC_MASS_SCALER, units='unitless')
         add_aviary_input(self, Aircraft.Engine.WING_LOCATIONS,
-                         shape=int(total_num_engines/2))
+                         shape=int(total_num_engines/2), units='unitless')
 
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS)
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS, units='lbm')
 
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_LOCATION)
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_LOCATION, units='unitless')
 
         has_hybrid_system = self.options[Aircraft.Electrical.HAS_HYBRID_SYSTEM]
 
@@ -537,13 +538,13 @@ class EngineMass(om.ExplicitComponent):
             self.add_input("aug_mass", val=400, units="lbm",
                            desc="WEAUG: mass of electrical augmentation system")
 
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_MASS)
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_MASS, units='lbm')
         add_aviary_output(self, Aircraft.Nacelle.MASS, shape=num_engine_type)
         self.add_output('pylon_mass', units='lbm',
                         desc='WPYLON: mass of each pylon', val=np.zeros(num_engine_type))
-        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_POD_MASS)
+        add_aviary_output(self, Aircraft.Propulsion.TOTAL_ENGINE_POD_MASS, units='lbm')
         add_aviary_output(self, Aircraft.Engine.ADDITIONAL_MASS,
-                          shape=num_engine_type)
+                          shape=num_engine_type, units='lbm')
         self.add_output("eng_comb_mass", val=0, units="lbm",
                         desc="WPSTAR: combined mass of dry engine and engine installation,"
                         " includes mass of electrical augmentation system")
@@ -855,33 +856,33 @@ class TailMass(om.ExplicitComponent):
     """
 
     def setup(self):
-        add_aviary_input(self, Aircraft.VerticalTail.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO)
+        add_aviary_input(self, Aircraft.VerticalTail.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.ASPECT_RATIO, units='unitless')
         add_aviary_input(self, Aircraft.VerticalTail.SWEEP, units="rad")
-        add_aviary_input(self, Aircraft.VerticalTail.SPAN)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.HorizontalTail.MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Fuselage.LENGTH)
-        add_aviary_input(self, Aircraft.HorizontalTail.SPAN)
-        add_aviary_input(self, Aircraft.LandingGear.TAIL_HOOK_MASS_SCALER)
-        add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.VerticalTail.MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.HorizontalTail.AREA)
+        add_aviary_input(self, Aircraft.VerticalTail.SPAN, units='ft')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.HorizontalTail.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.LENGTH, units='ft')
+        add_aviary_input(self, Aircraft.HorizontalTail.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.LandingGear.TAIL_HOOK_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.HorizontalTail.AREA, units='ft**2')
         self.add_input("min_dive_vel", val=200, units="kn", desc="VDMIN: dive velocity")
-        add_aviary_input(self, Aircraft.HorizontalTail.MOMENT_ARM)
-        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD)
-        add_aviary_input(self, Aircraft.HorizontalTail.ROOT_CHORD)
-        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION)
-        add_aviary_input(self, Aircraft.VerticalTail.AREA)
-        add_aviary_input(self, Aircraft.VerticalTail.MOMENT_ARM)
-        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD)
-        add_aviary_input(self, Aircraft.VerticalTail.ROOT_CHORD)
+        add_aviary_input(self, Aircraft.HorizontalTail.MOMENT_ARM, units='ft')
+        add_aviary_input(self, Aircraft.HorizontalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.ROOT_CHORD, units='ft')
+        add_aviary_input(self, Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.VerticalTail.MOMENT_ARM, units='ft')
+        add_aviary_input(self, Aircraft.VerticalTail.THICKNESS_TO_CHORD, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.ROOT_CHORD, units='ft')
 
         self.add_output("loc_MAC_vtail", val=0, units="ft",
                         desc="XVMAC: location of mean aerodynamic chord on the vertical tail")
-        add_aviary_output(self, Aircraft.HorizontalTail.MASS)
-        add_aviary_output(self, Aircraft.VerticalTail.MASS)
+        add_aviary_output(self, Aircraft.HorizontalTail.MASS, units='lbm')
+        add_aviary_output(self, Aircraft.VerticalTail.MASS, units='lbm')
 
         self.declare_partials(
             "loc_MAC_vtail",
@@ -1476,23 +1477,23 @@ class HighLiftMass(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Wing.NUM_FLAP_SEGMENTS)
 
     def setup(self):
-        add_aviary_input(self, Aircraft.Wing.HIGH_LIFT_MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Aircraft.Wing.SLAT_CHORD_RATIO)
-        add_aviary_input(self, Aircraft.Wing.FLAP_CHORD_RATIO)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.SLAT_SPAN_RATIO)
-        add_aviary_input(self, Aircraft.Wing.FLAP_SPAN_RATIO)
-        add_aviary_input(self, Aircraft.Wing.LOADING)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT)
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
-        add_aviary_input(self, Aircraft.Wing.CENTER_CHORD)
-        add_aviary_input(self, Mission.Landing.LIFT_COEFFICIENT_MAX)
+        add_aviary_input(self, Aircraft.Wing.HIGH_LIFT_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Wing.SLAT_CHORD_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.FLAP_CHORD_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SLAT_SPAN_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.FLAP_SPAN_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.LOADING, units='lbf/ft**2')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
+        add_aviary_input(self, Aircraft.Wing.CENTER_CHORD, units='ft')
+        add_aviary_input(self, Mission.Landing.LIFT_COEFFICIENT_MAX, units='unitless')
         self.add_input("density", val=RHO_SEA_LEVEL_ENGLISH, units='slug/ft**3',
                        desc='RHO: Density of air')
 
-        add_aviary_output(self, Aircraft.Wing.HIGH_LIFT_MASS)
+        add_aviary_output(self, Aircraft.Wing.HIGH_LIFT_MASS, units='lbm')
         self.add_output("flap_mass", val=0, units="lbm",
                         desc="WFLAP: mass of trailing edge devices")
         self.add_output("slat_mass", val=0, units="lbm",
@@ -1945,23 +1946,23 @@ class ControlMass(om.ExplicitComponent):
 
     def setup(self):
         add_aviary_input(
-            self, Aircraft.Wing.SURFACE_CONTROL_MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Wing.AREA)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR)
+            self, Aircraft.Wing.SURFACE_CONTROL_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR, units='unitless')
         self.add_input("min_dive_vel", val=700, units="kn", desc="VDMIN: dive velocity")
-        add_aviary_input(
-            self, Aircraft.Design.COCKPIT_CONTROL_MASS_COEFFICIENT)
-        add_aviary_input(
-            self, Aircraft.Controls.STABILITY_AUGMENTATION_SYSTEM_MASS)
-        add_aviary_input(self, Aircraft.Controls.COCKPIT_CONTROL_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER)
-        add_aviary_input(
-            self, Aircraft.Controls.STABILITY_AUGMENTATION_SYSTEM_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Controls.CONTROL_MASS_INCREMENT)
+        add_aviary_input(self, Aircraft.Design.COCKPIT_CONTROL_MASS_COEFFICIENT,
+                         units='unitless')
+        add_aviary_input(self, Aircraft.Controls.STABILITY_AUGMENTATION_SYSTEM_MASS,
+                         units='lbm')
+        add_aviary_input(self, Aircraft.Controls.COCKPIT_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Controls.STABILITY_AUGMENTATION_SYSTEM_MASS_SCALER,
+                         units='unitless')
+        add_aviary_input(self, Aircraft.Controls.CONTROL_MASS_INCREMENT, units='lbm')
 
-        add_aviary_output(self, Aircraft.Controls.TOTAL_MASS)
-        add_aviary_output(self, Aircraft.Wing.SURFACE_CONTROL_MASS)
+        add_aviary_output(self, Aircraft.Controls.TOTAL_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Wing.SURFACE_CONTROL_MASS, units='lbm')
 
         self.declare_partials(Aircraft.Controls.TOTAL_MASS, "*")
         self.declare_partials(
@@ -2173,16 +2174,18 @@ class GearMass(om.ExplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Aircraft.Wing.VERTICAL_MOUNT_LOCATION)
-        add_aviary_input(self, Aircraft.LandingGear.MASS_COEFFICIENT)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Nacelle.CLEARANCE_RATIO, shape=num_engine_type)
+        add_aviary_input(self, Aircraft.Wing.VERTICAL_MOUNT_LOCATION, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.LandingGear.MAIN_GEAR_MASS_COEFFICIENT,
+                         units='unitless')
+        add_aviary_input(self, Aircraft.Nacelle.CLEARANCE_RATIO,
+                         shape=num_engine_type, units='unitless')
         add_aviary_input(self, Aircraft.Nacelle.AVG_DIAMETER,
-                         shape=num_engine_type)
+                         shape=num_engine_type, units='ft')
 
-        add_aviary_output(self, Aircraft.LandingGear.TOTAL_MASS)
-        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS)
+        add_aviary_output(self, Aircraft.LandingGear.TOTAL_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.LandingGear.MAIN_GEAR_MASS, units='lbm')
 
         self.declare_partials(
             Aircraft.LandingGear.TOTAL_MASS, [

--- a/aviary/subsystems/mass/gasp_based/fixed.py
+++ b/aviary/subsystems/mass/gasp_based/fixed.py
@@ -521,7 +521,7 @@ class EngineMass(om.ExplicitComponent):
         add_aviary_input(self, Aircraft.Engine.PYLON_FACTOR,
                          shape=num_engine_type, units='unitless')
         add_aviary_input(self, Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
-                         val=np.full(num_engine_type, 0.0))
+                         val=np.full(num_engine_type, 0.14))
         add_aviary_input(self, Aircraft.Engine.MASS_SCALER,
                          shape=num_engine_type, units='unitless')
         add_aviary_input(self, Aircraft.Propulsion.MISC_MASS_SCALER, units='unitless')

--- a/aviary/subsystems/mass/gasp_based/fuel.py
+++ b/aviary/subsystems/mass/gasp_based/fuel.py
@@ -21,28 +21,28 @@ class BodyTankCalculations(om.ExplicitComponent):
 
     def setup(self):
 
-        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_DESIGN)
-        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_STRUCTURAL_MAX)
+        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_DESIGN, units='ft**3')
+        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_STRUCTURAL_MAX, units='ft**3')
         self.add_input("fuel_mass_min", val=2000, units="lbm",
                        desc="WFAMIN: minimum value of fuel mass (set when max payload is carried)")
-        add_aviary_input(self, Mission.Design.FUEL_MASS_REQUIRED)
+        add_aviary_input(self, Mission.Design.FUEL_MASS_REQUIRED, units='lbm')
         self.add_input("max_wingfuel_mass", val=6, units="lbm",
                        desc="WFWMX: maximum wingfuel mass")
-        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX)
+        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX, units='ft**3')
         add_aviary_input(self, Aircraft.Fuel.DENSITY, units="lbm/ft**3")
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Mission.Design.FUEL_MASS)
-        add_aviary_input(self, Aircraft.Design.OPERATING_MASS)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Mission.Design.FUEL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.OPERATING_MASS, units='lbm')
 
         # WFXTRA: extra amount of fuel that is required but does not fit in wings
-        add_aviary_output(self, Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY)
+        add_aviary_output(self, Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY, units='lbm')
         self.add_output("extra_fuel_volume", val=0, units="ft**3",
                         desc="FVOLXTRA: excess required design fuel volume (including fuel margin) greater than geometric fuel volume of wings")
         self.add_output("max_extra_fuel_mass", val=0, units="lbm",
                         desc="WFXTRAMX: mass of fuel that fits in extra_fuel_volume")
         self.add_output("wingfuel_mass_min", val=0, units="lbm",
                         desc="WFWMIN: minimum wing fuel mass")
-        add_aviary_output(self, Aircraft.Fuel.TOTAL_CAPACITY)
+        add_aviary_output(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm')
 
         self.declare_partials(Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY, [
                               Mission.Design.FUEL_MASS_REQUIRED, "max_wingfuel_mass"])
@@ -325,16 +325,16 @@ class FuelAndOEMOutputs(om.ExplicitComponent):
     def setup(self):
 
         add_aviary_input(self, Aircraft.Fuel.DENSITY, units="lbm/ft**3")
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Propulsion.MASS)
-        add_aviary_input(self, Aircraft.Controls.TOTAL_MASS)
-        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_input(self, Aircraft.Design.FIXED_EQUIPMENT_MASS)
-        add_aviary_input(self, Aircraft.Design.FIXED_USEFUL_LOAD)
-        add_aviary_input(self, Mission.Design.FUEL_MASS_REQUIRED)
-        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX)
-        add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN)
-        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Propulsion.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Controls.TOTAL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.FIXED_EQUIPMENT_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.FIXED_USEFUL_LOAD, units='lbm')
+        add_aviary_input(self, Mission.Design.FUEL_MASS_REQUIRED, units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX, units='ft**3')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.TOTAL_CAPACITY, units='lbm')
 
         self.add_output(
             "OEM_wingfuel_mass",
@@ -348,8 +348,8 @@ class FuelAndOEMOutputs(om.ExplicitComponent):
             units="ft**3",
             desc="FVOLW: wing tank fuel volume when carrying maximum fuel",
         )
-        add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_DESIGN)
-        add_aviary_output(self, Aircraft.Design.OPERATING_MASS)
+        add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_DESIGN, units='ft**3')
+        add_aviary_output(self, Aircraft.Design.OPERATING_MASS, units='lbm')
 
         self.add_output(
             "payload_mass_max_fuel",
@@ -366,7 +366,7 @@ class FuelAndOEMOutputs(om.ExplicitComponent):
         self.add_output(
             "max_wingfuel_mass", val=0, units="lbm", desc="WFWMX: maximum wingfuel mass"
         )
-        add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_STRUCTURAL_MAX)
+        add_aviary_output(self, Aircraft.Fuel.WING_VOLUME_STRUCTURAL_MAX, units='ft**3')
 
         self.declare_partials(
             "OEM_wingfuel_mass",
@@ -690,22 +690,22 @@ class FuelSysAndFullFuselageMass(om.ExplicitComponent):
 
     def setup(self):
 
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
 
-        add_aviary_input(self, Aircraft.Wing.MASS)
+        add_aviary_input(self, Aircraft.Wing.MASS, units='lbm')
         self.add_input("wing_mounted_mass", val=24446.343040697346, units="lbm",
                        desc="WM: mass of gear and engine (everything on wing that isn`t wing itself or fuel")
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Fuel.DENSITY)
-        add_aviary_input(self, Mission.Design.FUEL_MASS)
-        add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN)
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.DENSITY, units='lbm/galUS')
+        add_aviary_input(self, Mission.Design.FUEL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN, units='unitless')
         self.add_input("wingfuel_mass_min", val=32850, units="lbm",
                        desc="WFWMIN: minimum wing fuel mass")
 
         self.add_output("fus_mass_full", val=0, units="lbm",
                         desc="WX: mass of fuselage and contents, including empennage")
-        add_aviary_output(self, Aircraft.Fuel.FUEL_SYSTEM_MASS)
+        add_aviary_output(self, Aircraft.Fuel.FUEL_SYSTEM_MASS, units='lbm')
 
         self.declare_partials(
             Aircraft.Fuel.FUEL_SYSTEM_MASS,
@@ -811,33 +811,34 @@ class FuselageAndStructMass(om.ExplicitComponent):
 
         self.add_input("fus_mass_full", val=4000, units="lbm",
                        desc="WX: mass of fuselage and contents, including empennage")
-        add_aviary_input(self, Aircraft.Fuselage.MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA)
-        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER)
-        add_aviary_input(self, Aircraft.TailBoom.LENGTH)
+        add_aviary_input(self, Aircraft.Fuselage.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuselage.WETTED_AREA, units='ft**2')
+        add_aviary_input(self, Aircraft.Fuselage.AVG_DIAMETER, units='ft')
+        add_aviary_input(self, Aircraft.TailBoom.LENGTH, units='ft')
         self.add_input("pylon_len", val=0, units="ft",
                        desc="ELRW: length of pylon for fuselage mounted engines")
         self.add_input("min_dive_vel", val=419.75918333, units="kn",
                        desc="VDMIN: dive velocity")
-        add_aviary_input(self, Aircraft.Fuselage.PRESSURE_DIFFERENTIAL)
-        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR)
+        add_aviary_input(self, Aircraft.Fuselage.PRESSURE_DIFFERENTIAL, units='psi')
+        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR, units='unitless')
         self.add_input("MAT", val=0, units="lbm",
                        desc="WAT: Weight of the Fuselage Acoustic Treatment")
-        add_aviary_input(self, Aircraft.Wing.MASS_SCALER)
-        add_aviary_input(self, Aircraft.Wing.MASS)
-        add_aviary_input(self, Aircraft.HorizontalTail.MASS_SCALER)
-        add_aviary_input(self, Aircraft.HorizontalTail.MASS)
-        add_aviary_input(self, Aircraft.VerticalTail.MASS_SCALER)
-        add_aviary_input(self, Aircraft.VerticalTail.MASS)
-        add_aviary_input(self, Aircraft.Fuselage.MASS_SCALER)
-        add_aviary_input(self, Aircraft.LandingGear.TOTAL_MASS_SCALER)
-        add_aviary_input(self, Aircraft.LandingGear.TOTAL_MASS)
-        add_aviary_input(self, Aircraft.Engine.POD_MASS_SCALER, shape=num_engine_type)
-        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_POD_MASS)
-        add_aviary_input(self, Aircraft.Design.STRUCTURAL_MASS_INCREMENT)
+        add_aviary_input(self, Aircraft.Wing.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.HorizontalTail.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.HorizontalTail.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.VerticalTail.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.VerticalTail.MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuselage.MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.TOTAL_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.LandingGear.TOTAL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Engine.POD_MASS_SCALER,
+                         shape=num_engine_type, units='unitless')
+        add_aviary_input(self, Aircraft.Propulsion.TOTAL_ENGINE_POD_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.STRUCTURAL_MASS_INCREMENT, units='lbm')
 
-        add_aviary_output(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_output(self, Aircraft.Fuselage.MASS)
+        add_aviary_output(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Fuselage.MASS, units='lbm')
 
         self.declare_partials(
             Aircraft.Fuselage.MASS,
@@ -1130,29 +1131,29 @@ class FuelMass(om.ExplicitComponent):
 
     def setup(self):
 
-        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS)
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS)
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
+        add_aviary_input(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS, units='lbm')
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
         self.add_input("eng_comb_mass", val=14371.0, units="lbm",
                        desc="WPSTAR: mass of dry engine and engine installation. Includes mass of electrical augmentation system.")
-        add_aviary_input(self, Aircraft.Controls.TOTAL_MASS)
-        add_aviary_input(self, Aircraft.Design.FIXED_EQUIPMENT_MASS)
-        add_aviary_input(self, Aircraft.Design.FIXED_USEFUL_LOAD)
+        add_aviary_input(self, Aircraft.Controls.TOTAL_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.FIXED_EQUIPMENT_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Design.FIXED_USEFUL_LOAD, units='lbm')
         self.add_input("payload_mass_des", val=36000, units="lbm",
                        desc="WPLDES: design payload")
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER)
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Fuel.DENSITY)
-        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS)
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.DENSITY, units='lbm/galUS')
+        add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS, units='lbm')
 
         self.add_input("payload_mass_max", val=46040, units="lbm",
                        desc="WPLMAX: maximum payload that the aircraft is being asked to carry (design payload + cargo)")
 
-        add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN)
+        add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN, units='unitless')
 
-        add_aviary_output(self, Mission.Design.FUEL_MASS)
-        add_aviary_output(self, Aircraft.Propulsion.MASS)
-        add_aviary_output(self, Mission.Design.FUEL_MASS_REQUIRED)
+        add_aviary_output(self, Mission.Design.FUEL_MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Propulsion.MASS, units='lbm')
+        add_aviary_output(self, Mission.Design.FUEL_MASS_REQUIRED, units='lbm')
         self.add_output("fuel_mass_min", val=0, units="lbm",
                         desc="WFAMIN: minimum value of fuel mass (set when max payload is carried)")
 

--- a/aviary/subsystems/mass/gasp_based/fuel.py
+++ b/aviary/subsystems/mass/gasp_based/fuel.py
@@ -696,7 +696,8 @@ class FuelSysAndFullFuselageMass(om.ExplicitComponent):
         self.add_input("wing_mounted_mass", val=24446.343040697346, units="lbm",
                        desc="WM: mass of gear and engine (everything on wing that isn`t wing itself or fuel")
         add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER, units='unitless')
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Fuel.DENSITY, units='lbm/galUS')
         add_aviary_input(self, Mission.Design.FUEL_MASS, units='lbm')
         add_aviary_input(self, Aircraft.Fuel.FUEL_MARGIN, units='unitless')
@@ -1142,7 +1143,8 @@ class FuelMass(om.ExplicitComponent):
         self.add_input("payload_mass_des", val=36000, units="lbm",
                        desc="WPLDES: design payload")
         add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_SCALER, units='unitless')
-        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Fuel.FUEL_SYSTEM_MASS_COEFFICIENT,
+                         units='unitless')
         add_aviary_input(self, Aircraft.Fuel.DENSITY, units='lbm/galUS')
         add_aviary_input(self, Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS, units='lbm')
 

--- a/aviary/subsystems/mass/gasp_based/test/test_fixed.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fixed.py
@@ -427,6 +427,7 @@ class EngineTestCase1(unittest.TestCase):  # this is the large single aisle 1 V3
         options = get_option_defaults()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM,
                         val=False, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -449,9 +450,6 @@ class EngineTestCase1(unittest.TestCase):  # this is the large single aisle 1 V3
         )  # bug fixed value and original value
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )  # bug fixed value and original value
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
         )  # bug fixed value and original value
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless"
@@ -503,6 +501,7 @@ class EngineTestCase2(unittest.TestCase):
 
         options = get_option_defaults()
         options.set_val(Aircraft.Engine.HAS_PROPELLERS, val=[True], units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -525,9 +524,6 @@ class EngineTestCase2(unittest.TestCase):
         )  # bug fixed value and original value
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )  # bug fixed value and original value
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
         )  # bug fixed value and original value
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless"
@@ -593,6 +589,7 @@ class EngineTestCaseMultiEngine(unittest.TestCase):
 
         options.set_val(Aircraft.Engine.NUM_ENGINES, np.array([2, 4]))
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 6)
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, np.array([0.14, 0.19]))
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -611,8 +608,6 @@ class EngineTestCaseMultiEngine(unittest.TestCase):
             Aircraft.Nacelle.SURFACE_AREA, val=[339.58, 235.66], units="ft**2")
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=[1.25, 1.28], units="unitless")
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=[0.14, 0.19], units="unitless")
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=[1, 0.9], units="unitless")
         self.prob.model.set_input_defaults(
@@ -1009,6 +1004,7 @@ class FixedMassGroupTestCase1(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.PASSENGER_MASS_WITH_BAGS,
                         val=200, units="lbm")  # bug fixed value and original value
         options.set_val(Settings.VERBOSITY, 0)
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1166,9 +1162,6 @@ class FixedMassGroupTestCase1(unittest.TestCase):
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
         )  # bug fixed value and original value
         self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
-        )  # bug fixed value and original value
-        self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless"
         )  # bug fixed value and original value
         self.prob.model.set_input_defaults(
@@ -1276,6 +1269,7 @@ class FixedMassGroupTestCase2(unittest.TestCase):
                         val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.PASSENGER_MASS_WITH_BAGS,
                         val=200, units="lbm")  # bug fixed value and original value
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1479,9 +1473,6 @@ class FixedMassGroupTestCase2(unittest.TestCase):
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
         )  # bug fixed value and original value
         self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
-        )  # bug fixed value and original value
-        self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless"
         )  # bug fixed value and original value
         # self.prob.model.set_input_defaults(
@@ -1636,10 +1627,10 @@ class FixedMassGroupTestCase3(unittest.TestCase):
     def test_case1(self):
 
         data = AviaryValues({
-            Aircraft.Engine.NUM_ENGINES: ([2], 'unitless'),
+            Aircraft.Engine.NUM_ENGINES: (np.array([2]), 'unitless'),
             Aircraft.Propulsion.TOTAL_NUM_ENGINES: (2, 'unitless'),
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES: (False, 'unitless'),
-            Aircraft.Engine.NUM_FUSELAGE_ENGINES: (0, 'unitless'),
+            Aircraft.Engine.NUM_FUSELAGE_ENGINES: (np.array([0]), 'unitless'),
             Aircraft.CrewPayload.NUM_PASSENGERS: (150, 'unitless'),
             Aircraft.CrewPayload.Design.NUM_PASSENGERS: (150, 'unitless'),
             Aircraft.Electrical.HAS_HYBRID_SYSTEM: (False, 'unitless'),
@@ -1667,15 +1658,15 @@ class FixedMassGroupTestCase3(unittest.TestCase):
             'motor_spec_mass': (10.0, 'hp/lbm'),
             'inverter_spec_mass': (10.5, 'kW/lbm'),
             'TMS_spec_mass': (10.6, 'lbm/kW'),
-            Aircraft.Engine.MASS_SPECIFIC: (0.21366, 'lbm/lbf'),
-            Aircraft.Engine.SCALED_SLS_THRUST: (4000.0, 'lbf'),
+            Aircraft.Engine.MASS_SPECIFIC: (np.array([0.21366]), 'lbm/lbf'),
+            Aircraft.Engine.SCALED_SLS_THRUST: (np.array([4000.0]), 'lbf'),
             Aircraft.Nacelle.MASS_SPECIFIC: (3.0, 'lbm/ft**2'),
             Aircraft.Nacelle.SURFACE_AREA: (5.0, 'ft**2'),
-            Aircraft.Engine.PYLON_FACTOR: (1.25, 'unitless'),
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION: (0.14, 'unitless'),
-            Aircraft.Engine.MASS_SCALER: (1.05, 'unitless'),
+            Aircraft.Engine.PYLON_FACTOR: (np.array([1.25]), 'unitless'),
+            Aircraft.Engine.ADDITIONAL_MASS_FRACTION: (np.array([0.14]), 'unitless'),
+            Aircraft.Engine.MASS_SCALER: (np.array([1.05]), 'unitless'),
             Aircraft.Propulsion.MISC_MASS_SCALER: (1.06, 'unitless'),
-            Aircraft.Engine.WING_LOCATIONS: (0.35, 'unitless'),
+            Aircraft.Engine.WING_LOCATIONS: (np.array([0.35]), 'unitless'),
             'prop_mass': (0.5, 'lbm'),
             Aircraft.VerticalTail.TAPER_RATIO: (0.26, 'unitless'),
             Aircraft.VerticalTail.ASPECT_RATIO: (5.0, 'unitless'),
@@ -1752,6 +1743,6 @@ class FixedMassGroupTestCase3(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-    # test = GearTestCaseMultiengine()
-    # test = EngineTestCaseMultiEngine()
-    # test.test_case_1()
+    # test = FixedMassGroupTestCase3()
+    # test.setUp()
+    # test.test_case1()

--- a/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
@@ -192,7 +192,8 @@ class MassSummationTestCase2(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -582,7 +583,8 @@ class MassSummationTestCase3(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -964,7 +966,8 @@ class MassSummationTestCase4(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1347,7 +1350,8 @@ class MassSummationTestCase5(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1729,7 +1733,8 @@ class MassSummationTestCase6(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -2112,7 +2117,8 @@ class MassSummationTestCase7(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.165, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.165, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -2507,7 +2513,8 @@ class MassSummationTestCase8(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 44.2, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.163, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.163, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -2906,7 +2913,8 @@ class MassSummationTestCase9(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 44.2, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
-        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.163, units='unitless')
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
+                        0.163, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
@@ -53,8 +53,6 @@ class MassSummationTestCase1(unittest.TestCase):
             Aircraft.Fuselage.WETTED_AREA_SCALER, val=0.86215, units="unitless")
         self.prob.model.set_input_defaults(Aircraft.Wing.SLAT_CHORD_RATIO, val=.15)
         self.prob.model.set_input_defaults(Aircraft.Wing.SLAT_SPAN_RATIO, val=.9)
-        self.prob.model.set_input_defaults(Aircraft.Engine.ADDITIONAL_MASS_FRACTION,
-                                           val=0.14)
 
         setup_model_options(self.prob, V3_bug_fixed_options)
 
@@ -194,6 +192,7 @@ class MassSummationTestCase2(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -360,9 +359,6 @@ class MassSummationTestCase2(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")
@@ -586,6 +582,7 @@ class MassSummationTestCase3(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -754,9 +751,6 @@ class MassSummationTestCase3(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")
@@ -970,6 +964,7 @@ class MassSummationTestCase4(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1138,9 +1133,6 @@ class MassSummationTestCase4(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")
@@ -1355,6 +1347,7 @@ class MassSummationTestCase5(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1523,9 +1516,6 @@ class MassSummationTestCase5(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")
@@ -1739,6 +1729,7 @@ class MassSummationTestCase6(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1907,9 +1898,6 @@ class MassSummationTestCase6(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.14, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")
@@ -2124,6 +2112,7 @@ class MassSummationTestCase7(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 29, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.165, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -2292,9 +2281,6 @@ class MassSummationTestCase7(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.165, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")
@@ -2521,6 +2507,7 @@ class MassSummationTestCase8(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 44.2, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.163, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -2648,9 +2635,6 @@ class MassSummationTestCase8(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.163, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")
@@ -2922,6 +2906,7 @@ class MassSummationTestCase9(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.NUM_AISLES, 1)
         options.set_val(Aircraft.Fuselage.SEAT_PITCH, 44.2, units="inch")
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH, 20.2, units="inch")
+        options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.163, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -3049,9 +3034,6 @@ class MassSummationTestCase9(unittest.TestCase):
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.PYLON_FACTOR, val=1.25, units="unitless"
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Engine.ADDITIONAL_MASS_FRACTION, val=0.163, units="unitless"
         )
         self.prob.model.set_input_defaults(
             Aircraft.Engine.MASS_SCALER, val=1, units="unitless")

--- a/aviary/subsystems/mass/gasp_based/wing.py
+++ b/aviary/subsystems/mass/gasp_based/wing.py
@@ -18,19 +18,19 @@ class WingMassSolve(om.ImplicitComponent):
     def setup(self):
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
 
-        add_aviary_input(self, Mission.Design.GROSS_MASS)
-        add_aviary_input(self, Aircraft.Wing.HIGH_LIFT_MASS)
+        add_aviary_input(self, Mission.Design.GROSS_MASS, units='lbm')
+        add_aviary_input(self, Aircraft.Wing.HIGH_LIFT_MASS, units='lbm')
         self.add_input("c_strut_braced", val=1.00000001, units="unitless",
                        desc="SKSTR: reduction in bending moment factor for strut braced wing")
-        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR)
-        add_aviary_input(self, Aircraft.Wing.MASS_COEFFICIENT)
-        add_aviary_input(self, Aircraft.Wing.MATERIAL_FACTOR)
+        add_aviary_input(self, Aircraft.Wing.ULTIMATE_LOAD_FACTOR, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.MASS_COEFFICIENT, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.MATERIAL_FACTOR, units='unitless')
         add_aviary_input(self, Aircraft.Engine.POSITION_FACTOR, shape=num_engine_type)
         self.add_input("c_gear_loc", val=1.000000001, units="unitless",
                        desc="SKGEAR: landing gear location factor")
-        add_aviary_input(self, Aircraft.Wing.SPAN)
-        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO)
-        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT)
+        add_aviary_input(self, Aircraft.Wing.SPAN, units='ft')
+        add_aviary_input(self, Aircraft.Wing.TAPER_RATIO, units='unitless')
+        add_aviary_input(self, Aircraft.Wing.THICKNESS_TO_CHORD_ROOT, units='unitless')
         self.add_input("half_sweep", val=0.3947081519, units="rad",
                        desc="SWC2: wing half-chord sweep angle")
 
@@ -285,16 +285,16 @@ class WingMassTotal(om.ExplicitComponent):
                        desc="WW: wing mass including high lift devices (but excluding struts and fold effects)")
 
         if self.options[Aircraft.Wing.HAS_STRUT]:
-            add_aviary_input(self, Aircraft.Strut.MASS_COEFFICIENT)
+            add_aviary_input(self, Aircraft.Strut.MASS_COEFFICIENT, units='unitless')
 
         if self.options[Aircraft.Wing.HAS_FOLD]:
-            add_aviary_input(self, Aircraft.Wing.AREA)
-            add_aviary_input(self, Aircraft.Wing.FOLDING_AREA)
-            add_aviary_input(self, Aircraft.Wing.FOLD_MASS_COEFFICIENT)
+            add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
+            add_aviary_input(self, Aircraft.Wing.FOLDING_AREA, units='ft**2')
+            add_aviary_input(self, Aircraft.Wing.FOLD_MASS_COEFFICIENT, units='unitless')
 
-        add_aviary_output(self, Aircraft.Wing.MASS)
-        add_aviary_output(self, Aircraft.Strut.MASS)
-        add_aviary_output(self, Aircraft.Wing.FOLD_MASS)
+        add_aviary_output(self, Aircraft.Wing.MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Strut.MASS, units='lbm')
+        add_aviary_output(self, Aircraft.Wing.FOLD_MASS, units='lbm')
 
         self.declare_partials(Aircraft.Wing.MASS, "*")
         if self.options[Aircraft.Wing.HAS_STRUT]:


### PR DESCRIPTION
### Summary

This is to respond to issue #680: All Aviary components should explicitly declare units in their add_aviary_input/output calls. This will help make it clear to the reader what units the calculation are in. This PR adds units to all components in geometry and mass subsystems.

### Related Issues

- Resolves #680

### Backwards incompatibilities

None

### New Dependencies

None