### PR TITLE
Fix a bug in the engine builder mission where the aviary_options argument was accidentally replaced with the engine_options.

### DIFF
--- a/aviary/subsystems/propulsion/propulsion_mission.py
+++ b/aviary/subsystems/propulsion/propulsion_mission.py
@@ -91,15 +91,15 @@ class PropulsionMission(om.Group):
             )
 
             for i, engine in enumerate(engine_models):
-                options = {}
+                kwargs = {}
                 if engine.name in engine_options:
-                    options = engine_options[engine.name]
+                    kwargs = engine_options[engine.name]
                 self.add_subsystem(
                     engine.name,
                     subsys=engine.build_mission(
                         num_nodes=nn,
                         aviary_inputs=options,
-                        **options
+                        **kwargs
                     ),
                     promotes_inputs=['*'],
                 )
@@ -130,15 +130,15 @@ class PropulsionMission(om.Group):
                     )
         else:
             engine = engine_models[0]
-            options = {}
+            kwargs = {}
             if engine.name in engine_options:
-                options = engine_options[engine.name]
+                kwargs = engine_options[engine.name]
             self.add_subsystem(
                 engine.name,
                 subsys=engine.build_mission(
                     num_nodes=nn,
                     aviary_inputs=options,
-                    **options
+                    **kwargs
                 ),
                 promotes_inputs=['*'],
             )


### PR DESCRIPTION
### Summary

Fixes a bug reported by Mark Leader where he was seeing an exception because the aviary_options was accidentally replaced by a new dictionary of engine options.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None