### PR TITLE
Updated workflow to handle changes in conda env export.

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -159,7 +159,8 @@ runs:
       run: |
         conda info
         conda list
-        conda env export --file ${{ inputs.NAME }}_environment.yml
+        conda env export --file environment.yml
+        mv environment.yml ${{ inputs.NAME }}_environment.yml
 
     - name: 'Upload environment artifact'
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Summary

Earlier versions of conda could do `conda env export --file {name}`, and autodetect the format based on the file name extension.  That seems to have changed and it now demands `environment.yml` or an explicit `--format environment-yml` switch.  The problem with the latter is that some CI tests still use earlier versions that fail if they encounter that switch. The workaround implemented here is to always export to environment.yml and then move the file to the name being saved in the github CI artifact.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None