### PR TITLE
Fix for IPOPT CI failures.

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -110,6 +110,9 @@ runs:
         pip install git+https://github.com/OpenMDAO/build_pyoptsparse
         build_pyoptsparse -v $BRANCH $SNOPT
 
+        echo "The build script has been grabbing an older version of IPOPT with some problems."
+        conda install ipopt=3.14
+
     - name: Install OpenMDAO
       if: inputs.OPENMDAO
       shell: bash -l {0}


### PR DESCRIPTION
build_pyoptsparse started giving us an older version of IPOPT. Not sure why, but we seem to be able to update it in the next step of the build script.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None