### PR TITLE
Fix for backwards incompatible dymos change on control rate units.

### DIFF
--- a/aviary/interface/test/test_reports.py
+++ b/aviary/interface/test/test_reports.py
@@ -40,7 +40,7 @@ class TestReports(unittest.TestCase):
             'electric_power_in_total (kW)',
             'fuel_flow_rate_negative_total (lbm/h)',
             'mach (unitless)',
-            'mach_rate (unitless/s)',
+            'mach_rate (1/s)',
             'mass (kg)',
             'specific_energy_rate_excess (m/s)',
             'throttle (unitless)',

--- a/aviary/mission/flight_phase_builder.py
+++ b/aviary/mission/flight_phase_builder.py
@@ -408,7 +408,6 @@ class FlightPhaseBase(PhaseBuilderBase):
         control_dict = {
             'name': Dynamic.Atmosphere.MACH,
             'targets': Dynamic.Atmosphere.MACH,
-            #'units': 'unitless',
             'rate_targets': rate_targets,
             'opt': optimize_mach,
         }

--- a/aviary/mission/flight_phase_builder.py
+++ b/aviary/mission/flight_phase_builder.py
@@ -408,7 +408,7 @@ class FlightPhaseBase(PhaseBuilderBase):
         control_dict = {
             'name': Dynamic.Atmosphere.MACH,
             'targets': Dynamic.Atmosphere.MACH,
-            # 'units': mach_bounds[1],
+            #'units': 'unitless',
             'rate_targets': rate_targets,
             'opt': optimize_mach,
         }

--- a/aviary/mission/flops_based/ode/energy_ODE.py
+++ b/aviary/mission/flops_based/ode/energy_ODE.py
@@ -59,7 +59,7 @@ class EnergyODE(_BaseODE):
             name='velocity_rate_comp',
             subsys=om.ExecComp(
                 'velocity_rate = mach_rate * sos',
-                mach_rate={'units': 'unitless/s', 'shape': (nn,)},
+                mach_rate={'units': '1/s', 'shape': (nn,)},
                 sos={'units': 'm/s', 'shape': (nn,)},
                 velocity_rate={'units': 'm/s**2', 'shape': (nn,)},
                 has_diag_partials=True,


### PR DESCRIPTION
### Summary

A bug fix on dymos main has changed the specification of rate units for controls so that "unitless/s" is now reduced to "1/s". This required a change to 1 component in the height energy method.

NOTE: This change is on main currently, but there will be a release this week, after which this PR should be merged and the minimum version of dymos udpated.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None