### PR TITLE
Fixed throttle_enforcement type check

### DIFF
--- a/aviary/interface/utils/check_phase_info.py
+++ b/aviary/interface/utils/check_phase_info.py
@@ -24,7 +24,7 @@ common_entries = {
     'initial_altitude': tuple,
     'final_altitude': tuple,
     'altitude_bounds': tuple,
-    'throttle_enforcement': str,
+    'throttle_enforcement': (str, type(None)),
     'constrain_final': bool,
     'fix_duration': bool,
     'initial_bounds': tuple,


### PR DESCRIPTION
### Summary

Users should be able to set `throttle_enforcement=None` in phase_info to not enforce the throttle bounds [as defined here](https://github.com/OpenMDAO/Aviary/blob/1db0453089d873474cf164f670c71726fd119840/aviary/mission/flops_based/ode/energy_ODE.py#L38), but currently the phase info check enforces "throttle_enforcement" to be str. This PR modifies the check to also allow None.

### Related Issues

### Backwards incompatibilities

None

### New Dependencies

None