### PR TITLE
Updated optimizers in examples

### DIFF
--- a/aviary/docs/examples_unreviewed/detailed_takeoff_landing.ipynb
+++ b/aviary/docs/examples_unreviewed/detailed_takeoff_landing.ipynb
@@ -683,7 +683,7 @@
     "\n",
     "prob.build_model()\n",
     "\n",
-    "prob.add_driver('SLSQP', max_iter=100)\n",
+    "prob.add_driver('SLSQP', max_iter=25)\n",
     "\n",
     "prob.add_design_variables()\n",
     "\n",

--- a/aviary/docs/examples_unreviewed/more_advanced_example.ipynb
+++ b/aviary/docs/examples_unreviewed/more_advanced_example.ipynb
@@ -168,12 +168,7 @@
    "source": [
     "import aviary.api as av\n",
     "\n",
-    "prob = av.run_aviary(\n",
-    "    'models/aircraft/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
-    "    phase_info,\n",
-    "    optimizer='SLSQP',\n",
-    "    make_plots=True,\n",
-    ")"
+    "prob = av.run_aviary('models/aircraft/test_aircraft/aircraft_for_bench_FwFm.csv', phase_info)"
    ]
   },
   {
@@ -328,7 +323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob = av.run_aviary('modified_aircraft.csv', phase_info, optimizer='SLSQP', make_plots=True)"
+    "prob = av.run_aviary('modified_aircraft.csv', phase_info)"
    ]
   },
   {
@@ -396,12 +391,7 @@
     "phase_info['descent_1']['user_options']['mach_polynomial_order'] = 3\n",
     "phase_info['descent_1']['user_options']['altitude_polynomial_order'] = 3\n",
     "\n",
-    "prob = av.run_aviary(\n",
-    "    'models/aircraft/test_aircraft/aircraft_for_bench_FwFm.csv',\n",
-    "    phase_info,\n",
-    "    optimizer='IPOPT',\n",
-    "    make_plots=True,\n",
-    ")"
+    "prob = av.run_aviary('models/aircraft/test_aircraft/aircraft_for_bench_FwFm.csv', phase_info)"
    ]
   },
   {

--- a/aviary/models/external_subsystems/open_aero_struct/run_OAS_wing_mass_example.py
+++ b/aviary/models/external_subsystems/open_aero_struct/run_OAS_wing_mass_example.py
@@ -116,7 +116,6 @@ phase_info = {
 }
 
 phase_info['pre_mission'] = {'include_takeoff': False, 'optimize_mass': True}
-phase_info['pre_mission']['external_subsystems'] = [wing_mass_builder]
 
 aircraft_definition_file = 'models/aircraft/advanced_single_aisle/advanced_single_aisle_FLOPS.csv'
 make_plots = False
@@ -125,6 +124,7 @@ make_plots = False
 prob = av.AviaryProblem()
 
 prob.load_inputs(aircraft_definition_file, phase_info)
+prob.load_external_subsystems([wing_mass_builder])
 prob.check_and_preprocess_inputs()
 prob.build_model()
 prob.add_driver(optimizer=optimizer)


### PR DESCRIPTION
### Summary

Updates optimizers in some examples to IPOPT so they converge.

`detailed_takeoff_landing.ipynb` has a problem that does not converge with any optimizer, and `more_advanced_example.ipynb` has problems that only converge with SNOPT. These problems likely need a more thorough investigation (or more helpfully, a complete overhaul of those doc pages with new examples made from scratch)

### Related Issues

- Working towards #502

### Backwards incompatibilities

None

### New Dependencies

None