### PR TITLE
Fix for 2 test failures on main.

### DIFF
--- a/aviary/interface/test/test_reports.py
+++ b/aviary/interface/test/test_reports.py
@@ -105,7 +105,8 @@ class TestReports(unittest.TestCase):
 
         prob.setup()
 
-        prob.run_model()
+        # no need to run this model, just generate the report.
+        prob.final_setup()
 
 
 if __name__ == "__main__":

--- a/aviary/validation_cases/benchmark_tests/test_subsystems_within_a_mission.py
+++ b/aviary/validation_cases/benchmark_tests/test_subsystems_within_a_mission.py
@@ -100,9 +100,8 @@ class TestSubsystemsMission(unittest.TestCase):
         prob.run_aviary_problem()
 
         # add an assert to see if MoreMission.Dummy.TIMESERIES_VAR was correctly added to the dymos problem
-        # Note, default value for this DUMMY_CONTROL has changed in dymos.
         assert_almost_equal(prob[f'traj.phases.cruise.timeseries.{MoreMission.Dummy.TIMESERIES_VAR}'], np.array(
-            [[1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5]]).T)
+            [[0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]]).T)
 
     def test_bad_initial_guess_key(self):
         phase_info = self.phase_info.copy()


### PR DESCRIPTION
### Summary

1. The case in test_reports has some trouble running, but it is a degenerate case that creates a specific condition for a report. It just needs to final_setup.
2.  The dymos bug that broke the initial value for controls has been fixed.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None