### PR TITLE
Adding parallel phase flag to `add_phases`

### DIFF
--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -577,7 +577,8 @@ class AviaryProblem(om.Problem):
 
         if self.analysis_scheme is AnalysisScheme.COLLOCATION:
             phases = list(phase_info.keys())
-            traj = self.model.add_subsystem('traj', dm.Trajectory(parallel_phases=parallel_phases))
+            traj = self.model.add_subsystem(
+                'traj', dm.Trajectory(parallel_phases=parallel_phases))
 
         elif self.analysis_scheme is AnalysisScheme.SHOOTING:
             vb = self.aviary_inputs.get_val(Settings.VERBOSITY)

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -552,7 +552,7 @@ class AviaryProblem(om.Problem):
 
         return phase
 
-    def add_phases(self, phase_info_parameterization=None):
+    def add_phases(self, phase_info_parameterization=None, parallel_phases=True):
         """
         Add the mission phases to the problem trajectory based on the user-specified
         phase_info dictionary.
@@ -561,6 +561,9 @@ class AviaryProblem(om.Problem):
         ----------
         phase_info_parameterization (function, optional): A function that takes in the phase_info dictionary
             and aviary_inputs and returns modified phase_info. Defaults to None.
+
+        parallel_phases (bool, optional): If True, the top-level container of all phases will be a ParallelGroup,
+            otherwise it will be a standard OpenMDAO Group. Defaults to True.
 
         Returns
         -------
@@ -574,7 +577,7 @@ class AviaryProblem(om.Problem):
 
         if self.analysis_scheme is AnalysisScheme.COLLOCATION:
             phases = list(phase_info.keys())
-            traj = self.model.add_subsystem('traj', dm.Trajectory())
+            traj = self.model.add_subsystem('traj', dm.Trajectory(parallel_phases=parallel_phases))
 
         elif self.analysis_scheme is AnalysisScheme.SHOOTING:
             vb = self.aviary_inputs.get_val(Settings.VERBOSITY)

--- a/aviary/interface/test/test_interface_bugs.py
+++ b/aviary/interface/test/test_interface_bugs.py
@@ -99,6 +99,43 @@ class PreMissionGroupTest(unittest.TestCase):
 
         prob.setup()
 
+    def test_serial_phase_group(self):
+        phase_info = deepcopy(ph_in)
+        phase_info['post_mission'] = {}
+        phase_info['post_mission']['include_landing'] = False
+        phase_info['post_mission']['external_subsystems'] = [
+            WingWeightBuilder(name="wing_external")
+        ]
+
+        prob = AviaryProblem()
+
+        csv_path = get_aviary_resource_path(
+            'models/test_aircraft/aircraft_for_bench_GwFm.csv'
+        )
+        prob.load_inputs(csv_path, phase_info)
+
+        # Preprocess inputs
+        prob.check_and_preprocess_inputs()
+
+        prob.add_pre_mission_systems()
+
+        prob.add_phases(parallel_phases=False)
+
+        prob.add_post_mission_systems()
+
+        # Link phases and variables
+        prob.link_phases()
+
+        prob.add_driver("SLSQP", verbosity=0)
+
+        prob.add_design_variables()
+
+        prob.add_objective(objective_type="mass", ref=-1e5)
+
+        prob.setup()
+
+        assert not isinstance(prob.traj.phases, om.ParallelGroup)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary

Adding flag to optionally force phase group to be serial when calling `add_phases`. Defaults to `True` (phases group is a ParallelGroup), which is already the dymos default.

### Related Issues

- Resolves #682

### Backwards incompatibilities

None

### New Dependencies

None