### PR TITLE
removed Mission.FUEL_FLOW_SCALER

### DIFF
--- a/aviary/docs/examples_unreviewed/modified_aircraft.csv
+++ b/aviary/docs/examples_unreviewed/modified_aircraft.csv
@@ -148,7 +148,6 @@ aircraft:design:range,3500,NM
 aircraft:design:thrust_takeoff_per_eng,28928.1,lbf
 mission:landing:lift_coefficient_max,2.0,unitless
 aircraft:design:cruise_mach,0.785,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:takeoff:fuel,577,lbm
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless

--- a/aviary/interface/test/sizing_results_for_test.json
+++ b/aviary/interface/test/sizing_results_for_test.json
@@ -1011,12 +1011,6 @@
         "<class 'float'>"
     ],
     [
-        "mission:fuel_flow_scaler",
-        1.0,
-        "unitless",
-        "<class 'float'>"
-    ],
-    [
         "mission:takeoff:fuel",
         577.0,
         "lbm",

--- a/aviary/mission/two_dof/ode/params.py
+++ b/aviary/mission/two_dof/ode/params.py
@@ -94,7 +94,6 @@ params_for_unit_tests = {
     Aircraft.Wing.SPAN: dict(units='ft', val=117.8),
     Aircraft.Design.GROSS_MASS: dict(units='lbm', val=175400),
     Mission.GROSS_MASS: dict(units='lbm', val=175400),
-    Mission.FUEL_FLOW_SCALER: dict(units='unitless', val=1.0),
     Mission.Takeoff.AIRPORT_ALTITUDE: dict(units='ft', val=0),
     Mission.Landing.AIRPORT_ALTITUDE: dict(units='ft', val=0),
     Aircraft.Wing.AVERAGE_CHORD: dict(units='ft', val=12.615),

--- a/aviary/models/aircraft/advanced_single_aisle/advanced_single_aisle_FLOPS.csv
+++ b/aviary/models/aircraft/advanced_single_aisle/advanced_single_aisle_FLOPS.csv
@@ -179,7 +179,6 @@ mission:landing:rolling_friction_coefficient,0.0175,unitless
 mission:landing:spoiler_drag_coefficient,0.085,unitless
 mission:landing:spoiler_lift_coefficient,-0.81,unitless
 aircraft:design:cruise_mach,0.785,unitless
-mission:fuel_flow_scaler,1,unitless
 mission:takeoff:airport_altitude,0,ft
 mission:takeoff:angle_of_attack_runway,0,deg
 mission:takeoff:braking_friction_coefficient,0.35,unitless

--- a/aviary/models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py
+++ b/aviary/models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py
@@ -294,7 +294,6 @@ inputs.set_val(Aircraft.Wing.WETTED_AREA_SCALER, 1.0)
 # Mission
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.785)
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 inputs.set_val(Aircraft.Design.RANGE, 3500, 'NM')
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.785)
 inputs.set_val(Mission.Landing.DRAG_COEFFICIENT_MIN, 0.045, 'unitless')

--- a/aviary/models/aircraft/blended_wing_body/bwb300_baseline_FLOPS.csv
+++ b/aviary/models/aircraft/blended_wing_body/bwb300_baseline_FLOPS.csv
@@ -183,7 +183,6 @@ mission:landing:flare_rate,3.0,deg/s
 mission:landing:initial_velocity,150.0,ft/s
 mission:landing:lift_coefficient_max,3.0,unitless
 aircraft:design:cruise_mach,0.85,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:takeoff:angle_of_attack_runway,4.0,deg
 mission:takeoff:braking_friction_coefficient,0.35,unitless
 mission:takeoff:drag_coefficient_min,0.035258,unitless

--- a/aviary/models/aircraft/blended_wing_body/bwb_detailed_FLOPS.csv
+++ b/aviary/models/aircraft/blended_wing_body/bwb_detailed_FLOPS.csv
@@ -165,7 +165,6 @@ mission:landing:lift_coefficient_max,3.0,unitless
 mission:landing:rolling_friction_coefficient,0.025,unitless
 mission:takeoff:lift_coefficient_max,2.0,unitless
 aircraft:design:cruise_mach,0.85,unitless
-mission:fuel_flow_scaler,1.0,unitless
 settings:aerodynamics_method,FLOPS,unitless
 settings:equations_of_motion,energy_state,unitless
 settings:mass_method,FLOPS,unitless

--- a/aviary/models/aircraft/blended_wing_body/bwb_detailed_FLOPS_data.py
+++ b/aviary/models/aircraft/blended_wing_body/bwb_detailed_FLOPS_data.py
@@ -276,7 +276,6 @@ inputs.set_val(Aircraft.Wing.SPAN_EFFICIENCY_FACTOR, 0.0)  # E
 # Mission
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.85)  # VCMN
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)  # FACT
 inputs.set_val(Aircraft.Design.RANGE, 7750.0, 'NM')  # DESRNG
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.85)  # VMMO
 # inputs.set_val(Mission.Takeoff.FUEL, 577, 'lbm')  # FTKOFL

--- a/aviary/models/aircraft/blended_wing_body/bwb_simple_FLOPS.csv
+++ b/aviary/models/aircraft/blended_wing_body/bwb_simple_FLOPS.csv
@@ -164,7 +164,6 @@ mission:landing:lift_coefficient_max,3.0,unitless
 mission:landing:rolling_friction_coefficient,0.025,unitless
 mission:takeoff:lift_coefficient_max,2.0,unitless
 aircraft:design:cruise_mach,0.85,unitless
-mission:fuel_flow_scaler,1.0,unitless
 settings:aerodynamics_method,FLOPS,unitless
 settings:equations_of_motion,energy_state,unitless
 settings:mass_method,FLOPS,unitless

--- a/aviary/models/aircraft/blended_wing_body/bwb_simple_FLOPS_data.py
+++ b/aviary/models/aircraft/blended_wing_body/bwb_simple_FLOPS_data.py
@@ -224,7 +224,6 @@ inputs.set_val(Aircraft.Wing.SPAN_EFFICIENCY_FACTOR, 0.0)  # E
 # Mission
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.85)  # VCMN
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)  # FACT
 inputs.set_val(Aircraft.Design.RANGE, 7750.0, 'NM')  # DESRNG
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.85)  # VMMO
 # inputs.set_val(Mission.Takeoff.FUEL, 577, 'lbm')  # FTKOFL

--- a/aviary/models/aircraft/blended_wing_body/generic_BWB_GASP.csv
+++ b/aviary/models/aircraft/blended_wing_body/generic_BWB_GASP.csv
@@ -161,7 +161,6 @@ mission:landing:maximum_flare_load_factor,1.15,unitless
 mission:landing:maximum_sink_rate,900,ft/min
 mission:landing:obstacle_height,50,ft
 mission:landing:touchdown_sink_rate,5,ft/s
-mission:fuel_flow_scaler,1,unitless
 mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h

--- a/aviary/models/aircraft/large_single_aisle_1/large_single_aisle_1_FLOPS_data.csv
+++ b/aviary/models/aircraft/large_single_aisle_1/large_single_aisle_1_FLOPS_data.csv
@@ -151,7 +151,6 @@ aircraft:wing:var_sweep_mass_penalty,0.0,unitless
 aircraft:wing:wetted_area,2396.56,ft**2
 aircraft:wing:wetted_area_scaler,1.0,unitless
 mission:constraints:max_mach,0.785,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:lift_coefficient_max,3.0,unitless
 mission:takeoff:fuel,577.0,lbm
 mission:takeoff:lift_coefficient_max,2.0,unitless

--- a/aviary/models/aircraft/large_single_aisle_1/large_single_aisle_1_FLOPS_data.py
+++ b/aviary/models/aircraft/large_single_aisle_1/large_single_aisle_1_FLOPS_data.py
@@ -226,7 +226,6 @@ inputs.set_val(Aircraft.Wing.WETTED_AREA_SCALER, 1.0)
 # Mission
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.785)
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 inputs.set_val(Aircraft.Design.RANGE, 3500, 'NM')
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.785)
 # TODO investigate the origin of these values (taken from benchmark tests)

--- a/aviary/models/aircraft/large_single_aisle_1/large_single_aisle_1_GASP.csv
+++ b/aviary/models/aircraft/large_single_aisle_1/large_single_aisle_1_GASP.csv
@@ -148,7 +148,6 @@ mission:landing:maximum_flare_load_factor,1.15,unitless
 mission:landing:maximum_sink_rate,900,ft/min
 mission:landing:obstacle_height,50,ft
 mission:landing:touchdown_sink_rate,5,ft/s
-mission:fuel_flow_scaler,1,unitless
 mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h

--- a/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_FLOPS_data.csv
+++ b/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_FLOPS_data.csv
@@ -149,7 +149,6 @@ aircraft:wing:var_sweep_mass_penalty,0.0,unitless
 aircraft:wing:wetted_area,2423.02,ft**2
 aircraft:wing:wetted_area_scaler,1.0,unitless
 mission:constraints:max_mach,0.82,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:lift_coefficient_max,3.0,unitless
 mission:takeoff:fuel,659.0,lbm
 mission:takeoff:lift_coefficient_max,2.0,unitless

--- a/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_FLOPS_data.py
+++ b/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_FLOPS_data.py
@@ -229,7 +229,6 @@ inputs.set_val(Aircraft.Wing.WETTED_AREA_SCALER, 1.0)
 # Mission
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.785)
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 inputs.set_val(Aircraft.Design.RANGE, 2960.0, 'NM')
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.82)
 # TODO investigate the origin of these values (taken from benchmark tests)

--- a/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_altwt_FLOPS_data.csv
+++ b/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_altwt_FLOPS_data.csv
@@ -149,7 +149,6 @@ aircraft:wing:var_sweep_mass_penalty,0.0,unitless
 aircraft:wing:wetted_area,2423.02,ft**2
 aircraft:wing:wetted_area_scaler,1.0,unitless
 mission:constraints:max_mach,0.82,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:lift_coefficient_max,3.0,unitless
 mission:takeoff:fuel,659.0,lbm
 mission:takeoff:lift_coefficient_max,2.0,unitless

--- a/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_altwt_FLOPS_data.py
+++ b/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_altwt_FLOPS_data.py
@@ -230,7 +230,6 @@ inputs.set_val(Aircraft.Wing.WETTED_AREA_SCALER, 1.0)
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.785)
 inputs.set_val(Aircraft.Design.RANGE, 2960.0, 'NM')
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.82)
 # TODO investigate the origin of these values (taken from benchmark tests)
 # TODO: where should this get connected from?

--- a/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_detailwing_FLOPS_data.csv
+++ b/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_detailwing_FLOPS_data.csv
@@ -147,7 +147,6 @@ aircraft:wing:var_sweep_mass_penalty,0.0,unitless
 aircraft:wing:wetted_area,2423.02,ft**2
 aircraft:wing:wetted_area_scaler,1.0,unitless
 mission:constraints:max_mach,0.82,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:lift_coefficient_max,3.0,unitless
 mission:takeoff:fuel,577.0,lbm
 mission:takeoff:lift_coefficient_max,2.0,unitless

--- a/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_detailwing_FLOPS_data.py
+++ b/aviary/models/aircraft/large_single_aisle_2/large_single_aisle_2_detailwing_FLOPS_data.py
@@ -223,7 +223,6 @@ inputs.set_val(Aircraft.Wing.WETTED_AREA_SCALER, 1.0)
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.785)  # was 0.82
 inputs.set_val(Aircraft.Design.RANGE, 2960.0, 'NM')
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.82)
 # TODO investigate the origin of these values (taken from benchmark tests)
 # TODO: where should this get connected from?

--- a/aviary/models/aircraft/large_turboprop_freighter/large_turboprop_freighter_GASP.csv
+++ b/aviary/models/aircraft/large_turboprop_freighter/large_turboprop_freighter_GASP.csv
@@ -187,11 +187,6 @@ aircraft:strut:fuselage_interference_factor, 0, unitless
 aircraft:strut:mass_coefficient, 0, unitless
 aircraft:furnishings:mass, 0, lbm
 
-###########
-# MISSION #
-###########
-mission:fuel_flow_scaler, 1, unitless
-
 # Design
 aircraft:design:cruise_altitude, 21000, ft
 aircraft:design:gross_mass, 155000, lbm

--- a/aviary/models/aircraft/multi_engine_single_aisle/multi_engine_single_aisle_data.csv
+++ b/aviary/models/aircraft/multi_engine_single_aisle/multi_engine_single_aisle_data.csv
@@ -125,7 +125,6 @@ aircraft:wing:var_sweep_mass_penalty,0.0,unitless
 aircraft:wing:wetted_area,2423.02,ft**2
 aircraft:wing:wetted_area_scaler,1.0,unitless
 mission:constraints:max_mach,0.82,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:lift_coefficient_max,3.0,unitless
 mission:takeoff:fuel,577.0,lbm
 mission:takeoff:lift_coefficient_max,2.0,unitless

--- a/aviary/models/aircraft/multi_engine_single_aisle/multi_engine_single_aisle_data.py
+++ b/aviary/models/aircraft/multi_engine_single_aisle/multi_engine_single_aisle_data.py
@@ -177,7 +177,6 @@ engine_1_inputs.set_val(Aircraft.Engine.FLIGHT_IDLE_MAX_FRACTION, 1.0)
 engine_1_inputs.set_val(Aircraft.Engine.FLIGHT_IDLE_MIN_FRACTION, 0.08)
 engine_1_inputs.set_val(Aircraft.Engine.GEOPOTENTIAL_ALT, False)
 engine_1_inputs.set_val(Aircraft.Engine.INTERPOLATION_METHOD, 'slinear')
-engine_1_inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 
 # Engine 2:
 filename = get_path('models/engines/turbofan_22k.csv')
@@ -209,7 +208,6 @@ engine_2_inputs.set_val(Aircraft.Engine.FLIGHT_IDLE_MAX_FRACTION, 1.0)
 engine_2_inputs.set_val(Aircraft.Engine.FLIGHT_IDLE_MIN_FRACTION, 0.08)
 engine_2_inputs.set_val(Aircraft.Engine.GEOPOTENTIAL_ALT, False)
 engine_2_inputs.set_val(Aircraft.Engine.INTERPOLATION_METHOD, 'slinear')
-engine_2_inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 
 # Vertical Tail
 # ---------------------------
@@ -262,7 +260,6 @@ inputs.set_val(Aircraft.Wing.WETTED_AREA_SCALER, 1.0)
 # ---------------------------
 inputs.set_val(Aircraft.Design.CRUISE_MACH, 0.785)  # was 0.82
 inputs.set_val(Aircraft.Design.RANGE, 2960.0, 'NM')
-inputs.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
 inputs.set_val(Mission.Constraints.MAX_MACH, 0.82)
 # TODO investigate the origin of these values (taken from benchmark tests)
 # TODO: where should this get connected from?

--- a/aviary/models/aircraft/small_single_aisle/small_single_aisle_GASP.csv
+++ b/aviary/models/aircraft/small_single_aisle/small_single_aisle_GASP.csv
@@ -147,7 +147,6 @@ mission:landing:maximum_flare_load_factor,1.15,unitless
 mission:landing:maximum_sink_rate,900,ft/min
 mission:landing:obstacle_height,50,ft
 mission:landing:touchdown_sink_rate,5,ft/s
-mission:fuel_flow_scaler,1,unitless
 mission:gross_mass,124780
 mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn

--- a/aviary/models/aircraft/test_aircraft/aircraft_for_bench_FwFm.csv
+++ b/aviary/models/aircraft/test_aircraft/aircraft_for_bench_FwFm.csv
@@ -148,7 +148,6 @@ aircraft:design:range,3500,NM
 aircraft:design:thrust_takeoff_per_eng,28928.1,lbf
 mission:landing:lift_coefficient_max,2.0,unitless
 aircraft:design:cruise_mach,0.785,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:takeoff:fuel,577,lbm
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless

--- a/aviary/models/aircraft/test_aircraft/aircraft_for_bench_FwFm_with_electric.csv
+++ b/aviary/models/aircraft/test_aircraft/aircraft_for_bench_FwFm_with_electric.csv
@@ -147,7 +147,6 @@ aircraft:design:range,3500,NM
 aircraft:design:thrust_takeoff_per_eng,28928.1,lbf
 mission:landing:lift_coefficient_max,2.0,unitless
 aircraft:design:cruise_mach,0.785,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:takeoff:fuel,577,lbm
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless

--- a/aviary/models/aircraft/test_aircraft/aircraft_for_bench_FwGm.csv
+++ b/aviary/models/aircraft/test_aircraft/aircraft_for_bench_FwGm.csv
@@ -143,7 +143,6 @@ mission:landing:maximum_flare_load_factor,1.15,unitless
 mission:landing:maximum_sink_rate,900,ft/min
 mission:landing:obstacle_height,50,ft
 mission:landing:touchdown_sink_rate,5,ft/s
-mission:fuel_flow_scaler,1.0,unitless
 mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h

--- a/aviary/models/aircraft/test_aircraft/aircraft_for_bench_GwFm.csv
+++ b/aviary/models/aircraft/test_aircraft/aircraft_for_bench_GwFm.csv
@@ -152,7 +152,6 @@ mission:landing:drag_coefficient_flap_increment,0.0406,unitless
 mission:landing:lift_coefficient_flap_increment,1.0293,unitless
 mission:landing:lift_coefficient_max,2.8155,unitless
 aircraft:design:cruise_mach,0.785,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:gross_mass,175400,lbm
 mission:takeoff:airport_altitude,0,ft
 mission:takeoff:drag_coefficient_flap_increment,0.0085,unitless

--- a/aviary/models/aircraft/test_aircraft/aircraft_for_bench_GwGm.csv
+++ b/aviary/models/aircraft/test_aircraft/aircraft_for_bench_GwGm.csv
@@ -151,7 +151,6 @@ mission:landing:maximum_flare_load_factor,1.15,unitless
 mission:landing:maximum_sink_rate,900,ft/min
 mission:landing:obstacle_height,50,ft
 mission:landing:touchdown_sink_rate,5,ft/s
-mission:fuel_flow_scaler,1,unitless
 mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h

--- a/aviary/models/aircraft/test_aircraft/aircraft_for_bench_solved2dof.csv
+++ b/aviary/models/aircraft/test_aircraft/aircraft_for_bench_solved2dof.csv
@@ -147,7 +147,6 @@ aircraft:design:range,3500,NM
 aircraft:design:thrust_takeoff_per_eng,28928.1,lbf
 mission:landing:lift_coefficient_max,2.0,unitless
 aircraft:design:cruise_mach,0.785,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:takeoff:fuel,577,lbm
 mission:takeoff:lift_coefficient_max,3.0,unitless
 mission:takeoff:lift_over_drag,17.354,unitless

--- a/aviary/models/aircraft/test_aircraft/configuration_test_GASP.csv
+++ b/aviary/models/aircraft/test_aircraft/configuration_test_GASP.csv
@@ -146,7 +146,6 @@ mission:landing:maximum_flare_load_factor,1.15,unitless
 mission:landing:maximum_sink_rate,900,ft/min
 mission:landing:obstacle_height,50,ft
 mission:landing:touchdown_sink_rate,5,ft/s
-mission:fuel_flow_scaler,1,unitless
 mission:takeoff:decision_speed_increment,10,kn
 mission:takeoff:rotation_speed_increment,5,kn
 mission:taxi:duration,0.1677,h

--- a/aviary/subsystems/aerodynamics/flops_based/test/data/high_wing_single_aisle.csv
+++ b/aviary/subsystems/aerodynamics/flops_based/test/data/high_wing_single_aisle.csv
@@ -46,7 +46,7 @@ aircraft:engine:reference_sls_thrust,23000.0,lbf
 aircraft:engine:scale_mass,True,unitless
 aircraft:engine:scaled_sls_thrust,23000.0,lbf
 aircraft:engine:subsonic_fuel_flow_scaler,1.01,unitless   #check, multiplied by MISSN.FACT
-aircraft:engine:supersonic_fuel_flow_scaler,1.01.,unitless   #check, multiplied by MISSN.FACT
+aircraft:engine:supersonic_fuel_flow_scaler,1.01,unitless   #check, multiplied by MISSN.FACT
 aircraft:engine:thrust_reversers_mass_scaler,0.01,unitless   #check
 aircraft:engine:wing_locations,0.22,unitless
 aircraft:fins:num_fins,0,unitless

--- a/aviary/subsystems/aerodynamics/flops_based/test/data/high_wing_single_aisle.csv
+++ b/aviary/subsystems/aerodynamics/flops_based/test/data/high_wing_single_aisle.csv
@@ -45,8 +45,8 @@ aircraft:engine:reference_mass,4600.0,lbm
 aircraft:engine:reference_sls_thrust,23000.0,lbf
 aircraft:engine:scale_mass,True,unitless
 aircraft:engine:scaled_sls_thrust,23000.0,lbf
-aircraft:engine:subsonic_fuel_flow_scaler,1.,unitless
-aircraft:engine:supersonic_fuel_flow_scaler,1.,unitless
+aircraft:engine:subsonic_fuel_flow_scaler,1.01,unitless   #check, multiplied by MISSN.FACT
+aircraft:engine:supersonic_fuel_flow_scaler,1.01.,unitless   #check, multiplied by MISSN.FACT
 aircraft:engine:thrust_reversers_mass_scaler,0.01,unitless   #check
 aircraft:engine:wing_locations,0.22,unitless
 aircraft:fins:num_fins,0,unitless
@@ -132,7 +132,6 @@ aircraft:design:range,3500,NM
 aircraft:design:thrust_takeoff_per_eng,23000.0,lbf
 mission:landing:lift_coefficient_max,2.7,unitless
 aircraft:design:cruise_mach,0.8,unitless
-mission:fuel_flow_scaler,1.01,unitless   #check
 mission:takeoff:fuel,400,lbm
 mission:takeoff:lift_coefficient_max,2.55,unitless
 mission:takeoff:lift_over_drag,25,unitless

--- a/aviary/subsystems/propulsion/engine_deck.py
+++ b/aviary/subsystems/propulsion/engine_deck.py
@@ -100,10 +100,6 @@ required_options = (
     Aircraft.Engine.GENERATE_FLIGHT_IDLE,
     Aircraft.Engine.INTERPOLATION_METHOD,
     Aircraft.Engine.INTERPOLATION_SORT,
-    # TODO fuel flow scaler is required for the EngineScaling component but does not need to be
-    # defined on a per-engine basis, so it could exist only in the problem-level aviary_options
-    # without issue. Is this a propulsion_preprocessor task?
-    Mission.FUEL_FLOW_SCALER,
 )
 
 # options that are only required based on the value of another option

--- a/aviary/subsystems/propulsion/engine_scaling.py
+++ b/aviary/subsystems/propulsion/engine_scaling.py
@@ -48,7 +48,6 @@ class EngineScaling(om.ExplicitComponent):
         add_aviary_option(self, Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM)
         add_aviary_option(self, Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER)
         add_aviary_option(self, Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER)
-        add_aviary_option(self, Mission.FUEL_FLOW_SCALER)
 
     def setup(self):
         nn = self.options['num_nodes']
@@ -109,7 +108,6 @@ class EngineScaling(om.ExplicitComponent):
         constant_fuel_term = options[Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM]
         linear_fuel_term = options[Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM]
         constant_fuel_flow, _ = options[Aircraft.Engine.CONSTANT_FUEL_CONSUMPTION]
-        mission_fuel_scaler = options[Mission.FUEL_FLOW_SCALER]
 
         # thrust-based engine scaling factor
         engine_scale_factor = inputs[Aircraft.Engine.SCALE_FACTOR]
@@ -130,10 +128,7 @@ class EngineScaling(om.ExplicitComponent):
         fuel_flow_mach_scaling[supersonic_idx] = supersonic_fuel_factor
 
         fuel_flow_scale_factor = (
-            engine_scale_factor
-            * fuel_flow_mach_scaling
-            * fuel_flow_equation_scaling
-            * mission_fuel_scaler
+            engine_scale_factor * fuel_flow_mach_scaling * fuel_flow_equation_scaling
         )
 
         scale_factor = engine_scale_factor
@@ -215,7 +210,6 @@ class EngineScaling(om.ExplicitComponent):
         supersonic_fuel_factor = options[Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER]
         constant_fuel_term = options[Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM]
         linear_fuel_term = options[Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM]
-        mission_fuel_scaler = options[Mission.FUEL_FLOW_SCALER]
 
         mach_number = inputs[Dynamic.Atmosphere.MACH]
         engine_scale_factor = inputs[Aircraft.Engine.SCALE_FACTOR]
@@ -234,15 +228,11 @@ class EngineScaling(om.ExplicitComponent):
             )
 
             fuel_flow_deriv = (
-                -engine_scale_factor
-                * fuel_flow_mach_scaling
-                * fuel_flow_equation_scaling
-                * mission_fuel_scaler
+                -engine_scale_factor * fuel_flow_mach_scaling * fuel_flow_equation_scaling
             )
 
             fuel_flow_scale_deriv = (
                 -fuel_flow_mach_scaling
-                * mission_fuel_scaler
                 * inputs['fuel_flow_rate_unscaled']
                 * (
                     1

--- a/aviary/subsystems/propulsion/test/test_engine_scaling.py
+++ b/aviary/subsystems/propulsion/test/test_engine_scaling.py
@@ -28,9 +28,9 @@ class EngineScalingTest(unittest.TestCase):
         options = AviaryValues()
         options.set_val(Settings.VERBOSITY, 0)
         options.set_val(Aircraft.Engine.DATA_FILE, filename)
-        options.set_val(Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER, 0.9)
+        options.set_val(Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER, 9)
         # make supersonic scaling factor extremely high so it is obvious if it gets used
-        options.set_val(Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER, 100)
+        options.set_val(Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER, 1000)
         options.set_val(Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM, 1.15)
         options.set_val(Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM, 1.05)
         options.set_val(Aircraft.Engine.CONSTANT_FUEL_CONSUMPTION, 10.0, units='lbm/h')
@@ -48,7 +48,6 @@ class EngineScalingTest(unittest.TestCase):
 
         preprocess_propulsion(options, [engine1])
 
-        options.set_val(Mission.FUEL_FLOW_SCALER, 10.0)
         engine_variables = {
             EngineModelVariables.THRUST: 'lbf',
             EngineModelVariables.FUEL_FLOW: 'lbm/h',

--- a/aviary/subsystems/propulsion/test/test_propulsion_mission.py
+++ b/aviary/subsystems/propulsion/test/test_propulsion_mission.py
@@ -48,7 +48,6 @@ class PropulsionMissionTest(unittest.TestCase):
         options.set_val(Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM, 0.0)
         options.set_val(Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM, 1.0)
         options.set_val(Aircraft.Engine.CONSTANT_FUEL_CONSUMPTION, 0.0, units='lbm/h')
-        options.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
         options.set_val(Aircraft.Engine.SCALE_FACTOR, 0.5)
         options.set_val(Aircraft.Engine.IGNORE_NEGATIVE_THRUST, False)
 

--- a/aviary/subsystems/propulsion/test/test_turboprop_model.py
+++ b/aviary/subsystems/propulsion/test/test_turboprop_model.py
@@ -38,7 +38,6 @@ class TurbopropMissionTest(unittest.TestCase):
         options.set_val(Aircraft.Engine.FUEL_FLOW_SCALER_CONSTANT_TERM, 0.0)
         options.set_val(Aircraft.Engine.FUEL_FLOW_SCALER_LINEAR_TERM, 1.0)
         options.set_val(Aircraft.Engine.CONSTANT_FUEL_CONSUMPTION, 0.0, units='lbm/h')
-        options.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
         options.set_val(Aircraft.Engine.SCALE_FACTOR, 1)
         options.set_val(Aircraft.Engine.GENERATE_FLIGHT_IDLE, False)
         options.set_val(Aircraft.Engine.IGNORE_NEGATIVE_THRUST, False)

--- a/aviary/subsystems/propulsion/utils.py
+++ b/aviary/subsystems/propulsion/utils.py
@@ -156,9 +156,7 @@ def build_engine_deck(
     EngineDeck
         EngineDeck created using provided options.
     """
-    # Required engine vars include one setting from Mission.*
     engine_vars = [item for item in Aircraft.Engine.__dict__.values()]
-    engine_vars.append(Mission.FUEL_FLOW_SCALER)
 
     # Build a single engine deck, currently ignoring vectorization of AviaryValues
     # (use first item in arrays when appropriate)

--- a/aviary/utils/fortran_to_aviary.py
+++ b/aviary/utils/fortran_to_aviary.py
@@ -1265,6 +1265,27 @@ def update_flops_options(vehicle_data, verbosity=Verbosity.BRIEF):
             ARHT = input_values.get_val(Aircraft.HorizontalTail.ASPECT_RATIO)[0]
             input_values.set_val(Aircraft.VerticalTail.ASPECT_RATIO, [ARHT / 2.0], 'unitless')
 
+    # if mission-wide fuel flow factor provided, combine into sub and supersonic fuel flow factors
+    if 'MISSIN.fact' in vehicle_data['unused_values']:
+        FACT = vehicle_data['unused_values'].get_item('MISSIN.fact')[0][0]
+        if Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER in input_values:
+            sub_fuel_flow_fact = input_values.get_val(Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER)[0]
+            input_values.set_val(
+                Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER, [sub_fuel_flow_fact * FACT]
+            )
+        else:
+            input_values.set_val(Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER, [FACT])
+        if Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER in input_values:
+            sup_fuel_flow_fact = input_values.get_val(Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER)[
+                0
+            ]
+            input_values.set_val(
+                Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER, [sup_fuel_flow_fact * FACT]
+            )
+        else:
+            input_values.set_val(Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER, [FACT])
+        vehicle_data['unused_values'].delete('MISSIN.fact')
+
     # These variables should be removed if they are zero.
     rem_list = [
         (Aircraft.Design.TOUCHDOWN_MASS_MAX, 'lbm'),

--- a/aviary/utils/preprocessors.py
+++ b/aviary/utils/preprocessors.py
@@ -847,9 +847,6 @@ def preprocess_propulsion(
     aviary_options.set_val(Aircraft.Engine.NUM_WING_ENGINES, num_wing_engines_all)
     aviary_options.set_val(Aircraft.Engine.NUM_FUSELAGE_ENGINES, num_fuse_engines_all)
 
-    if Mission.FUEL_FLOW_SCALER not in aviary_options:
-        aviary_options.set_val(Mission.FUEL_FLOW_SCALER, 1.0)
-
     num_engines = aviary_options.get_val(Aircraft.Engine.NUM_ENGINES)
     total_num_engines = int(sum(num_engines_all))
     total_num_fuse_engines = int(sum(num_fuse_engines_all))

--- a/aviary/utils/test/data/converter_test_BWB_GASP.csv
+++ b/aviary/utils/test/data/converter_test_BWB_GASP.csv
@@ -53,6 +53,8 @@ aircraft:engine:pod_mass_scaler,1.0,unitless
 aircraft:engine:pylon_factor,1.25,unitless
 aircraft:engine:reference_sls_thrust,28690.0,lbf
 aircraft:engine:scaled_sls_thrust,19580.2,lbf
+aircraft:engine:subsonic_fuel_flow_scaler,1.0,unitless
+aircraft:engine:supersonic_fuel_flow_scaler,1.0,unitless
 aircraft:engine:type,7,unitless
 aircraft:engine:wing_locations,0.0,unitless
 aircraft:fuel:density,6.687,lbm/galUS
@@ -159,7 +161,6 @@ aircraft:wing:thickness_to_chord_root,0.165,unitless
 aircraft:wing:thickness_to_chord_tip,0.1,unitless
 aircraft:wing:vertical_mount_location,0.5,unitless
 aircraft:wing:zero_lift_angle,0.0,deg
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1.0,s
 mission:landing:glide_to_stall_ratio,1.3,unitless

--- a/aviary/utils/test/data/converter_test_advanced_single_aisle_FLOPS.csv
+++ b/aviary/utils/test/data/converter_test_advanced_single_aisle_FLOPS.csv
@@ -154,7 +154,6 @@ aircraft:wing:ultimate_load_factor,3.75,unitless
 aircraft:wing:var_sweep_mass_penalty,0.0,unitless
 aircraft:wing:wetted_area,2210.280228,ft**2
 mission:constraints:max_mach,0.785,unitless
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:drag_coefficient_min,0.045,unitless
 mission:landing:flare_rate,2.2,deg/s
 mission:landing:initial_velocity,145.0,ft/s

--- a/aviary/utils/test/data/converter_test_configuration_GASP.csv
+++ b/aviary/utils/test/data/converter_test_configuration_GASP.csv
@@ -45,6 +45,8 @@ aircraft:engine:pod_mass_scaler,1.0,unitless
 aircraft:engine:pylon_factor,1.25,unitless
 aircraft:engine:reference_sls_thrust,28690.0,lbf
 aircraft:engine:scaled_sls_thrust,21162.0,lbf
+aircraft:engine:subsonic_fuel_flow_scaler,1.0,unitless
+aircraft:engine:supersonic_fuel_flow_scaler,1.0,unitless
 aircraft:engine:type,7,unitless
 aircraft:engine:wing_locations,0.2143,unitless
 aircraft:fuel:density,6.687,lbm/galUS
@@ -140,7 +142,6 @@ aircraft:wing:thickness_to_chord_root,0.11,unitless
 aircraft:wing:thickness_to_chord_tip,0.1,unitless
 aircraft:wing:vertical_mount_location,1.0,unitless
 aircraft:wing:zero_lift_angle,-1.2,deg
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1.0,s
 mission:landing:glide_to_stall_ratio,1.3,unitless

--- a/aviary/utils/test/data/converter_test_large_single_aisle_1_GASP.csv
+++ b/aviary/utils/test/data/converter_test_large_single_aisle_1_GASP.csv
@@ -45,6 +45,8 @@ aircraft:engine:pod_mass_scaler,1.0,unitless
 aircraft:engine:pylon_factor,1.25,unitless
 aircraft:engine:reference_sls_thrust,28690.0,lbf
 aircraft:engine:scaled_sls_thrust,28690.0,lbf
+aircraft:engine:subsonic_fuel_flow_scaler,1.0,unitless
+aircraft:engine:supersonic_fuel_flow_scaler,1.0,unitless
 aircraft:engine:type,7,unitless
 aircraft:engine:wing_locations,0.35,unitless
 aircraft:fuel:density,6.687,lbm/galUS
@@ -143,7 +145,6 @@ aircraft:wing:thickness_to_chord_root,0.15,unitless
 aircraft:wing:thickness_to_chord_tip,0.12,unitless
 aircraft:wing:vertical_mount_location,0.0,unitless
 aircraft:wing:zero_lift_angle,-1.2,deg
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1.0,s
 mission:landing:glide_to_stall_ratio,1.3,unitless

--- a/aviary/utils/test/data/converter_test_small_single_aisle_GASP.csv
+++ b/aviary/utils/test/data/converter_test_small_single_aisle_GASP.csv
@@ -45,6 +45,8 @@ aircraft:engine:pod_mass_scaler,1.0,unitless
 aircraft:engine:pylon_factor,0.6,unitless
 aircraft:engine:reference_sls_thrust,28690.0,lbf
 aircraft:engine:scaled_sls_thrust,23800.0,lbf
+aircraft:engine:subsonic_fuel_flow_scaler,1.0,unitless
+aircraft:engine:supersonic_fuel_flow_scaler,1.0,unitless
 aircraft:engine:type,7,unitless
 aircraft:engine:wing_locations,0.272,unitless
 aircraft:fuel:density,6.687,lbm/galUS
@@ -141,7 +143,6 @@ aircraft:wing:thickness_to_chord_root,0.1125,unitless
 aircraft:wing:thickness_to_chord_tip,0.12,unitless
 aircraft:wing:vertical_mount_location,0.0,unitless
 aircraft:wing:zero_lift_angle,-1.2,deg
-mission:fuel_flow_scaler,1.0,unitless
 mission:landing:airport_altitude,0,ft
 mission:landing:braking_delay,1.0,s
 mission:landing:glide_to_stall_ratio,1.3,unitless

--- a/aviary/utils/test/test_fortran_to_aviary.py
+++ b/aviary/utils/test/test_fortran_to_aviary.py
@@ -133,3 +133,5 @@ class TestFortranToAviary(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    # test = TestFortranToAviary()
+    # test.test_advanced_single_aisle()

--- a/aviary/variable_info/variable_meta_data.py
+++ b/aviary/variable_info/variable_meta_data.py
@@ -2397,7 +2397,7 @@ add_meta_data(
     Aircraft.Engine.SUBSONIC_FUEL_FLOW_SCALER,
     meta_data=_MetaData,
     historical_name={
-        'GASP': None,
+        'GASP': 'INGASP.CKFF',
         'FLOPS': 'ENGDIN.FFFSUB',
     },
     units='unitless',
@@ -2411,7 +2411,7 @@ add_meta_data(
     Aircraft.Engine.SUPERSONIC_FUEL_FLOW_SCALER,
     meta_data=_MetaData,
     historical_name={
-        'GASP': None,
+        'GASP': 'INGASP.CKFF',
         'FLOPS': 'ENGDIN.FFFSUP',
     },
     units='unitless',
@@ -6848,23 +6848,6 @@ add_meta_data(
     'This does not include fuel burned in reserve phases or taxi-in.'
     'The only time taxi-in would be included in this is if the user'
     'specifies a taxi phase as part of the regular mission phases.',
-)
-
-# NOTE if per-mission level scaling is not best mapping for GASP's 'CKFF', map
-#      to FFFSUB/FFFSUP
-# CKFF is consistent for one aircraft over all missions, once the vehicle is sized
-# can we map it to both FFFSUB and FFFSUP?
-add_meta_data(
-    Mission.FUEL_FLOW_SCALER,
-    meta_data=_MetaData,
-    historical_name={
-        'GASP': 'INGASP.CKFF',
-        'FLOPS': 'MISSIN.FACT',  # ['&DEFMSS.MISSIN.FACT', 'TRNSF.FACT'],
-    },
-    units='unitless',
-    desc='scale factor on overall fuel flow',
-    default_value=1.0,
-    option=True,
 )
 
 add_meta_data(

--- a/aviary/variable_info/variables.py
+++ b/aviary/variable_info/variables.py
@@ -671,7 +671,6 @@ class Mission:
     FINAL_MASS = 'mission:final_mass'
     FINAL_TIME = 'mission:final_time'
     FUEL = 'mission:fuel'
-    FUEL_FLOW_SCALER = 'mission:fuel_flow_scaler'
     GROSS_MASS = 'mission:gross_mass'
     OPERATING_MASS = 'mission:operating_mass'
     RANGE = 'mission:range'


### PR DESCRIPTION
### Summary

Mission.FUEL_FLOW_SCALER is a per-mission fuel flow scaling factor present in FLOPS. Aviary currently does not support per-mission modifications of variables in the input deck (i.e. csv file), so this variable is redundant with the subsonic and supersonic fuel flow factors that already exist.

Fortran-to-aviary was updated to apply this fuel flow factor to any existing sub and supersonic factors. For GASP, it splits the single fuel flow factor variable into the two.

### Related Issues

- Resolves #1048

### Backwards incompatibilities

Removes `Mission.FUEL_FLOW_SCALER`

### New Dependencies

None