### PR TITLE
Fix for bug where time duration value was no longer respected.

### DIFF
--- a/aviary/docs/user_guide/reserve_missions.ipynb
+++ b/aviary/docs/user_guide/reserve_missions.ipynb
@@ -321,7 +321,7 @@
     "expected_values = {\n",
     "    'time_duration': (10, 'min'),\n",
     "    'time_duration_bounds': ((30, 300), 's'),\n",
-    "    'time': ((1.0, 2.0), 'min'),\n",
+    "    'time': ((1.0, 10.0), 'min'),\n",
     "}\n",
     "check_value(values_of_interest, expected_values)"
    ]

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -326,7 +326,11 @@ class AviaryProblem(om.Problem):
                             msg += f'Using fixed value of {time_duration} {units} instead.'
                             print(msg)
 
-                        guesses['time'][0][1] = time_duration
+                        time_duration_conv = wrapped_convert_units(
+                            (time_duration, units),
+                            units_guess
+                        )
+                        guesses['time'] = ((time_guess[0], time_duration_conv), units_guess)
 
                     else:
                         guesses['time'] = ((None, time_duration), units)

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -283,7 +283,6 @@ class AviaryProblem(om.Problem):
         # Checks to make sure time_duration is positive,
         # Sets duration_bounds, initial_guesses, and fixed_duration
         for phase_name, phase in self.phase_info.items():
-
             if 'user_options' in phase:
                 analytic = False
                 if (

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -283,6 +283,7 @@ class AviaryProblem(om.Problem):
         # Checks to make sure time_duration is positive,
         # Sets duration_bounds, initial_guesses, and fixed_duration
         for phase_name, phase in self.phase_info.items():
+
             if 'user_options' in phase:
                 analytic = False
                 if (
@@ -301,13 +302,36 @@ class AviaryProblem(om.Problem):
                             analytic = phase['user_options']['analytic'] = False
 
                 if 'time_duration' in phase['user_options']:
-                    time_duration = phase['user_options']['time_duration']
-                    if time_duration[0] is not None and time_duration[0] <= 0:
+                    time_duration, units = phase['user_options']['time_duration']
+
+                    if time_duration is None:
+                        continue
+
+                    if time_duration <= 0:
                         raise ValueError(
                             f'Invalid time_duration in phase_info[{phase_name}]'
                             f'[user_options]. Current (value: {time_duration[0]}), '
                             f'(units: {time_duration[1]}) <= 0")'
                         )
+
+                    if 'initial_guesses' not in phase:
+                        phase['initial_guesses'] = {}
+
+                    guesses = phase['initial_guesses']
+                    if 'time' in guesses:
+                        time_guess, units_guess = guesses['time']
+
+                        if time_guess[1] is not None:
+                            msg = f'Duration initial guess of {time_guess[1]} {units_guess} '
+                            msg += f'specified on fixed duration phase for phase {phase_name}. '
+                            msg += f'Using fixed value of {time_duration} {units} instead.'
+                            print(msg)
+
+                        guesses['time'][0][1] = time_duration
+
+                    else:
+                        guesses['time'] = ((None, time_duration), units)
+                    guesses = self.phase_info[phase_name]['initial_guesses']
 
         for phase_name in self.phase_info:
             for external_subsystem in self.phase_info[phase_name]['external_subsystems']:

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -330,7 +330,6 @@ class AviaryProblem(om.Problem):
 
                     else:
                         guesses['time'] = ((None, time_duration), units)
-                    guesses = self.phase_info[phase_name]['initial_guesses']
 
         for phase_name in self.phase_info:
             for external_subsystem in self.phase_info[phase_name]['external_subsystems']:

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -327,8 +327,7 @@ class AviaryProblem(om.Problem):
                             print(msg)
 
                         time_duration_conv = wrapped_convert_units(
-                            (time_duration, units),
-                            units_guess
+                            (time_duration, units), units_guess
                         )
                         guesses['time'] = ((time_guess[0], time_duration_conv), units_guess)
 

--- a/aviary/interface/test/test_phase_info.py
+++ b/aviary/interface/test/test_phase_info.py
@@ -96,6 +96,44 @@ class TestParameterizePhaseInfo(unittest.TestCase):
         assert_near_equal(prob.get_val('traj.cruise.timeseries.mach')[0], 0.6)
 
 
+@use_tempdirs
+class TestPhaseInfoAPI(unittest.TestCase):
+    def test_time_duration(self):
+        phase_info = {
+            'only_cruise': {
+                'user_options': {
+                    'num_segments': 5,
+                    'order': 3,
+                    'mach_initial': (0.72, 'unitless'),
+                    'mach_final': (0.72, 'unitless'),
+                    'altitude_initial': (32000.0, 'ft'),
+                    'altitude_final': (32000.0, 'ft'),
+                    'time_duration': (77, 's'),
+                },
+            },
+        }
+        prob = AviaryProblem()
+
+        csv_path = 'models/test_aircraft/aircraft_for_bench_FwFm.csv'
+
+        prob.load_inputs(csv_path, phase_info)
+        prob.check_and_preprocess_inputs()
+
+        prob.add_pre_mission_systems()
+        prob.add_phases()
+        prob.add_post_mission_systems()
+
+        prob.link_phases()
+
+        prob.setup()
+        prob.set_initial_guesses()
+
+        prob.run_aviary_problem()
+
+        time = prob.get_val('traj.only_cruise.timeseries.time', units='s')[-1]
+        assert_near_equal(time, 77.0, 1e-5)
+
+
 # To run the tests
 if __name__ == '__main__':
     unittest.main()

--- a/aviary/interface/test/test_reserve_support.py
+++ b/aviary/interface/test/test_reserve_support.py
@@ -16,7 +16,7 @@ from aviary.variable_info.variables import Aircraft, Mission
 #      it only partially does (should be checking that the reserve mission properly
 #      exists in traj as well)
 @use_tempdirs
-class PreMissionGroupTest(unittest.TestCase):
+class ReserveTest(unittest.TestCase):
     def test_post_mission_promotion(self):
         phase_info = deepcopy(ph_in_flops)
 

--- a/aviary/mission/height_energy_problem_configurator.py
+++ b/aviary/mission/height_energy_problem_configurator.py
@@ -225,20 +225,22 @@ class HeightEnergyProblemConfigurator(ProblemConfiguratorBase):
 
         if (fix_initial or input_initial) and prob.comm.size == 1:
             # Redundant on a fixed input (unless MPI); raises a warning if specified.
-            initial_options = {}
+            extra_options = {}
         else:
-            initial_options = {
+            extra_options = {
                 'initial_ref': initial_ref,
                 'initial_bounds': initial_bounds,
             }
+
+        if not fix_duration:
+            extra_options['duration_bounds'] = duration_bounds
+            extra_options['duration_ref'] = duration_ref
 
         phase.set_time_options(
             fix_initial=fix_initial,
             fix_duration=fix_duration,
             units=time_units,
-            duration_bounds=duration_bounds,
-            duration_ref=duration_ref,
-            **initial_options,
+            **extra_options,
         )
 
     def link_phases(self, prob, phases, connect_directly=True):
@@ -600,12 +602,14 @@ class HeightEnergyProblemConfigurator(ProblemConfiguratorBase):
                 # Seems to be an openmdao bug. Switch to this when fixed.
                 # phase.set_time_val(initial=val[0], duration=val[1], units=units)
 
-                target_prob.set_val(
-                    parent_prefix + f'traj.{phase_name}.t_initial', val[0], units=units
-                )
-                target_prob.set_val(
-                    parent_prefix + f'traj.{phase_name}.t_duration', val[1], units=units
-                )
+                if val[0] is not None:
+                    target_prob.set_val(
+                        parent_prefix + f'traj.{phase_name}.t_initial', val[0], units=units
+                    )
+                if val[1] is not None:
+                    target_prob.set_val(
+                        parent_prefix + f'traj.{phase_name}.t_duration', val[1], units=units
+                    )
 
             elif guess_key in control_keys:
                 # Set initial guess for control variables

--- a/aviary/mission/two_dof_problem_configurator.py
+++ b/aviary/mission/two_dof_problem_configurator.py
@@ -740,6 +740,9 @@ class TwoDOFProblemConfigurator(ProblemConfiguratorBase):
                         parent_prefix + f'traj.{phase_name}.t_duration', val[1], units=units
                     )
 
+                elif guess_key == 'time':
+                    # Time needs to be dealt with elsewhere.
+                    continue
                 else:
                     # Otherwise, set the value of the parameter in the trajectory
                     # phase


### PR DESCRIPTION
### Summary

1. Fix for a regression that came in with the phase_info revamp, where time_duration (formerly target_duration) was no longer being respected.
2. Print a warning if both time_duration and a duration initial guess are specified.
3. Clean up the arguments being passed into set_time_options to avoid dymos warnings.

### Related Issues

- Resolves #805 

### Backwards incompatibilities

None

### New Dependencies

None