### PR TITLE
Fix one more failing bench due to removal of hybrid paths in OpenMDAO.

### DIFF
--- a/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
@@ -69,7 +69,7 @@ class ProblemPhaseTestCase(unittest.TestCase):
         assert_near_equal(prob.get_val(Mission.Summary.TOTAL_FUEL_MASS), 39979.0, tolerance=rtol)
 
         assert_near_equal(
-            prob.get_val('landing.' + Mission.Landing.GROUND_DISTANCE), 2595.0, tolerance=rtol
+            prob.get_val(Mission.Landing.GROUND_DISTANCE), 2595.0, tolerance=rtol
         )
 
         assert_near_equal(

--- a/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_FwGm.py
@@ -68,9 +68,7 @@ class ProblemPhaseTestCase(unittest.TestCase):
 
         assert_near_equal(prob.get_val(Mission.Summary.TOTAL_FUEL_MASS), 39979.0, tolerance=rtol)
 
-        assert_near_equal(
-            prob.get_val(Mission.Landing.GROUND_DISTANCE), 2595.0, tolerance=rtol
-        )
+        assert_near_equal(prob.get_val(Mission.Landing.GROUND_DISTANCE), 2595.0, tolerance=rtol)
 
         assert_near_equal(
             prob.get_val('traj.desc2.timeseries.distance')[-1], 3675.0, tolerance=rtol


### PR DESCRIPTION
### Summary

Fix one more failing bench due to removal of hybrid paths in OpenMDAO.
Missed this one in my last PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None