### PR TITLE
Update to dashboard to fix error caused by OpenMDAO update

### DIFF
--- a/aviary/visualization/dashboard.py
+++ b/aviary/visualization/dashboard.py
@@ -1144,7 +1144,7 @@ def dashboard(script_name, problem_recorder, driver_recorder, port, run_in_backg
             phases = set()
             varnames = set()
             # pattern used to parse out the phase names and variable names
-            pattern = rf'{traj_name}\.phases\.([a-zA-Z0-9_]+)\.timeseries\.timeseries_comp\.([a-zA-Z0-9_]+)'
+            pattern = rf'{traj_name}\.phases\.([a-zA-Z0-9_]+)\.timeseries\.([a-zA-Z0-9_]+)'
             for varname, meta in outputs:
                 match = re.match(pattern, varname)
                 if match:


### PR DESCRIPTION
### Summary
This PR fixes an error with the dashboard.py file caused by an OpenMDAO update to remove support for hybrid pathnames.

### Related Issues
Formal issue never created...

> aviary run_mission 'aviary/models/test_aircraft/aircraft_for_bench_FwFm.csv'
> aviary dashboard aircraft_for_bench_FwFm

results in this error:
![image](https://github.com/user-attachments/assets/6d94441b-8cbe-4d11-a816-440fd22d73d8)

after the change the above test runs without error.

### Backwards incompatibilities

Presumably if people are running an old version of OpenMDAO then this will break their dashboards.

### New Dependencies

Latest OpenMDAO after the hybrid pathnames change - I don't know exactly which version this was, but I tested this fix with these versions of aviary/openmdao:
> python -m openmdao --version
![image](https://github.com/user-attachments/assets/d7285d37-5f51-4c34-ba8e-948de0feea9e)
>aviary --version
![image](https://github.com/user-attachments/assets/c87b3fae-62e6-4dec-8237-f9720b6d3236)