### PR TITLE
Groundwork for aero builder overhauls

### DIFF
--- a/aviary/interface/test/sizing_problem_for_test.json
+++ b/aviary/interface/test/sizing_problem_for_test.json
@@ -1275,6 +1275,12 @@
         "<enum 'EquationsOfMotion'>"
     ],
     [
+        "settings:aerodynamics_method",
+        "[<LegacyCode.FLOPS: 'FLOPS'>]",
+        "unitless",
+        "<enum 'LegacyCode'>"
+    ],
+    [
         "settings:mass_method",
         "[<LegacyCode.FLOPS: 'FLOPS'>]",
         "unitless",

--- a/aviary/models/N3CC/N3CC_FLOPS.csv
+++ b/aviary/models/N3CC/N3CC_FLOPS.csv
@@ -168,6 +168,7 @@ mission:takeoff:spoiler_drag_coefficient,0.085,unitless
 mission:takeoff:spoiler_lift_coefficient,-0.81,unitless
 mission:takeoff:thrust_incidence,0,deg
 settings:equations_of_motion,height_energy
+settings:aerodynamics_method,FLOPS
 settings:mass_method,FLOPS
 
 # Unconverted Values

--- a/aviary/models/N3CC/N3CC_data.py
+++ b/aviary/models/N3CC/N3CC_data.py
@@ -303,6 +303,7 @@ inputs.set_val(Mission.Takeoff.FUEL_SIMPLE, 577., 'lbm')
 # Settings
 # ---------------------------
 inputs.set_val(Settings.EQUATIONS_OF_MOTION, EquationsOfMotion.HEIGHT_ENERGY)
+inputs.set_val(Settings.AERODYNAMICS_METHOD, LegacyCode.FLOPS)
 inputs.set_val(Settings.MASS_METHOD, LegacyCode.FLOPS)
 inputs.set_val(Settings.VERBOSITY, 0)
 inputs.set_val(Settings.PROBLEM_TYPE, ProblemType.SIZING)

--- a/aviary/models/large_single_aisle_1/large_single_aisle_1_GASP.csv
+++ b/aviary/models/large_single_aisle_1/large_single_aisle_1_GASP.csv
@@ -155,6 +155,7 @@ mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h
 settings:equations_of_motion,2DOF
+settings:aerodynamics_method,GASP
 settings:mass_method,GASP
 
 # Initialization Guesses

--- a/aviary/models/large_single_aisle_2/large_single_aisle_2_FLOPS_data.py
+++ b/aviary/models/large_single_aisle_2/large_single_aisle_2_FLOPS_data.py
@@ -254,6 +254,7 @@ inputs.set_val(Mission.Design.THRUST_TAKEOFF_PER_ENG, 27301.0, 'lbf')
 # Settings
 # ---------------------------
 inputs.set_val(Settings.EQUATIONS_OF_MOTION, EquationsOfMotion.HEIGHT_ENERGY)
+inputs.set_val(Settings.AERODYNAMICS_METHOD, LegacyCode.FLOPS)
 inputs.set_val(Settings.MASS_METHOD, LegacyCode.FLOPS)
 
 # ---------------------------

--- a/aviary/models/large_single_aisle_2/large_single_aisle_2_altwt_FLOPS_data.py
+++ b/aviary/models/large_single_aisle_2/large_single_aisle_2_altwt_FLOPS_data.py
@@ -254,6 +254,7 @@ inputs.set_val(Mission.Design.THRUST_TAKEOFF_PER_ENG, 27301.0, 'lbf')
 # Settings
 # ---------------------------
 inputs.set_val(Settings.EQUATIONS_OF_MOTION, EquationsOfMotion.HEIGHT_ENERGY)
+inputs.set_val(Settings.AERODYNAMICS_METHOD, LegacyCode.FLOPS)
 inputs.set_val(Settings.MASS_METHOD, LegacyCode.FLOPS)
 
 # ---------------------------

--- a/aviary/models/large_single_aisle_2/large_single_aisle_2_detailwing_FLOPS_data.py
+++ b/aviary/models/large_single_aisle_2/large_single_aisle_2_detailwing_FLOPS_data.py
@@ -249,6 +249,7 @@ inputs.set_val(Mission.Design.THRUST_TAKEOFF_PER_ENG, 24555.5, 'lbf')
 # Settings
 # ---------------------------
 inputs.set_val(Settings.EQUATIONS_OF_MOTION, EquationsOfMotion.HEIGHT_ENERGY)
+inputs.set_val(Settings.AERODYNAMICS_METHOD, LegacyCode.FLOPS)
 inputs.set_val(Settings.MASS_METHOD, LegacyCode.FLOPS)
 
 # ---------------------------

--- a/aviary/models/large_turboprop_freighter/large_turboprop_freighter_GASP.csv
+++ b/aviary/models/large_turboprop_freighter/large_turboprop_freighter_GASP.csv
@@ -3,6 +3,7 @@
 ############
 settings:problem_type, fallout, unitless
 settings:equations_of_motion, 2DOF
+settings:aerodynamics_method, GASP
 settings:mass_method, GASP
 
 ############

--- a/aviary/models/multi_engine_single_aisle/multi_engine_single_aisle_data.py
+++ b/aviary/models/multi_engine_single_aisle/multi_engine_single_aisle_data.py
@@ -287,6 +287,7 @@ inputs.set_val(Mission.Design.THRUST_TAKEOFF_PER_ENG, 24555.5, 'lbf')
 # Settings
 # ---------------------------
 inputs.set_val(Settings.EQUATIONS_OF_MOTION, EquationsOfMotion.HEIGHT_ENERGY)
+inputs.set_val(Settings.AERODYNAMICS_METHOD, LegacyCode.FLOPS)
 inputs.set_val(Settings.MASS_METHOD, LegacyCode.FLOPS)
 inputs.set_val(Settings.VERBOSITY, 0)
 

--- a/aviary/models/small_single_aisle/small_single_aisle_GASP.csv
+++ b/aviary/models/small_single_aisle/small_single_aisle_GASP.csv
@@ -155,6 +155,7 @@ mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.3333,h
 settings:equations_of_motion,2DOF
+settings:aerodynamics_method,GASP
 settings:mass_method,GASP
 
 # Initialization Guesses

--- a/aviary/models/test_aircraft/aircraft_for_bench_FwFm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_FwFm.csv
@@ -154,4 +154,5 @@ mission:takeoff:fuel_simple,577,lbm
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless
 settings:equations_of_motion,height_energy
+settings:aerodynamics_method,FLOPS
 settings:mass_method,FLOPS

--- a/aviary/models/test_aircraft/aircraft_for_bench_FwFm_with_electric.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_FwFm_with_electric.csv
@@ -154,4 +154,5 @@ mission:takeoff:fuel_simple,577,lbm
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless
 settings:equations_of_motion,height_energy
+settings:aerodynamics_method,FLOPS
 settings:mass_method,FLOPS

--- a/aviary/models/test_aircraft/aircraft_for_bench_FwGm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_FwGm.csv
@@ -251,6 +251,7 @@ mission:takeoff:lift_over_drag,17.354,unitless
 mission:takeoff:rolling_friction_coefficient,0.0175,unitless
 aircraft:fuel:burn_per_passenger_mile,0.1
 settings:equations_of_motion,2DOF
+settings:aerodynamics_method,GASP
 settings:mass_method,FLOPS
 
 # Initialization Guesses

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwFm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwFm.csv
@@ -277,5 +277,5 @@ mission:takeoff:lift_coefficient_flap_increment,0.4182,unitless
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless
 settings:equations_of_motion,height_energy
-settings:aerodynamics_method,GASP
+settings:aerodynamics_method,FLOPS
 settings:mass_method,GASP

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwFm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwFm.csv
@@ -277,4 +277,5 @@ mission:takeoff:lift_coefficient_flap_increment,0.4182,unitless
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless
 settings:equations_of_motion,height_energy
+settings:aerodynamics_method,GASP
 settings:mass_method,GASP

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm.csv
@@ -156,6 +156,7 @@ mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h
 settings:equations_of_motion,2DOF
+settings:aerodynamics_method,GASP
 settings:mass_method,GASP
 
 # Initialization Guesses

--- a/aviary/models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_GwGm_lbm_s.csv
@@ -155,6 +155,7 @@ mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h
 settings:equations_of_motion,2DOF
+settings:aerodynamics_method,GASP
 settings:mass_method,GASP
 
 # Initialization Guesses

--- a/aviary/models/test_aircraft/aircraft_for_bench_solved2dof.csv
+++ b/aviary/models/test_aircraft/aircraft_for_bench_solved2dof.csv
@@ -154,4 +154,5 @@ mission:takeoff:fuel_simple,577,lbm
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless
 settings:equations_of_motion,solved_2DOF
+settings:aerodynamics_method,FLOPS
 settings:mass_method,FLOPS

--- a/aviary/models/test_aircraft/configuration_test_GASP.csv
+++ b/aviary/models/test_aircraft/configuration_test_GASP.csv
@@ -154,6 +154,7 @@ mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h
 settings:equations_of_motion,2DOF
+settings:aerodynamics_method,GASP
 settings:mass_method,GASP
 
 # Initialization Guesses

--- a/aviary/subsystems/aerodynamics/flops_based/test/data/high_wing_single_aisle.csv
+++ b/aviary/subsystems/aerodynamics/flops_based/test/data/high_wing_single_aisle.csv
@@ -138,4 +138,5 @@ mission:takeoff:lift_coefficient_max,2.55,unitless
 mission:takeoff:lift_over_drag,25,unitless
 mission:takeoff:rolling_friction_coefficient,0.0175,unitless
 settings:equations_of_motion,height_energy
+settings:aerodynamics_method,FLOPS
 settings:mass_method,FLOPS

--- a/aviary/subsystems/geometry/geometry_builder.py
+++ b/aviary/subsystems/geometry/geometry_builder.py
@@ -54,10 +54,10 @@ class CoreGeometryBuilder(GeometryBuilderBase):
     """
     Core geometry builder
 
-    Method
-    ------
+    Methods
+    -------
     __init__(self, name=None, meta_data=None, code_origin=None,
-        use_both_geometries=False, code_origin_to_prioritize=None):
+        code_origin_to_prioritize=None):
     build_pre_mission(self, aviary_inputs) -> openmdao.core.System:
         Builds an OpenMDAO system for the pre-mission computations of the subsystem.
     build_mission(self, num_nodes, aviary_inputs, **kwargs) -> openmdao.core.System:

--- a/aviary/subsystems/geometry/geometry_builder.py
+++ b/aviary/subsystems/geometry/geometry_builder.py
@@ -68,16 +68,21 @@ class CoreGeometryBuilder(GeometryBuilderBase):
         Generate the report for Aviary core geometry analysis.
     """
 
-    def __init__(self, name=None, meta_data=None, code_origin=None,
-                 use_both_geometries=False, code_origin_to_prioritize=None):
+    def __init__(
+        self,
+        name=None,
+        meta_data=None,
+        code_origin=None,
+        code_origin_to_prioritize=None,
+    ):
         if name is None:
             name = 'core_geometry'
 
-        if code_origin not in (FLOPS, GASP) and not use_both_geometries:
+        if code_origin not in (FLOPS, GASP) and set(code_origin) != set((FLOPS, GASP)):
             raise ValueError('Code origin is not one of the following: (FLOPS, GASP)')
 
         self.code_origin = code_origin
-        self.use_both_geometries = use_both_geometries
+        self.use_both_geometries = code_origin == (FLOPS, GASP)
         self.code_origin_to_prioritize = code_origin_to_prioritize
 
         super().__init__(name=name, meta_data=meta_data)

--- a/aviary/subsystems/geometry/test/test_flops_geom_builder.py
+++ b/aviary/subsystems/geometry/test/test_flops_geom_builder.py
@@ -4,6 +4,7 @@ import numpy as np
 import openmdao.api as om
 
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.geometry.geometry_builder import CoreGeometryBuilder
 from aviary.variable_info.enums import LegacyCode
@@ -12,8 +13,10 @@ from aviary.variable_info.variable_meta_data import _MetaData as BaseMetaData
 import aviary.api as av
 
 FLOPS = LegacyCode.FLOPS
+GASP = LegacyCode.GASP
 
 
+@use_tempdirs
 class TestFLOPSGeomBuilder(av.TestSubsystemBuilderBase):
     """
     That class inherits from TestSubsystemBuilder. So all the test functions are
@@ -25,27 +28,34 @@ class TestFLOPSGeomBuilder(av.TestSubsystemBuilderBase):
         self.subsystem_builder = CoreGeometryBuilder(
             'core_geometry',
             BaseMetaData,
-            use_both_geometries=False,
             code_origin=FLOPS,
-            code_origin_to_prioritize=FLOPS)
+            code_origin_to_prioritize=FLOPS,
+        )
         self.aviary_values = av.AviaryValues()
         self.aviary_values.set_val(Aircraft.Engine.NUM_ENGINES, [1], units='unitless')
         self.aviary_values.set_val(
-            Aircraft.Electrical.HAS_HYBRID_SYSTEM, False, units='unitless')
+            Aircraft.Electrical.HAS_HYBRID_SYSTEM, False, units='unitless'
+        )
         self.aviary_values.set_val(Aircraft.Wing.HAS_FOLD, True, units='unitless')
         self.aviary_values.set_val(Aircraft.Wing.HAS_STRUT, True, units='unitless')
         self.aviary_values.set_val(
-            Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, True, units='unitless')
+            Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, True, units='unitless')
+            Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Wing.SPAN_EFFICIENCY_REDUCTION, True, units='unitless')
+            Aircraft.Wing.SPAN_EFFICIENCY_REDUCTION, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Wing.CHOOSE_FOLD_LOCATION, True, units='unitless')
+            Aircraft.Wing.CHOOSE_FOLD_LOCATION, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Wing.FOLD_DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless')
+            Aircraft.Wing.FOLD_DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless')
+            Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless'
+        )
 
 
 class TestFLOPSGeomBuilderHybrid(av.TestSubsystemBuilderBase):
@@ -59,28 +69,37 @@ class TestFLOPSGeomBuilderHybrid(av.TestSubsystemBuilderBase):
         self.subsystem_builder = CoreGeometryBuilder(
             'core_geometry',
             BaseMetaData,
-            use_both_geometries=True,
-            code_origin_to_prioritize=FLOPS)
+            code_origin=(FLOPS, GASP),
+            code_origin_to_prioritize=FLOPS,
+        )
         self.aviary_values = av.AviaryValues()
         self.aviary_values.set_val(Aircraft.Engine.NUM_ENGINES, [1], units='unitless')
         self.aviary_values.set_val(
-            Aircraft.Electrical.HAS_HYBRID_SYSTEM, True, units='unitless')
+            Aircraft.Electrical.HAS_HYBRID_SYSTEM, True, units='unitless'
+        )
         self.aviary_values.set_val(Aircraft.Wing.HAS_FOLD, True, units='unitless')
         self.aviary_values.set_val(Aircraft.Wing.HAS_STRUT, True, units='unitless')
         self.aviary_values.set_val(
-            Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, True, units='unitless')
+            Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, True, units='unitless')
+            Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Wing.SPAN_EFFICIENCY_REDUCTION, True, units='unitless')
+            Aircraft.Wing.SPAN_EFFICIENCY_REDUCTION, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Wing.CHOOSE_FOLD_LOCATION, True, units='unitless')
+            Aircraft.Wing.CHOOSE_FOLD_LOCATION, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Wing.FOLD_DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless')
+            Aircraft.Wing.FOLD_DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless')
+            Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED, True, units='unitless'
+        )
         self.aviary_values.set_val(
-            Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+            Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless'
+        )
 
 
 if __name__ == '__main__':

--- a/aviary/subsystems/geometry/test/test_gasp_geom_builder.py
+++ b/aviary/subsystems/geometry/test/test_gasp_geom_builder.py
@@ -4,6 +4,7 @@ import numpy as np
 import openmdao.api as om
 
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.geometry.geometry_builder import CoreGeometryBuilder
 from aviary.variable_info.enums import LegacyCode
@@ -12,8 +13,10 @@ from aviary.variable_info.variable_meta_data import _MetaData as BaseMetaData
 import aviary.api as av
 
 GASP = LegacyCode.GASP
+FLOPS = LegacyCode.FLOPS
 
 
+@use_tempdirs
 class TestGASPGeomBuilder(av.TestSubsystemBuilderBase):
     """
     That class inherits from TestSubsystemBuilder. So all the test functions are
@@ -25,9 +28,9 @@ class TestGASPGeomBuilder(av.TestSubsystemBuilderBase):
         self.subsystem_builder = CoreGeometryBuilder(
             'core_geometry',
             BaseMetaData,
-            use_both_geometries=False,
             code_origin=GASP,
-            code_origin_to_prioritize=GASP)
+            code_origin_to_prioritize=GASP,
+        )
         self.aviary_values = av.AviaryValues()
         self.aviary_values.set_val(Aircraft.Engine.NUM_ENGINES, [1], units='unitless')
         self.aviary_values.set_val(
@@ -59,8 +62,9 @@ class TestGASPGeomBuilderHybrid(av.TestSubsystemBuilderBase):
         self.subsystem_builder = CoreGeometryBuilder(
             'core_geometry',
             BaseMetaData,
-            use_both_geometries=True,
-            code_origin_to_prioritize=GASP)
+            code_origin=(GASP, FLOPS),
+            code_origin_to_prioritize=GASP,
+        )
         self.aviary_values = av.AviaryValues()
         self.aviary_values.set_val(Aircraft.Engine.NUM_ENGINES, [1], units='unitless')
         self.aviary_values.set_val(

--- a/aviary/subsystems/test/test_premission.py
+++ b/aviary/subsystems/test/test_premission.py
@@ -74,10 +74,12 @@ class PreMissionTestCase(unittest.TestCase):
         prop = CorePropulsionBuilder('core_propulsion', BaseMetaData, engine)
         mass = CoreMassBuilder('core_mass', BaseMetaData, GASP)
         aero = CoreAerodynamicsBuilder('core_aerodynamics', BaseMetaData, FLOPS)
-        geom = CoreGeometryBuilder('core_geometry',
-                                   BaseMetaData,
-                                   use_both_geometries=True,
-                                   code_origin_to_prioritize=GASP)
+        geom = CoreGeometryBuilder(
+            'core_geometry',
+            BaseMetaData,
+            code_origin=(FLOPS, GASP),
+            code_origin_to_prioritize=GASP,
+        )
 
         core_subsystems = [prop, geom, mass, aero]
 
@@ -288,10 +290,12 @@ class PreMissionTestCase(unittest.TestCase):
         prop = CorePropulsionBuilder('core_propulsion', BaseMetaData, engine)
         mass = CoreMassBuilder('core_mass', BaseMetaData, GASP)
         aero = CoreAerodynamicsBuilder('core_aerodynamics', BaseMetaData, FLOPS)
-        geom = CoreGeometryBuilder('core_geometry',
-                                   BaseMetaData,
-                                   use_both_geometries=True,
-                                   code_origin_to_prioritize=FLOPS)
+        geom = CoreGeometryBuilder(
+            'core_geometry',
+            BaseMetaData,
+            code_origin=(FLOPS, GASP),
+            code_origin_to_prioritize=FLOPS,
+        )
 
         core_subsystems = [prop, geom, mass, aero]
 

--- a/aviary/variable_info/variable_meta_data.py
+++ b/aviary/variable_info/variable_meta_data.py
@@ -7756,6 +7756,16 @@ add_meta_data(
 #  '----------------'  '----------------'  '----------------'  '----------------'  '----------------'  '----------------'  '----------------'  '----------------'
 
 add_meta_data(
+    Settings.AERODYNAMICS_METHOD,
+    meta_data=_MetaData,
+    historical_name={"GASP": None, "FLOPS": None, "LEAPS1": None},
+    desc="Sets which legacy code's methods will be used for aerodynamics estimation",
+    option=True,
+    types=LegacyCode,
+    default_value=None,
+)
+
+add_meta_data(
     Settings.EQUATIONS_OF_MOTION,
     meta_data=_MetaData,
     historical_name={"GASP": None, "FLOPS": None, "LEAPS1": None},

--- a/aviary/variable_info/variables.py
+++ b/aviary/variable_info/variables.py
@@ -817,7 +817,7 @@ class Mission:
 
 class Settings:
     """Setting data hierarchy"""
-
+    AERODYNAMICS_METHOD = 'settings:aerodynamics_method'
     EQUATIONS_OF_MOTION = 'settings:equations_of_motion'
     MASS_METHOD = 'settings:mass_method'
     PROBLEM_TYPE = 'settings:problem_type'


### PR DESCRIPTION
### Summary

Adds the `AERODYNAMICS_METHOD` flag to `Settings`
Streamlines the geometry builder to remove the `both_geom` flag, and instead provide a tuple of (`FLOPS`, `GASP`)

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None