### PR TITLE
Removed requirement for certain engine options

### DIFF
--- a/aviary/variable_info/functions.py
+++ b/aviary/variable_info/functions.py
@@ -11,7 +11,7 @@ from aviary.utils.aviary_values import AviaryValues
 from aviary.utils.utils import cast_type, check_type, enum_setter, wrapped_convert_units
 from aviary.variable_info.enums import Verbosity
 from aviary.variable_info.variable_meta_data import _MetaData
-from aviary.variable_info.variables import Aircraft, Settings
+from aviary.variable_info.variables import Aircraft, Mission, Settings
 
 # ---------------------------
 # Helper functions for setting up inputs/outputs in components
@@ -576,12 +576,14 @@ def setup_model_options(
             eng_name = engine_models[idx].name
 
             # TODO: For future flexibility, need to tag the required engine options.
+            # TODO: Revisit this list and verify these variables actually need to be here
             opt_names = [
                 Aircraft.Engine.SCALE_PERFORMANCE,
                 Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER,
                 Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER,
                 Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM,
                 Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM,
+                Mission.Summary.FUEL_FLOW_SCALER,
             ]
             opt_names_units = [
                 Aircraft.Engine.REFERENCE_SLS_THRUST,
@@ -589,10 +591,12 @@ def setup_model_options(
             ]
             opts = {}
             for key in opt_names:
-                opts[key] = aviary_inputs.get_item(key)[0][idx]
+                if key in aviary_inputs:
+                    opts[key] = aviary_inputs.get_item(key)[0][idx]
             for key in opt_names_units:
-                val, units = aviary_inputs.get_item(key)
-                opts[key] = (val[idx], units)
+                if key in aviary_inputs:
+                    val, units = aviary_inputs.get_item(key)
+                    opts[key] = (val[idx], units)
 
             path = f'{prefix}*core_propulsion.{eng_name}*'
             prob.model_options[path] = opts


### PR DESCRIPTION
### Summary
Removed requirement for certain options to be defined inside an EngineModel, which causes errors in set_model_options() if not defined, but don't actually cause a problem if they are not.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None