### PR TITLE
Add ref scaling to gross_mass_resid constraint

### DIFF
--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -1389,7 +1389,11 @@ class AviaryGroup(om.Group):
                     promotes_outputs=['gross_mass_resid'],
                 )
 
-                self.add_constraint('gross_mass_resid', lower=0)
+                # ref scales gross_mass_resid = design_mass - actual_mass to O(1).
+                # For fleet missions much lighter than design, residuals can be
+                # 10-20% of design mass. GROSS_MASS/4 puts scaled values ~0.2-0.6.
+                _gm_ref = self.aviary_inputs.get_val(Mission.Design.GROSS_MASS, 'kg') / 4.0
+                self.add_constraint('gross_mass_resid', lower=0, ref=_gm_ref)
 
             if self.mission_method is TWO_DEGREES_OF_FREEDOM:
                 # TODO: This should be moved into the problem configurator b/c it's 2DOF specific


### PR DESCRIPTION
The gross_mass_resid constraint (design_mass - actual_mass >= 0) had no ref, leaving it unscaled. For multi-mission problems where fleet missions are much lighter than the design mission, the residual can be 10-20% of GROSS_MASS, creating poorly scaled constraints.

Set ref = GROSS_MASS/4 so that typical residual values are O(0.2-0.6) in scaled space.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None