### PR TITLE
Fix for non-deterministic behavior during optimization.

### DIFF
--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -734,7 +734,7 @@ class AviaryGroup(om.Group):
                     aviary_inputs=self.aviary_inputs,
                     **kwargs,
                 )
-                for parameter in parameter_dict:
+                for parameter in sorted(parameter_dict):
                     external_parameters[phase_name][parameter] = parameter_dict[parameter]
 
         traj = setup_trajectory_params(


### PR DESCRIPTION
### Summary

We had been seeing some non-deterministic behavior in the optimization path for sensitive problems for a while. Turns out it was due to parameters being added to the trajectory in whatever semi-random order they were assmebled inside of the builders' `get_parameters` methods. Sorting the parameters before adding them makes sure that they are always added in the same order.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None