### PR TITLE
Remove deepcopy from aero builder.

### DIFF
--- a/aviary/subsystems/aerodynamics/aerodynamics_builder.py
+++ b/aviary/subsystems/aerodynamics/aerodynamics_builder.py
@@ -9,7 +9,6 @@ CoreAerodynamicsBuilder : the interface for Aviary's core aerodynamics subsystem
 """
 
 import warnings
-from copy import deepcopy
 
 import numpy as np
 import openmdao.api as om
@@ -118,9 +117,8 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
             return Design()
 
     def build_mission(self, num_nodes, aviary_inputs, **kwargs):
-        arguments = deepcopy(kwargs)
         try:
-            method = arguments.pop('method')
+            method = kwargs.pop('method')
         except KeyError:
             method = None
 
@@ -131,7 +129,7 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
 
         if self.code_origin is FLOPS:
             try:
-                solve_alpha = arguments.pop('solve_alpha')
+                solve_alpha = kwargs.pop('solve_alpha')
             except KeyError:
                 warnings.warn(
                     "The 'solve_alpha' flag has been set, but is not used for FLOPS-based "
@@ -142,19 +140,19 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
                 aero_group = ComputedAeroGroup(num_nodes=num_nodes)
 
             elif method == 'computed':
-                aero_group = ComputedAeroGroup(num_nodes=num_nodes, **arguments)
+                aero_group = ComputedAeroGroup(num_nodes=num_nodes, **kwargs)
 
             elif method == 'low_speed':
                 aero_group = TakeoffAeroGroup(
-                    num_nodes=num_nodes, aviary_options=aviary_inputs, **arguments
+                    num_nodes=num_nodes, aviary_options=aviary_inputs, **kwargs
                 )
 
             elif method == 'tabular':
                 aero_group = TabularAeroGroup(
                     num_nodes=num_nodes,
-                    CD0_data=arguments.pop('CD0_data'),
-                    CDI_data=arguments.pop('CDI_data'),
-                    **arguments,
+                    CD0_data=kwargs.pop('CD0_data'),
+                    CDI_data=kwargs.pop('CDI_data'),
+                    **kwargs,
                 )
 
             else:
@@ -165,7 +163,7 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
 
         elif self.code_origin is GASP:
             try:
-                solve_alpha = arguments.pop('solve_alpha')
+                solve_alpha = kwargs.pop('solve_alpha')
             except KeyError:
                 solve_alpha = False
 
@@ -173,27 +171,27 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
                 aero_group = CruiseAero(num_nodes=num_nodes)
 
             elif method == 'cruise':
-                aero_group = CruiseAero(num_nodes=num_nodes, **arguments)
+                aero_group = CruiseAero(num_nodes=num_nodes, **kwargs)
 
             elif method == 'tabular_cruise':
-                # if 'aero_data' in arguments:
+                # if 'aero_data' in kwargs:
                 aero_group = TabularCruiseAero(
                     num_nodes=num_nodes,
-                    aero_data=arguments.pop('aero_data'),
-                    **arguments,
+                    aero_data=kwargs.pop('aero_data'),
+                    **kwargs,
                 )
 
             elif method == 'low_speed':
-                aero_group = LowSpeedAero(num_nodes=num_nodes, **arguments)
+                aero_group = LowSpeedAero(num_nodes=num_nodes, **kwargs)
 
             elif method == 'tabular_low_speed':
                 data_tables = [
-                    key in arguments
+                    key in kwargs
                     for key in ['free_aero_data', 'free_flaps_data', 'free_ground_data']
                 ]
 
                 if all(data_tables):
-                    aero_group = TabularLowSpeedAero(num_nodes=num_nodes, **arguments)
+                    aero_group = TabularLowSpeedAero(num_nodes=num_nodes, **kwargs)
                 # raise error if only some data types are provided (at this point we know
                 # not all are present, now need to see if any were provided at all)
                 elif any(data_tables):
@@ -244,9 +242,8 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
     #     return aero_group
 
     def mission_inputs(self, **kwargs):
-        arguments = deepcopy(kwargs)
         try:
-            method = arguments.pop('method')
+            method = kwargs.pop('method')
         except KeyError:
             method = None
 
@@ -331,9 +328,8 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
         return promotes
 
     def mission_outputs(self, **kwargs):
-        arguments = deepcopy(kwargs)
         try:
-            method = arguments.pop('method')
+            method = kwargs.pop('method')
         except KeyError:
             method = None
         promotes = ['*']
@@ -416,9 +412,8 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
             - any additional keyword arguments required by OpenMDAO for the fixed
               variable.
         """
-        arguments = deepcopy(kwargs)
         try:
-            method = arguments.pop('method')
+            method = kwargs.pop('method')
         except KeyError:
             method = None
 
@@ -427,7 +422,7 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
 
         num_engine_type = len(aviary_inputs.get_val(Aircraft.Engine.NUM_ENGINES))
         params = {}
-        aero_options = arguments
+        aero_options = kwargs
 
         if self.code_origin is FLOPS:
             # FLOPS default is 'computed'
@@ -570,12 +565,12 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilderBase):
                 # GASP default is 'cruise'
                 method = 'cruise'
             try:
-                solve_alpha = arguments.pop('solve_alpha')
+                solve_alpha = kwargs.pop('solve_alpha')
             except KeyError:
                 solve_alpha = False
 
             if solve_alpha and 'tabular' in method:
-                aero_data = arguments['aero_data']
+                aero_data = kwargs['aero_data']
 
                 if isinstance(aero_data, NamedValues):
                     altitude = aero_data.get_item('altitude')[0]


### PR DESCRIPTION
### Summary

The deepcopy isn't needed, and it breaks some external builders.

### Related Issues

- Resolves #794

### Backwards incompatibilities

None

### New Dependencies

None