### PR TITLE
Fixed smalll bugs in aviary dashboard optimization history and aviary variables tabs

### DIFF
--- a/aviary/visualization/dashboard.py
+++ b/aviary/visualization/dashboard.py
@@ -29,7 +29,7 @@ from bokeh.models import (
 )
 from bokeh.palettes import Category20, d3
 from bokeh.plotting import figure
-from openmdao.utils.general_utils import env_truthy
+from openmdao.utils.general_utils import env_truthy, make_serializable
 from openmdao.utils.units import conversion_to_base_units
 
 try:
@@ -523,6 +523,8 @@ def create_aviary_variables_table_data_nested(script_name, recorder_file):
             var_info = grouped[group_name][0]
             prom_name = outputs[var_info]['prom_name']
             aviary_metadata = av.CoreMetaData.get(prom_name)
+            # the metadata has some object types, like "type", that don't serialize normally
+            aviary_metadata = make_serializable(aviary_metadata)
             table_data_nested.append(
                 {
                     'abs_name': group_name,
@@ -538,6 +540,8 @@ def create_aviary_variables_table_data_nested(script_name, recorder_file):
             for children_name in grouped[group_name]:
                 prom_name = outputs[children_name]['prom_name']
                 aviary_metadata = av.CoreMetaData.get(prom_name)
+                # the metadata has some object types, like "type", that don't serialize normally
+                aviary_metadata = make_serializable(aviary_metadata)
                 children_list.append(
                     {
                         'abs_name': children_name,
@@ -878,7 +882,7 @@ def create_optimization_history_plot(case_recorder, df):
         f"""
         <label style="display:block; margin-bottom:5px;">
             <input type="checkbox" value="{variable_name}"
-                onchange="Bokeh.documents[0].get_model_by_id('{variable_checkbox_callback.id}').execute({index: {i}, checked: this.checked} )">
+                onchange="Bokeh.documents[0].get_model_by_id('{variable_checkbox_callback.id}').execute({{index: {i}, checked: this.checked}} )">
             {variable_name}
         </label>
     """


### PR DESCRIPTION
### Summary

In the optimization history code, there was some javascript code being created using an f-string and it didn't make use of double braces needed to create a literal brace. 

Also, unrelated to the issue, there was a bug in the aviary variables tab creation because the serialization of the aviary metadata failed. Need to make use of the `make_serializable` function from OpenMDAO to clean that up.

### Related Issues

- Resolves #685 

### Backwards incompatibilities

None

### New Dependencies

None