### PR TITLE
fortran_to_aviary bug fix for FLOPS variable FRVT

### DIFF
--- a/aviary/utils/fortran_to_aviary.py
+++ b/aviary/utils/fortran_to_aviary.py
@@ -813,7 +813,7 @@ flops_scaler_variables = [
     Aircraft.Nacelle.MASS,
     Aircraft.Nacelle.WETTED_AREA,
     Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS,
-    Aircraft.VerticalTail.MASS_SCALER,
+    Aircraft.VerticalTail.MASS,
     Aircraft.VerticalTail.WETTED_AREA,
     Aircraft.Wing.MASS,
     Aircraft.Wing.SHEAR_CONTROL_MASS,


### PR DESCRIPTION
### Summary

Correction to fortran_to_aviary to fix bug with vertical_tail:mass vs mass_scalar.
Aviary will now correctly translate FRVT to aircraft:vertical_tail:mass for values > 5 and aircraft:vertical_tail:mass_scalar for all other values.

<img width="652" height="307" alt="image" src="https://github.com/user-attachments/assets/e0ed4270-dd35-4b8d-a928-dae2ed8907c1" />

### Related Issues

- Resolves #833 

### Backwards incompatibilities

None

### New Dependencies

None