### PR TITLE
added use_tempdir to unit tests

### DIFF
--- a/aviary/interface/test/test_phase_info.py
+++ b/aviary/interface/test/test_phase_info.py
@@ -6,6 +6,7 @@ import unittest
 from copy import deepcopy
 
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.interface.default_phase_info.two_dof import phase_info as ph_in_two_dof
 from aviary.interface.default_phase_info.two_dof import phase_info_parameterization as phase_info_parameterization_two_dof
@@ -80,6 +81,7 @@ class TestPhaseInfo(unittest.TestCase):
         self._test_phase_info_dict(local_phase_info, 'cruise')
 
 
+@use_tempdirs
 class TestParameterizePhaseInfo(unittest.TestCase):
 
     def test_phase_info_parameterization_two_dof(self):

--- a/aviary/mission/flops_based/phases/test/test_time_integration_phases.py
+++ b/aviary/mission/flops_based/phases/test/test_time_integration_phases.py
@@ -4,6 +4,7 @@ import importlib
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.interface.default_phase_info.height_energy_fiti import add_default_sgm_args
 from aviary.interface.methods_for_level2 import AviaryGroup
@@ -21,6 +22,7 @@ from aviary.variable_info.variable_meta_data import _MetaData as BaseMetaData
 from aviary.variable_info.variables import Aircraft, Dynamic, Mission, Settings
 
 
+@use_tempdirs
 @unittest.skipUnless(importlib.util.find_spec("pyoptsparse") is not None, "pyoptsparse is not installed")
 class HE_SGMDescentTestCase(unittest.TestCase):
     """

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.interface.default_phase_info.height_energy import phase_info
 from aviary.interface.methods_for_level2 import AviaryProblem
@@ -31,6 +32,7 @@ CDI_table = "subsystems/aerodynamics/flops_based/test/large_single_aisle_1_CDI_p
 CD0_table = "subsystems/aerodynamics/flops_based/test/large_single_aisle_1_CD0_polar.csv"
 
 
+@use_tempdirs
 class TabularAeroGroupFileTest(unittest.TestCase):
     # Test drag comp with data from file, structured grid
     def setUp(self):
@@ -127,6 +129,7 @@ class TabularAeroGroupFileTest(unittest.TestCase):
         assert_near_equal(wing_area, actual_wing_area)
 
 
+@use_tempdirs
 class TabularAeroGroupDataTest(unittest.TestCase):
     # Test tabular drag comp with training data, structured grid
     def setUp(self):

--- a/aviary/subsystems/aerodynamics/test/test_external_mission_aero.py
+++ b/aviary/subsystems/aerodynamics/test/test_external_mission_aero.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 import unittest
 
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import require_pyoptsparse
+from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 
 import aviary.api as av
 from aviary.examples.external_subsystems.custom_aero.custom_aero_builder import CustomAeroBuilder
@@ -10,6 +10,7 @@ from aviary.examples.external_subsystems.custom_aero.custom_aero_builder import 
 phase_info = deepcopy(av.default_height_energy_phase_info)
 
 
+@use_tempdirs
 class TestBattery(av.TestSubsystemBuilderBase):
     """
     Test replacing internal drag calculation with an external subsystem.

--- a/aviary/subsystems/test/test_external_subsystem_bus.py
+++ b/aviary/subsystems/test/test_external_subsystem_bus.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.interface.default_phase_info.height_energy import phase_info as ph_in
 from aviary.interface.methods_for_level2 import AviaryProblem
@@ -79,6 +80,7 @@ class CustomBuilder(SubsystemBuilderBase):
         return vars_to_connect
 
 
+@use_tempdirs
 class TestExternalSubsystemBus(unittest.TestCase):
 
     def test_external_subsystem_bus(self):


### PR DESCRIPTION
### Summary

This PR is a solution to issue #503 "Stop generation of reports during testing".
I added use_tempdir wherever needed to avoid output directories during testflo runs

### Related Issues

- Resolves #503 

### Backwards incompatibilities

None

### New Dependencies

None