### PR TITLE
Cleaned up a warning and fixed a test that fails if you run testflo from aviary/aviary

### DIFF
--- a/aviary/utils/preprocessors.py
+++ b/aviary/utils/preprocessors.py
@@ -477,31 +477,32 @@ def preprocess_crewpayload(aviary_options: AviaryValues, meta_data=_MetaData, ve
             if isinstance(num_fulselage_engines, (list, np.ndarray)):
                 num_fulselage_engines = num_fulselage_engines[0]
 
-        if (
-            Aircraft.Engine.NUM_FUSELAGE_ENGINES in aviary_options
-            and num_fulselage_engines > 1
-            and aviary_options.get_val(Aircraft.Design.TYPE) == AircraftTypes.TRANSPORT
-        ):
-            HHT = 1
-            warnings.warn(
-                'Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION not specified and '
-                'Aircraft.Engine.NUM_FUSELAGE_ENGINES = '
-                f'{aviary_options.get_val(Aircraft.Engine.NUM_FUSELAGE_ENGINES)}'
-                ' assume T-Tail configuration. Setting '
-                ' Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION = 1'
+        if Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION not in aviary_options:
+            if (
+                Aircraft.Engine.NUM_FUSELAGE_ENGINES in aviary_options
+                and num_fulselage_engines > 1
+                and aviary_options.get_val(Aircraft.Design.TYPE) == AircraftTypes.TRANSPORT
+            ):
+                HHT = 1
+                warnings.warn(
+                    'Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION not specified and '
+                    'Aircraft.Engine.NUM_FUSELAGE_ENGINES = '
+                    f'{aviary_options.get_val(Aircraft.Engine.NUM_FUSELAGE_ENGINES)}'
+                    ' assume T-Tail configuration. Setting '
+                    ' Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION = 1'
+                )
+            else:
+                HHT = 0
+                warnings.warn(
+                    'Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION not specified '
+                    'assume conventional tail configuration. Setting '
+                    'Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION = 0'
+                )
+            aviary_options.set_val(
+                Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION,
+                val=HHT,
+                units='unitless',
             )
-        else:
-            HHT = 0
-            warnings.warn(
-                'Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION not specified '
-                'assume conventional tail configuration. Setting '
-                'Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION = 0'
-            )
-        aviary_options.set_val(
-            Aircraft.HorizontalTail.VERTICAL_TAIL_FRACTION,
-            val=HHT,
-            units='unitless',
-        )
 
     return aviary_options
 

--- a/aviary/utils/test/test_doctape.py
+++ b/aviary/utils/test/test_doctape.py
@@ -7,6 +7,8 @@ from openmdao.utils.assert_utils import (
     assert_near_equal,
 )
 
+from openmdao.utils.testing_utils import use_tempdirs
+
 from aviary.utils.doctape import (
     check_args,
     check_contains,
@@ -35,6 +37,7 @@ except ImportError:
     myst_nb is False,
     'Skipping because myst_nb is not installed for doc testing.',
 )
+@use_tempdirs
 class DocTAPETests(unittest.TestCase):
     """
     Testing the DocTAPE functions to make sure they all run in all supported Python versions


### PR DESCRIPTION
### Summary

1. Fixed a new warning that cropped up recently. That logic needed to be under a check for undeclared vertical_tail fraction.
2. Put the doctape tests in a tempdir so that it doesn't interact when run in ./aviary.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None