### PR TITLE
Updated the `no_dev_install` workflow to use the specified run_name if one is given

### DIFF
--- a/.github/workflows/test_workflow_no_dev_install.yml
+++ b/.github/workflows/test_workflow_no_dev_install.yml
@@ -27,6 +27,7 @@ on:
         required: false
         default: false
 
+run-name:  ${{ inputs.run_name }}
 
 jobs:
 


### PR DESCRIPTION
### Summary

Updated the `no_dev_install` workflow to use the specified run_name if one is given (e.g. when triggered by a release)

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None