### PR TITLE
Add note about using released version of OpenMDAO and dymos

### DIFF
--- a/aviary/docs/getting_started/installation.md
+++ b/aviary/docs/getting_started/installation.md
@@ -281,6 +281,8 @@ Ran 1065 tests using 1 processes
 Wall clock time:   00:02:47.31
 ```
 
+If you have failed tests, you may want to try the latest released versions of OpenMDAO and Dymos instead of the developer versions.
+
 To find which tests are skipped, we can add `--show_skipped` option:
 
 ```


### PR DESCRIPTION
### Summary

Current Aviary is not compatible with the development versions of OpenMDAO (d210761b2dc4b870677d2a2662ccd01d4409e7a7) and dymos (4fc82d9898875aca1f6be0d2fe151cbf3b6e33b1). I added a note in the installation instruction to advise users to use the latest released version instead of the development version.

I tried to install Aviary following the instruction in the page below.
https://openmdao.github.io/Aviary/getting_started/installation.html
However, testflo had lots of failed tests. When I installed the latest version of OpenMDAO (3.38.0) and dymos (1.13.1), all the tests in testflo passed.

Ideally, Aviary should be modified to be compatible with the development version of OpenMDAO and dymos. However, always keeping compatibility with the development versions is not possible. Adding the note should help the unfamiliar users like me.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None