### PR TITLE
add unit test for gasp_based aero builder.

### DIFF
--- a/aviary/subsystems/aerodynamics/test/test_gasp_aero_builder.py
+++ b/aviary/subsystems/aerodynamics/test/test_gasp_aero_builder.py
@@ -1,0 +1,27 @@
+import unittest
+
+from aviary.subsystems.aerodynamics.aerodynamics_builder import CoreAerodynamicsBuilder
+from aviary.variable_info.enums import LegacyCode
+from aviary.variable_info.variables import Aircraft
+from aviary.variable_info.variable_meta_data import _MetaData as BaseMetaData
+import aviary.api as av
+
+GASP = LegacyCode.GASP
+
+
+class TestAeroBuilder(av.TestSubsystemBuilderBase):
+    """
+    That class inherits from TestSubsystemBuilder. So all the test functions are
+    within that inherited class. The setUp() method prepares the class and is run
+    before the test methods; then the test methods are run.
+    """
+
+    def setUp(self):
+        self.subsystem_builder = CoreAerodynamicsBuilder(
+            'core_aerodynamics', BaseMetaData, GASP)
+        self.aviary_values = av.AviaryValues()
+        self.aviary_values.set_val(Aircraft.Engine.NUM_ENGINES, [1], units='unitless')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary

For the sake of completeness, this unit test file is to add unit tests for GASP based aero builder.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None