### PR TITLE
Name change for output directories of off design problems.

### DIFF
--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -1367,7 +1367,7 @@ class AviaryProblem(om.Problem):
 
         if name is None:
             name = self._name + '_' + str(problem_type.value)
-            curr_time = datetime.now().strftime("%m%d%y%H%M%S")
+            curr_time = datetime.now().strftime('%m%d%y%H%M%S')
             name += '_' + curr_time
         off_design_prob = AviaryProblem(name=name)
 

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -1366,12 +1366,12 @@ class AviaryProblem(om.Problem):
             )
 
         if name is None:
-            suggestion = self._name + "_" + str(problem_type.value)
-            # For while loop / numbering names
+            # Numbering problem names.
+            suggestion = self._name + '_' + str(problem_type.value)
             suggestion_update = suggestion
             counter = 2
-            while os.path.exists(os.path.join(".", suggestion_update + "_out")):
-                suggestion_update = suggestion + "_" + str(counter)
+            while os.path.exists(suggestion_update + '_out'):
+                suggestion_update = suggestion + '_' + str(counter)
                 counter += 1
             name = suggestion_update
         off_design_prob = AviaryProblem(name=name)

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -1366,14 +1366,9 @@ class AviaryProblem(om.Problem):
             )
 
         if name is None:
-            # Numbering problem names.
-            suggestion = self._name + '_' + str(problem_type.value)
-            suggestion_update = suggestion
-            counter = 2
-            while os.path.exists(suggestion_update + '_out'):
-                suggestion_update = suggestion + '_' + str(counter)
-                counter += 1
-            name = suggestion_update
+            name = self._name + '_' + str(problem_type.value)
+            curr_time = datetime.now().strftime("%m%d%y%H%M%S")
+            name += '_' + curr_time
         off_design_prob = AviaryProblem(name=name)
 
         # Set up problem for mission, such as equations of motion, configurators, etc.

--- a/aviary/interface/methods_for_level2.py
+++ b/aviary/interface/methods_for_level2.py
@@ -1366,7 +1366,14 @@ class AviaryProblem(om.Problem):
             )
 
         if name is None:
-            name = name = self._name + '_off_design'
+            suggestion = self._name + "_" + str(problem_type.value)
+            # For while loop / numbering names
+            suggestion_update = suggestion
+            counter = 2
+            while os.path.exists(os.path.join(".", suggestion_update + "_out")):
+                suggestion_update = suggestion + "_" + str(counter)
+                counter += 1
+            name = suggestion_update
         off_design_prob = AviaryProblem(name=name)
 
         # Set up problem for mission, such as equations of motion, configurators, etc.

--- a/aviary/interface/test/test_reports.py
+++ b/aviary/interface/test/test_reports.py
@@ -1,5 +1,4 @@
 import csv
-import os
 import unittest
 from copy import deepcopy
 from pathlib import Path
@@ -135,28 +134,6 @@ class TestReports(unittest.TestCase):
 
         # no need to run this model, just generate the report.
         prob.final_setup()
-
-    def test_report_directory_naming(self):
-        problem_name = 'test_problem'
-        phase_info['post_mission']['target_range'] = (2500.0, 'nmi')
-        prob = AviaryProblem(name=problem_name)
-        prob.load_inputs(
-            'models/aircraft/advanced_single_aisle/advanced_single_aisle_FLOPS.csv', phase_info
-        )
-        prob.check_and_preprocess_inputs()
-        prob.build_model()
-        prob.add_driver('SLSQP', max_iter=50)
-        prob.add_design_variables()
-        prob.add_objective()
-        prob.setup()
-        prob.run_aviary_problem()
-        self.assertTrue(os.path.exists(f'{problem_name}_out'))
-        _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
-        self.assertTrue(os.path.exists(f'{problem_name}_fallout_out'))
-        _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
-        self.assertTrue(os.path.exists(f'{problem_name}_fallout_2_out'))
-        _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
-        self.assertTrue(os.path.exists(f'{problem_name}_fallout_3_out'))
 
 
 if __name__ == '__main__':

--- a/aviary/interface/test/test_reports.py
+++ b/aviary/interface/test/test_reports.py
@@ -1,4 +1,5 @@
 import csv
+import os
 import unittest
 from copy import deepcopy
 from pathlib import Path
@@ -135,6 +136,27 @@ class TestReports(unittest.TestCase):
         # no need to run this model, just generate the report.
         prob.final_setup()
 
+    def test_report_directory_naming(self):
+        problem_name = "test_problem"
+        phase_info['post_mission']['target_range'] = (2500.0, 'nmi')
+        prob = AviaryProblem(name=problem_name)
+        prob.load_inputs(
+            'models/aircraft/advanced_single_aisle/advanced_single_aisle_FLOPS.csv', phase_info
+        )
+        prob.check_and_preprocess_inputs()
+        prob.build_model()
+        prob.add_driver('SLSQP', max_iter=50)
+        prob.add_design_variables()
+        prob.add_objective()
+        prob.setup()
+        prob.run_aviary_problem()
+        self.assertTrue(os.path.exists(f"{problem_name}_out"))
+        _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
+        self.assertTrue(os.path.exists(f"{problem_name}_fallout_out"))
+        _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
+        self.assertTrue(os.path.exists(f"{problem_name}_fallout_2_out"))
+        _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
+        self.assertTrue(os.path.exists(f"{problem_name}_fallout_3_out"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/aviary/interface/test/test_reports.py
+++ b/aviary/interface/test/test_reports.py
@@ -137,7 +137,7 @@ class TestReports(unittest.TestCase):
         prob.final_setup()
 
     def test_report_directory_naming(self):
-        problem_name = "test_problem"
+        problem_name = 'test_problem'
         phase_info['post_mission']['target_range'] = (2500.0, 'nmi')
         prob = AviaryProblem(name=problem_name)
         prob.load_inputs(
@@ -150,13 +150,14 @@ class TestReports(unittest.TestCase):
         prob.add_objective()
         prob.setup()
         prob.run_aviary_problem()
-        self.assertTrue(os.path.exists(f"{problem_name}_out"))
+        self.assertTrue(os.path.exists(f'{problem_name}_out'))
         _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
-        self.assertTrue(os.path.exists(f"{problem_name}_fallout_out"))
+        self.assertTrue(os.path.exists(f'{problem_name}_fallout_out'))
         _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
-        self.assertTrue(os.path.exists(f"{problem_name}_fallout_2_out"))
+        self.assertTrue(os.path.exists(f'{problem_name}_fallout_2_out'))
         _ = prob.run_off_design_mission(problem_type='fallout', mission_gross_mass=115000)
-        self.assertTrue(os.path.exists(f"{problem_name}_fallout_3_out"))
+        self.assertTrue(os.path.exists(f'{problem_name}_fallout_3_out'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/aviary/interface/test/test_save_results.py
+++ b/aviary/interface/test/test_save_results.py
@@ -1,5 +1,8 @@
 import unittest
+from unittest.mock import patch, Mock
 from copy import deepcopy
+from datetime import datetime
+import re
 
 from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 
@@ -65,6 +68,18 @@ class TestSizingResults(unittest.TestCase):
 
         prob = reload_aviary_problem('interface/test/sizing_results_for_test.json')
         prob.run_off_design_mission(problem_type='fallout', phase_info=local_phase_info)
+
+    @require_pyoptsparse(optimizer='IPOPT')
+    @patch('aviary.interface.methods_for_level2.datetime')
+    def test_output_naming(self, mock_datetime):
+        fixed_now = datetime(2026, 2, 5, 12, 1, 1)
+        mock_datetime.now.return_value = fixed_now
+
+        local_phase_info = deepcopy(phase_info)
+
+        prob = reload_aviary_problem('interface/test/sizing_results_for_test.json')
+        prob = prob.run_off_design_mission(problem_type='fallout', phase_info=local_phase_info)
+        self.assertTrue('fallout_020526120101' in prob._name)
 
     def compare_files(self, test_file, validation_file):
         """


### PR DESCRIPTION
### Summary

This adds logic and a test to essentially do the following to resolve issue #957 and follow up @jkirk5's comment on PR #981:

If your problem is named 'test', the baseline output directory will be named 'test_out', and if you run off design problem types (say, fallout, alternate, etc) without a name the problem type and the time the problem was run will be added to its name to produce the following directory outputs:
- test_fallout_020526182200_out
- test_alternate_020526182223_out
- and so on.

### Related Issues

- Resolves #957 
- Related to #981 

### Backwards incompatibilities

None

### New Dependencies

None