### PR TITLE
Some fixes for the latest changes in OpenMDAO 3.38.1-dev

### DIFF
--- a/aviary/interface/reports.py
+++ b/aviary/interface/reports.py
@@ -274,6 +274,7 @@ def input_check_report(prob, **kwargs):
             return resolver.abs2prom(abs_name, 'input')
 
     except AttributeError:
+
         def prom2abs(prom_name):
             return model._var_allprocs_prom2abs_list['input'][prom_name][0]
 

--- a/aviary/interface/reports.py
+++ b/aviary/interface/reports.py
@@ -262,12 +262,27 @@ def input_check_report(prob, **kwargs):
     report_file = reports_folder / 'input_checks.md'
 
     model = prob.model
-    abs2prom = model._var_allprocs_abs2prom['input']
-    prom2abs = model._var_allprocs_prom2abs_list['input']
+
+    # a change in OpenMDAO 3.38.1-dev adds a resolver in place of the prom2abs/abs2prom attributes
+    try:
+        resolver = model._resolver
+
+        def prom2abs(prom_name):
+            return resolver.absnames(prom_name, 'input')
+
+        def abs2prom(abs_name):
+            return resolver.abs2prom(abs_name, 'input')
+
+    except AttributeError:
+        def prom2abs(prom_name):
+            return model._var_allprocs_prom2abs_list['input'][prom_name][0]
+
+        def abs2prom(abs_name):
+            return model._var_allprocs_abs2prom['input'][abs_name]
 
     # Find all unconnected inputs.
     all_ivc_abs = [k for k, v in model._conn_abs_in2out.items() if 'ivc' in v]
-    all_ivc_prom = [abs2prom[v] for v in all_ivc_abs]
+    all_ivc_prom = [abs2prom(v) for v in all_ivc_abs]
 
     aviary_metadata = prob.meta_data
     aviary_inputs = prob.aviary_inputs
@@ -297,7 +312,7 @@ def input_check_report(prob, **kwargs):
                 units = metadata['units']
                 val = model.get_val(var, units=units)
                 desc = metadata['desc']
-                abs_paths = prom2abs[var]
+                abs_paths = prom2abs(var)
 
                 f.write(f'| **{var}** | {val} | {units} | {desc} | {abs_paths}|\n')
 
@@ -321,7 +336,7 @@ def input_check_report(prob, **kwargs):
                 if var.startswith('traj') and '.rhs_all.' not in var:
                     continue
 
-                abs_paths = prom2abs[var]
+                abs_paths = prom2abs(var)
                 val = model.get_val(var)
                 meta = model._var_allprocs_abs2meta['input'][abs_paths[0]]
                 units = meta['units']

--- a/aviary/interface/reports.py
+++ b/aviary/interface/reports.py
@@ -276,7 +276,7 @@ def input_check_report(prob, **kwargs):
     except AttributeError:
 
         def prom2abs(prom_name):
-            return model._var_allprocs_prom2abs_list['input'][prom_name][0]
+            return model._var_allprocs_prom2abs_list['input'][prom_name]
 
         def abs2prom(abs_name):
             return model._var_allprocs_abs2prom['input'][abs_name]

--- a/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_mass_summation.py
@@ -88,7 +88,7 @@ class MassSummationTestCase1(unittest.TestCase):
         )
 
         # wing values:
-        assert_near_equal(self.prob['total_mass.wing_mass.isolated_wing_mass'], 15758, tol)
+        assert_near_equal(self.prob['wing_mass.isolated_wing_mass'], 15758, tol)
         assert_near_equal(self.prob[Aircraft.Propulsion.TOTAL_ENGINE_MASS], 12606, tol)
         assert_near_equal(self.prob[Aircraft.Engine.ADDITIONAL_MASS], 1765 / 2, tol)
 
@@ -100,7 +100,7 @@ class MassSummationTestCase1(unittest.TestCase):
         )
         # modified from GASP value to account for updated crew mass. GASP value is
         # 102408.05695930264
-        assert_near_equal(self.prob['total_mass.fuel_mass.fus_mass_full'], 102408.4, tol)
+        assert_near_equal(self.prob['fuel_mass.fus_mass_full'], 102408.4, tol)
         # modified from GASP value to account for updated crew mass. GASP value is
         # 1757
         assert_near_equal(
@@ -123,13 +123,13 @@ class MassSummationTestCase1(unittest.TestCase):
             self.prob[Mission.Design.FUEL_MASS], 42846.3, tol
         )  # modified from GASP value to account for updated crew mass. GASP value is 42844.0
         assert_near_equal(
-            self.prob['total_mass.fuel_mass.fuel_mass_min'], 32806.3, tol
+            self.prob['fuel_mass.fuel_mass_min'], 32806.3, tol
         )  # modified from GASP value to account for updated crew mass. GASP value is 32803.6
         assert_near_equal(
             self.prob[Aircraft.Fuel.WING_VOLUME_DESIGN], 856.55, tol
         )  # modified from GASP value to account for updated crew mass. GASP value is 856.4910800459031
         assert_near_equal(
-            self.prob['total_mass.fuel_mass.fuel_and_oem.OEM_fuel_vol'], 1576.22, tol
+            self.prob['fuel_mass.fuel_and_oem.OEM_fuel_vol'], 1576.22, tol
         )  # modified from GASP value to account for updated crew mass. GASP value is 1576.1710061411081
         assert_near_equal(
             self.prob[Aircraft.Design.OPERATING_MASS], 96553.7, tol
@@ -138,7 +138,7 @@ class MassSummationTestCase1(unittest.TestCase):
         assert_near_equal(
             self.prob['total_mass.fuel_mass.fuel_and_oem.volume_wingfuel_mass'], 57066.3, tol
         )
-        assert_near_equal(self.prob['total_mass.fuel_mass.max_wingfuel_mass'], 57066.3, tol)
+        assert_near_equal(self.prob['fuel_mass.max_wingfuel_mass'], 57066.3, tol)
         assert_near_equal(
             self.prob[Aircraft.Fuel.AUXILIARY_FUEL_CAPACITY], 0, tol
         )  # always zero when no body tank

--- a/aviary/subsystems/propulsion/test/test_custom_engine_model.py
+++ b/aviary/subsystems/propulsion/test/test_custom_engine_model.py
@@ -224,7 +224,7 @@ class CustomEngineTest(unittest.TestCase):
         prob.final_setup()
 
         # check that the different throttle initial guess has been set correctly
-        initial_guesses = prob.get_val('traj.phases.cruise.controls:different_throttle')[0]
+        initial_guesses = prob.get_val('traj.cruise.controls:different_throttle')[0]
         assert_near_equal(float(initial_guesses), 0.05)
 
         # and run mission

--- a/aviary/subsystems/propulsion/test/test_turboprop_model.py
+++ b/aviary/subsystems/propulsion/test/test_turboprop_model.py
@@ -95,8 +95,8 @@ class TurbopropMissionTest(unittest.TestCase):
     def get_results(self, point_names=None, display_results=False):
         shp = self.prob.get_val(Dynamic.Vehicle.Propulsion.SHAFT_POWER, units='hp')
         total_thrust = self.prob.get_val(Dynamic.Vehicle.Propulsion.THRUST, units='lbf')
-        prop_thrust = self.prob.get_val('turboprop_model.propeller_thrust', units='lbf')
-        tailpipe_thrust = self.prob.get_val('turboprop_model.turboshaft_thrust', units='lbf')
+        prop_thrust = self.prob.get_val('propeller_thrust', units='lbf')
+        tailpipe_thrust = self.prob.get_val('turboshaft_thrust', units='lbf')
         max_thrust = self.prob.get_val(Dynamic.Vehicle.Propulsion.THRUST_MAX, units='lbf')
         fuel_flow = self.prob.get_val(
             Dynamic.Vehicle.Propulsion.FUEL_FLOW_RATE_NEGATIVE, units='lbm/h'
@@ -319,7 +319,7 @@ class TurbopropMissionTest(unittest.TestCase):
 
         shp = self.prob.get_val(Dynamic.Vehicle.Propulsion.SHAFT_POWER, units='hp')
         total_thrust = self.prob.get_val(Dynamic.Vehicle.Propulsion.THRUST, units='lbf')
-        prop_thrust = self.prob.get_val('turboprop_model.propeller_thrust', units='lbf')
+        prop_thrust = self.prob.get_val('propeller_thrust', units='lbf')
         electric_power = self.prob.get_val(Dynamic.Vehicle.Propulsion.ELECTRIC_POWER_IN, units='kW')
 
         assert_near_equal(shp, shp_expected, tolerance=1e-8)

--- a/aviary/utils/functions.py
+++ b/aviary/utils/functions.py
@@ -311,8 +311,15 @@ def promote_aircraft_and_mission_vars(group):
         if comp.name == 'core_subsystems':
             continue
 
-        out_names = [item for item in comp._var_allprocs_prom2abs_list['output']]
-        in_names = [item for item in comp._var_allprocs_prom2abs_list['input']]
+        try:
+            resolver = comp._resolver
+            out_names = [item for item in resolver.prom_iter(iotype='output')]
+            in_names = [item for item in resolver.prom_iter(iotype='input')]
+
+        except AttributeError:
+            # This is an older version of OpenMDAO
+            out_names = [item for item in comp._var_allprocs_prom2abs_list['output']]
+            in_names = [item for item in comp._var_allprocs_prom2abs_list['input']]
 
         external_outputs.extend(out_names)
 


### PR DESCRIPTION
Fixes some failing test on the nightly that are related to the following:

1. OpenMDAO system data structures storing prom<->abs name resolutions have been removed and replaced with a new _resolver object.
2. The remaining support for hybrid variable names has been removed from OpenMDAO.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None