### PR TITLE
Address a numpy deprecation warning about assigning a vector to a single vector index.

### DIFF
--- a/aviary/subsystems/mass/flops_based/wing_detailed.py
+++ b/aviary/subsystems/mass/flops_based/wing_detailed.py
@@ -242,7 +242,7 @@ class DetailedWingBendingFact(om.ExplicitComponent):
 
                 bte = 8 * np.sum((ea[:-1] + ea[1:]) * dy[:-1] * 0.5)
 
-                inertia_factor_i = 1 - bte / bt * pod_mass[i] / gross_mass
+                inertia_factor_i = 1 - bte / bt[0] * pod_mass[i] / gross_mass[0]
                 # avoid passing an array into specific index of inertia_factor
                 inertia_factor[i] = inertia_factor_i
 


### PR DESCRIPTION
### Summary

Address a numpy deprecation warning about assigning a vector to a single vector index.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None