### PR TITLE
Fix #953: Initialize self.subsystems for AviaryGroup

### DIFF
--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -69,6 +69,7 @@ class AviaryGroup(om.Group):
         self.engine_models = []
         self.regular_phases = []
         self.reserve_phases = []
+        self.subsystems = []
 
         self.aviary_inputs = None
         self.meta_data = None


### PR DESCRIPTION
### Summary

Initialize self.subsystems to an empty list in the AviaryGroup __init__. Otherwise, self.subsystems isn't initialized until a successful run of check_and_preprocess_inputs() is made. This also allows full reports to be made for the level3 example without crashing. Prior, the level3 example would crash before writing the full report, and fail to write these files:
- status.json
- mission_summary.md
- mission_timeseries_data.csv
- traj_results_report.html

### Related Issues

- Resolves #953 

### Backwards incompatibilities

None

### New Dependencies

None