### PR TITLE
Discontinuities in GASP based mass subsystem are removed

### DIFF
--- a/aviary/subsystems/mass/gasp_based/air_conditioning.py
+++ b/aviary/subsystems/mass/gasp_based/air_conditioning.py
@@ -1,12 +1,130 @@
 import openmdao.api as om
 
 from aviary.constants import GRAV_ENGLISH_LBM
-from aviary.variable_info.functions import add_aviary_input
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.utils.math import dSigmoidXdx, sigmoidX
+from aviary.variable_info.functions import add_aviary_input, add_aviary_option
+from aviary.variable_info.variables import Aircraft
+
+
+def common_compute(smooth, mu, x0, gross_wt_initial, fus_len, p_diff_fus, cabin_width, ac_coeff):
+    if smooth:
+        smoother = sigmoidX(gross_wt_initial, x0, mu)
+        # gross_wt_initial > 3500.0:
+        air_cond1_wt = ac_coeff * (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
+        # gross_wt_initial <= 3500.0:
+        air_cond2_wt = 5.0
+        air_conditioning_wt = smoother * air_cond1_wt + (1 - smoother) * air_cond2_wt
+    else:
+        if gross_wt_initial > 3500.0:
+            air_conditioning_wt = (
+                ac_coeff * (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
+            )
+        else:
+            air_conditioning_wt = 5.0
+
+    return air_conditioning_wt
+
+
+def common_conpute_partials(
+    smooth, mu, x0, gross_wt_initial, fus_len, p_diff_fus, cabin_width, ac_coeff
+):
+    if smooth:
+        air_cond1_wt = ac_coeff * (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
+        air_cond2_wt = 5.0
+
+        dac_wt_dgross_wt = (
+            dSigmoidXdx(gross_wt_initial, x0, mu) * air_cond1_wt
+            - dSigmoidXdx(gross_wt_initial, x0, mu) * air_cond2_wt
+        )
+    else:
+        dac_wt_dgross_wt = 0.0
+
+    # case gross_wt_initial > 3500.0:
+    dac_wt_dfus_1_len = (
+        0.5
+        * ac_coeff
+        * (1.5 + p_diff_fus)
+        * 0.358
+        * cabin_width**2
+        * (0.358 * fus_len * cabin_width**2) ** -0.5
+    )
+    dac_wt_dp_diff_1_fus = ac_coeff * (0.358 * fus_len * cabin_width**2) ** 0.5
+    dac_wt_dcabin_1_width = (
+        ac_coeff
+        * (1.5 + p_diff_fus)
+        * 0.358
+        * fus_len
+        * cabin_width
+        * (0.358 * fus_len * cabin_width**2) ** -0.5
+    )
+    dac_wt_dac_1_coeff = (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
+
+    # case gross_wt_initial <= 3500.0:
+    dac_wt_dfus_2_len = 0.0
+    dac_wt_dp_diff_2_fus = 0.0
+    dac_wt_dcabin_2_width = 0.0
+    dac_wt_dac_2_coeff = 0.0
+
+    if smooth:
+        dac_wt_dfus_len = (
+            sigmoidX(gross_wt_initial, x0, mu) * dac_wt_dfus_1_len
+            + (1 - sigmoidX(gross_wt_initial, x0, mu)) * dac_wt_dfus_2_len
+        )
+    else:
+        if gross_wt_initial > 3500.0:
+            dac_wt_dfus_len = dac_wt_dfus_1_len
+        else:
+            dac_wt_dfus_len = dac_wt_dfus_2_len
+
+    if smooth:
+        dac_wt_dp_diff_fus = (
+            sigmoidX(gross_wt_initial, x0, mu) * dac_wt_dp_diff_1_fus
+            + (1 - sigmoidX(gross_wt_initial, x0, mu)) * dac_wt_dp_diff_2_fus
+        )
+    else:
+        if gross_wt_initial > 3500.0:
+            dac_wt_dp_diff_fus = dac_wt_dp_diff_1_fus
+        else:
+            dac_wt_dp_diff_fus = dac_wt_dp_diff_2_fus
+
+    if smooth:
+        dac_wt_dcabin_width = (
+            sigmoidX(gross_wt_initial, x0, mu) * dac_wt_dcabin_1_width
+            + (1 - sigmoidX(gross_wt_initial, x0, mu)) * dac_wt_dcabin_2_width
+        )
+    else:
+        if gross_wt_initial > 3500.0:
+            dac_wt_dcabin_width = dac_wt_dcabin_1_width
+        else:
+            dac_wt_dcabin_width = dac_wt_dcabin_2_width
+
+    if smooth:
+        dac_wt_dac_coeff = (
+            sigmoidX(gross_wt_initial, x0, mu) * dac_wt_dac_1_coeff
+            + (1 - sigmoidX(gross_wt_initial, x0, mu)) * dac_wt_dac_2_coeff
+        )
+    else:
+        if gross_wt_initial > 3500.0:
+            dac_wt_dac_coeff = dac_wt_dac_1_coeff
+        else:
+            dac_wt_dac_coeff = dac_wt_dac_2_coeff
+
+    return [
+        dac_wt_dgross_wt,
+        dac_wt_dfus_len,
+        dac_wt_dp_diff_fus,
+        dac_wt_dcabin_width,
+        dac_wt_dac_coeff,
+    ]
 
 
 class ACMass(om.ExplicitComponent):
     """Computation of air conditioning mass."""
+
+    def initialize(self):
+        add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES)
+        self.options.declare('x0', default=3500.0, types=float)
+        self.options.declare('mu', default=0.01, types=float)
 
     def setup(self):
         add_aviary_input(self, Aircraft.AirConditioning.MASS_COEFFICIENT, units='unitless')
@@ -29,56 +147,39 @@ class ACMass(om.ExplicitComponent):
         )
 
     def compute(self, inputs, outputs):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
+        mu = self.options['mu']
+        x0 = self.options['x0']
         gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         p_diff_fus = inputs[Aircraft.Fuselage.PRESSURE_DIFFERENTIAL]
         cabin_width = inputs[Aircraft.Fuselage.AVG_DIAMETER]
         ac_coeff = inputs[Aircraft.AirConditioning.MASS_COEFFICIENT]
 
-        # note: this technically creates a discontinuity but we will not smooth it.
-        if gross_wt_initial > 3500.0:
-            air_conditioning_wt = (
-                ac_coeff * (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
-            )
-        else:
-            air_conditioning_wt = 5.0
-
+        air_conditioning_wt = common_compute(
+            smooth, mu, x0, gross_wt_initial, fus_len, p_diff_fus, cabin_width, ac_coeff
+        )
         outputs[Aircraft.AirConditioning.MASS] = air_conditioning_wt / GRAV_ENGLISH_LBM
 
     def compute_partials(self, inputs, J):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
+        mu = self.options['mu']
+        x0 = self.options['x0']
         gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         p_diff_fus = inputs[Aircraft.Fuselage.PRESSURE_DIFFERENTIAL]
         cabin_width = inputs[Aircraft.Fuselage.AVG_DIAMETER]
         ac_coeff = inputs[Aircraft.AirConditioning.MASS_COEFFICIENT]
 
-        dac_wt_dgross_wt = 0.0
-
-        if gross_wt_initial > 3500.0:
-            dac_wt_dfus_len = (
-                0.5
-                * ac_coeff
-                * (1.5 + p_diff_fus)
-                * 0.358
-                * cabin_width**2
-                * (0.358 * fus_len * cabin_width**2) ** -0.5
-            )
-            dac_wt_dp_diff_fus = ac_coeff * (0.358 * fus_len * cabin_width**2) ** 0.5
-            dac_wt_dcabin_width = (
-                ac_coeff
-                * (1.5 + p_diff_fus)
-                * 0.358
-                * fus_len
-                * cabin_width
-                * (0.358 * fus_len * cabin_width**2) ** -0.5
-            )
-            dac_wt_dac_coeff = (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
-        else:
-            dac_wt_dfus_len = 0.0
-            dac_wt_dp_diff_fus = 0.0
-            dac_wt_dcabin_width = 0.0
-            dac_wt_dac_coeff = 0.0
-
+        [
+            dac_wt_dgross_wt,
+            dac_wt_dfus_len,
+            dac_wt_dp_diff_fus,
+            dac_wt_dcabin_width,
+            dac_wt_dac_coeff,
+        ] = common_conpute_partials(
+            smooth, mu, x0, gross_wt_initial, fus_len, p_diff_fus, cabin_width, ac_coeff
+        )
         J[Aircraft.AirConditioning.MASS, Aircraft.Design.GROSS_MASS] = dac_wt_dgross_wt
         J[Aircraft.AirConditioning.MASS, Aircraft.Fuselage.LENGTH] = (
             dac_wt_dfus_len / GRAV_ENGLISH_LBM
@@ -96,6 +197,11 @@ class ACMass(om.ExplicitComponent):
 
 class BWBACMass(om.ExplicitComponent):
     """Computation of air conditioning mass for BWB."""
+
+    def initialize(self):
+        add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES)
+        self.options.declare('x0', default=3500.0, types=float)
+        self.options.declare('mu', default=0.01, types=float)
 
     def setup(self):
         add_aviary_input(self, Aircraft.AirConditioning.MASS_COEFFICIENT, units='unitless')
@@ -118,56 +224,40 @@ class BWBACMass(om.ExplicitComponent):
         )
 
     def compute(self, inputs, outputs):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
+        mu = self.options['mu']
+        x0 = self.options['x0']
         gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         p_diff_fus = inputs[Aircraft.Fuselage.PRESSURE_DIFFERENTIAL]
         cabin_width = inputs[Aircraft.Fuselage.HYDRAULIC_DIAMETER]
         ac_coeff = inputs[Aircraft.AirConditioning.MASS_COEFFICIENT]
 
-        # note: this technically creates a discontinuity but we will not smooth it.
-        if gross_wt_initial > 3500.0:
-            air_conditioning_wt = (
-                ac_coeff * (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
-            )
-        else:
-            air_conditioning_wt = 5.0
+        air_conditioning_wt = common_compute(
+            smooth, mu, x0, gross_wt_initial, fus_len, p_diff_fus, cabin_width, ac_coeff
+        )
 
         outputs[Aircraft.AirConditioning.MASS] = air_conditioning_wt / GRAV_ENGLISH_LBM
 
     def compute_partials(self, inputs, J):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
+        mu = self.options['mu']
+        x0 = self.options['x0']
         gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         p_diff_fus = inputs[Aircraft.Fuselage.PRESSURE_DIFFERENTIAL]
         cabin_width = inputs[Aircraft.Fuselage.HYDRAULIC_DIAMETER]
         ac_coeff = inputs[Aircraft.AirConditioning.MASS_COEFFICIENT]
 
-        dac_wt_dgross_wt = 0.0
-
-        if gross_wt_initial > 3500.0:
-            dac_wt_dfus_len = (
-                0.5
-                * ac_coeff
-                * (1.5 + p_diff_fus)
-                * 0.358
-                * cabin_width**2
-                * (0.358 * fus_len * cabin_width**2) ** -0.5
-            )
-            dac_wt_dp_diff_fus = ac_coeff * (0.358 * fus_len * cabin_width**2) ** 0.5
-            dac_wt_dcabin_width = (
-                ac_coeff
-                * (1.5 + p_diff_fus)
-                * 0.358
-                * fus_len
-                * cabin_width
-                * (0.358 * fus_len * cabin_width**2) ** -0.5
-            )
-            dac_wt_dac_coeff = (1.5 + p_diff_fus) * (0.358 * fus_len * cabin_width**2) ** 0.5
-        else:
-            dac_wt_dfus_len = 0.0
-            dac_wt_dp_diff_fus = 0.0
-            dac_wt_dcabin_width = 0.0
-            dac_wt_dac_coeff = 0.0
-
+        [
+            dac_wt_dgross_wt,
+            dac_wt_dfus_len,
+            dac_wt_dp_diff_fus,
+            dac_wt_dcabin_width,
+            dac_wt_dac_coeff,
+        ] = common_conpute_partials(
+            smooth, mu, x0, gross_wt_initial, fus_len, p_diff_fus, cabin_width, ac_coeff
+        )
         J[Aircraft.AirConditioning.MASS, Aircraft.Design.GROSS_MASS] = dac_wt_dgross_wt
         J[Aircraft.AirConditioning.MASS, Aircraft.Fuselage.LENGTH] = (
             dac_wt_dfus_len / GRAV_ENGLISH_LBM

--- a/aviary/subsystems/mass/gasp_based/anti_icing.py
+++ b/aviary/subsystems/mass/gasp_based/anti_icing.py
@@ -1,6 +1,7 @@
 import openmdao.api as om
 
 from aviary.constants import GRAV_ENGLISH_LBM
+from aviary.utils.math import d_smooth_max, smooth_max
 from aviary.variable_info.functions import add_aviary_input, add_aviary_option, add_aviary_output
 from aviary.variable_info.variables import Aircraft
 
@@ -13,6 +14,7 @@ class AntiIcingMass(om.ExplicitComponent):
 
     def initialize(self):
         add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES)
+        self.options.declare('mu', default=10.0, types=float)
 
     def setup(self):
         add_aviary_input(self, Aircraft.Wing.AREA, units='ft**2')
@@ -25,6 +27,7 @@ class AntiIcingMass(om.ExplicitComponent):
         self.declare_partials('*', '*')
 
     def compute(self, inputs, outputs):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
         wing_area = inputs[Aircraft.Wing.AREA]
         htail_area = inputs[Aircraft.HorizontalTail.AREA]
         vtail_area = inputs[Aircraft.VerticalTail.AREA]
@@ -32,12 +35,17 @@ class AntiIcingMass(om.ExplicitComponent):
         SSUM = wing_area + htail_area + vtail_area
         icing_wt = 22.7 * (SSUM**0.5) - 385.0
 
-        if icing_wt < 0.0:  # note: this technically creates a discontinuity
-            icing_wt = 0.0
+        if smooth:
+            mu = self.options['mu']
+            icing_wt = smooth_max(icing_wt, 0.0, mu)
+        else:
+            if icing_wt < 0.0:
+                icing_wt = 0.0
 
         outputs[Aircraft.AntiIcing.MASS] = icing_wt / GRAV_ENGLISH_LBM
 
     def compute_partials(self, inputs, J):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
         wing_area = inputs[Aircraft.Wing.AREA]
         htail_area = inputs[Aircraft.HorizontalTail.AREA]
         vtail_area = inputs[Aircraft.VerticalTail.AREA]
@@ -49,11 +57,21 @@ class AntiIcingMass(om.ExplicitComponent):
         dicing_weight_dhtail_area = 0.5 * 22.7 * (SSUM**-0.5) / GRAV_ENGLISH_LBM
         dicing_weight_dvtail_area = 0.5 * 22.7 * (SSUM**-0.5) / GRAV_ENGLISH_LBM
 
-        if icing_wt < 0.0:  # note: this technically creates a discontinuity
-            icing_wt = 0.0
-            dicing_weight_dwing_area = 0.0
-            dicing_weight_dhtail_area = 0.0
-            dicing_weight_dvtail_area = 0.0
+        if smooth:
+            import pdb
+
+            # pdb.set_trace()
+            mu = self.options['mu']
+            sm_fac = d_smooth_max(icing_wt, 0.0, mu)
+            dicing_weight_dwing_area = sm_fac * dicing_weight_dwing_area
+            dicing_weight_dhtail_area = sm_fac * dicing_weight_dhtail_area
+            dicing_weight_dvtail_area = sm_fac * dicing_weight_dvtail_area
+        else:
+            if icing_wt < 0.0:
+                icing_wt = 0.0
+                dicing_weight_dwing_area = 0.0
+                dicing_weight_dhtail_area = 0.0
+                dicing_weight_dvtail_area = 0.0
 
         J[Aircraft.AntiIcing.MASS, Aircraft.Wing.AREA] = dicing_weight_dwing_area
         J[Aircraft.AntiIcing.MASS, Aircraft.HorizontalTail.AREA] = dicing_weight_dhtail_area

--- a/aviary/subsystems/mass/gasp_based/avionics.py
+++ b/aviary/subsystems/mass/gasp_based/avionics.py
@@ -46,13 +46,13 @@ class AvionicsMass(om.ExplicitComponent):
                 # Should we use use 4 sigmoid functions (one for each transition zone) instead?
                 avionics_wt = 35.538 * np.exp(0.0002 * gross_wt_initial)
             else:
-                if gross_wt_initial >= 3000.0:  # note: this technically creates a discontinuity
+                if gross_wt_initial >= 3000.0:
                     avionics_wt = 65.0
-                if gross_wt_initial >= 5500.0:  # note: this technically creates a discontinuity
+                if gross_wt_initial >= 5500.0:
                     avionics_wt = 113.0
-                if gross_wt_initial >= 7500.0:  # note: this technically creates a discontinuity
+                if gross_wt_initial >= 7500.0:
                     avionics_wt = 163.0
-                if gross_wt_initial >= 11000.0:  # note: this technically creates a discontinuity
+                if gross_wt_initial >= 11000.0:
                     avionics_wt = 340.0
         if PAX >= 20 and PAX < 30:
             avionics_wt = 400.0

--- a/aviary/subsystems/mass/gasp_based/fuel_capacity.py
+++ b/aviary/subsystems/mass/gasp_based/fuel_capacity.py
@@ -1,12 +1,18 @@
 import openmdao.api as om
 
 from aviary.constants import GRAV_ENGLISH_LBM
-from aviary.variable_info.functions import add_aviary_input, add_aviary_output
+from aviary.utils.math import dSigmoidXdx, sigmoidX
+from aviary.variable_info.functions import add_aviary_input, add_aviary_option, add_aviary_output
 from aviary.variable_info.variables import Aircraft
 
 
 class TrappedFuelCapacity(om.ExplicitComponent):
     """Compute the maximum fuel that can be carried in the fuselage."""
+
+    def initialize(self):
+        add_aviary_option(self, Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES)
+        self.options.declare('x0', default=0.075, types=float)
+        self.options.declare('mu', default=0.01, types=float)
 
     def setup(self):
         add_aviary_input(self, Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT, units='unitless')
@@ -19,32 +25,81 @@ class TrappedFuelCapacity(om.ExplicitComponent):
         self.declare_partials('*', '*')
 
     def compute(self, inputs, outputs):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
+        mu = self.options['mu']
+        x0 = self.options['x0']
         wing_area = inputs[Aircraft.Wing.AREA]
         fuel_vol_frac = inputs[Aircraft.Fuel.WING_FUEL_FRACTION]
         unusable_fuel_coeff = inputs[Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT]
 
-        trapped_fuel_wt = unusable_fuel_coeff * (wing_area**0.5) * fuel_vol_frac / 0.430
+        if wing_area <= 0.0:
+            raise ValueError(
+                f'Aircraft.Wing.AREA must be positive, however {wing_area} is provided.'
+            )
 
-        if fuel_vol_frac <= 0.075:  # note: this technically creates a discontinuity # won't change
-            trapped_fuel_wt = unusable_fuel_coeff * 0.18 * (wing_area**0.5)
+        trapped_fuel_1_wt = unusable_fuel_coeff * (wing_area**0.5) * fuel_vol_frac / 0.430
+        trapped_fuel_2_wt = unusable_fuel_coeff * 0.18 * (wing_area**0.5)
+
+        import pdb
+
+        # pdb.set_trace()
+        if smooth:
+            smoother = sigmoidX(fuel_vol_frac, x0, mu)
+            trapped_fuel_wt = smoother * trapped_fuel_1_wt + (1 - smoother) * trapped_fuel_2_wt
+        else:
+            if fuel_vol_frac > 0.075:
+                trapped_fuel_wt = trapped_fuel_1_wt
+            else:
+                trapped_fuel_wt = trapped_fuel_2_wt
 
         outputs[Aircraft.Fuel.UNUSABLE_FUEL_MASS] = trapped_fuel_wt / GRAV_ENGLISH_LBM
 
     def compute_partials(self, inputs, J):
+        smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
+        mu = self.options['mu']
+        x0 = self.options['x0']
         wing_area = inputs[Aircraft.Wing.AREA]
         fuel_vol_frac = inputs[Aircraft.Fuel.WING_FUEL_FRACTION]
         unusable_fuel_coeff = inputs[Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT]
 
-        dtrapped_fuel_wt_dmass_coeff_12 = (wing_area**0.5) * fuel_vol_frac / 0.430
-        dtrapped_fuel_wt_dwing_area = (
-            0.5 * unusable_fuel_coeff * (wing_area**-0.5) * fuel_vol_frac / 0.430
-        )
-        dtrapped_fuel_wt_dfuel_vol_frac = unusable_fuel_coeff * (wing_area**0.5) / 0.430
-
-        if fuel_vol_frac <= 0.075:  # note: this technically creates a discontinuity # won't change
-            dtrapped_fuel_wt_dmass_coeff_12 = 0.18 * (wing_area**0.5)
-            dtrapped_fuel_wt_dwing_area = 0.5 * unusable_fuel_coeff * 0.18 * (wing_area**-0.5)
-            dtrapped_fuel_wt_dfuel_vol_frac = 0.0
+        if smooth:
+            smoother = sigmoidX(fuel_vol_frac, x0, mu)
+            dsmoother_dfuel_vol_frac = dSigmoidXdx(fuel_vol_frac, x0, mu)
+            trapped_fuel_1_wt = unusable_fuel_coeff * (wing_area**0.5) * fuel_vol_frac / 0.430
+            trapped_fuel_2_wt = unusable_fuel_coeff * 0.18 * (wing_area**0.5)
+            dtrapped_fuel_wt_dmass_coeff_1 = (wing_area**0.5) * fuel_vol_frac / 0.430
+            dtrapped_fuel_wt_dwing_area_1 = (
+                0.5 * unusable_fuel_coeff * (wing_area**-0.5) * fuel_vol_frac / 0.430
+            )
+            dtrapped_fuel_wt_dfuel_vol_frac_1 = unusable_fuel_coeff * (wing_area**0.5) / 0.430
+            dtrapped_fuel_wt_dmass_coeff_2 = 0.18 * (wing_area**0.5)
+            dtrapped_fuel_wt_dwing_area_2 = 0.5 * unusable_fuel_coeff * 0.18 * (wing_area**-0.5)
+            dtrapped_fuel_wt_dfuel_vol_frac_2 = 0.0
+            dtrapped_fuel_wt_dmass_coeff = (
+                smoother * dtrapped_fuel_wt_dmass_coeff_1
+                + (1 - smoother) * dtrapped_fuel_wt_dmass_coeff_2
+            )
+            dtrapped_fuel_wt_dwing_area = (
+                smoother * dtrapped_fuel_wt_dwing_area_1
+                + (1 - smoother) * dtrapped_fuel_wt_dwing_area_2
+            )
+            dtrapped_fuel_wt_dfuel_vol_frac = (
+                dsmoother_dfuel_vol_frac * trapped_fuel_1_wt
+                + smoother * dtrapped_fuel_wt_dfuel_vol_frac_1
+                - dsmoother_dfuel_vol_frac * trapped_fuel_2_wt
+                + (1 - smoother) * dtrapped_fuel_wt_dfuel_vol_frac_2
+            )
+        else:
+            if fuel_vol_frac > 0.075:
+                dtrapped_fuel_wt_dmass_coeff = (wing_area**0.5) * fuel_vol_frac / 0.430
+                dtrapped_fuel_wt_dwing_area = (
+                    0.5 * unusable_fuel_coeff * (wing_area**-0.5) * fuel_vol_frac / 0.430
+                )
+                dtrapped_fuel_wt_dfuel_vol_frac = unusable_fuel_coeff * (wing_area**0.5) / 0.430
+            else:
+                dtrapped_fuel_wt_dmass_coeff = 0.18 * (wing_area**0.5)
+                dtrapped_fuel_wt_dwing_area = 0.5 * unusable_fuel_coeff * 0.18 * (wing_area**-0.5)
+                dtrapped_fuel_wt_dfuel_vol_frac = 0.0
 
         J[Aircraft.Fuel.UNUSABLE_FUEL_MASS, Aircraft.Wing.AREA] = (
             dtrapped_fuel_wt_dwing_area / GRAV_ENGLISH_LBM
@@ -53,5 +108,5 @@ class TrappedFuelCapacity(om.ExplicitComponent):
             dtrapped_fuel_wt_dfuel_vol_frac
         ) / GRAV_ENGLISH_LBM
         J[Aircraft.Fuel.UNUSABLE_FUEL_MASS, Aircraft.Fuel.UNUSABLE_FUEL_MASS_COEFFICIENT] = (
-            dtrapped_fuel_wt_dmass_coeff_12
+            dtrapped_fuel_wt_dmass_coeff
         ) / GRAV_ENGLISH_LBM

--- a/aviary/subsystems/mass/gasp_based/furnishings.py
+++ b/aviary/subsystems/mass/gasp_based/furnishings.py
@@ -5,7 +5,7 @@ from aviary.constants import GRAV_ENGLISH_LBM
 from aviary.utils.math import d_smooth_max, dSigmoidXdx, sigmoidX, smooth_max
 from aviary.variable_info.enums import GASPEngineType
 from aviary.variable_info.functions import add_aviary_input, add_aviary_option
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 def get_num_of_flight_attendent(num_pax):
@@ -56,6 +56,280 @@ def get_num_of_lavatories(num_pax):
     return num_lavatories
 
 
+def common_compute(
+    PAX, smooth, empirical, engine_type, mu, gross_wt_init, fus_len, cabin_width, scaler, acabin
+):
+    num_pilots = get_num_of_pilots(PAX, engine_type)
+    num_flight_attendants = get_num_of_flight_attendent(PAX)
+    lavatories = get_num_of_lavatories(PAX)
+
+    if smooth:
+        # gross_wt_init <= 10000.0:
+        furnishing_wt_1 = 0.065 * gross_wt_init - 59.0
+        # gross_wt_init > 10000.0:
+        if PAX >= 50:
+            if empirical:
+                # commonly used empirical furnishing weight equation
+                furnishing_wt_additional = scaler * PAX
+            else:
+                # linear regression formula
+                furnishing_wt_additional = 118.4 * PAX - 4190.0
+            # baseline furnishings (crew seats, cockpit, lavatories, galleys)
+            cabin_len = 0.75 * fus_len
+            agalley = 0.50 * PAX
+            furnishing_wt_2 = (
+                furnishing_wt_additional
+                + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
+                + num_flight_attendants * 30.0
+                + lavatories * 240.0
+                + agalley * 12.0
+                + 1.5 * cabin_len * cabin_width * np.pi / 2.0
+                + 0.5 * acabin
+            )
+        else:
+            CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
+            CPX = (
+                28 * sigmoidX(CPX_lin / 28, 1, -0.01)
+                + CPX_lin * sigmoidX(CPX_lin / 28, 1, 0.01) * sigmoidX(CPX_lin / 62, 1, -0.01)
+                + 62 * sigmoidX(CPX_lin / 62, 1, 0.01)
+            )
+            furnishing_wt_2 = CPX * PAX + 310.0
+        smoother = sigmoidX(gross_wt_init, 10000.0, 0.01)
+        furnishing_wt = (1 - smoother) * furnishing_wt_1 + smooth * furnishing_wt_2
+        furnishing_wt = smooth_max(furnishing_wt, 30.0, mu)
+    else:
+        if gross_wt_init <= 10000.0:
+            furnishing_wt = 0.065 * gross_wt_init - 59.0
+        else:
+            if PAX >= 50:
+                if empirical:
+                    # commonly used empirical furnishing weight equation
+                    furnishing_wt_additional = scaler * PAX
+                else:
+                    # linear regression formula
+                    furnishing_wt_additional = 118.4 * PAX - 4190.0
+                # baseline furnishings (crew seats, cockpit, lavatories, galleys)
+                cabin_len = 0.75 * fus_len
+                agalley = 0.50 * PAX
+                furnishing_wt = (
+                    furnishing_wt_additional
+                    + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
+                    + num_flight_attendants * 30.0
+                    + lavatories * 240.0
+                    + agalley * 12.0
+                    + 1.5 * cabin_len * cabin_width * np.pi / 2.0
+                    + 0.5 * acabin
+                )
+            else:
+                CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
+                if cabin_width <= 5.667:
+                    CPX = 28.0
+                elif cabin_width > 8.90:
+                    CPX = 62.0
+                furnishing_wt = CPX * PAX + 310.0
+        furnishing_wt = np.maximum(furnishing_wt, 30.0)
+
+    return furnishing_wt
+
+
+def common_compute_partials(
+    PAX, smooth, empirical, engine_type, mu, gross_wt_init, fus_len, cabin_width, scaler, acabin
+):
+    num_pilots = get_num_of_pilots(PAX, engine_type)
+    num_flight_attendants = get_num_of_flight_attendent(PAX)
+    lavatories = get_num_of_lavatories(PAX)
+
+    if smooth:
+        # gross_wt_init <= 10000.0:
+        furnishing_wt_1 = 0.065 * gross_wt_init - 59.0
+        dfurnishing_wt_dgross_wt_init_1 = 0.065
+        dfurnishing_wt_dcabin_width_1 = 0.0
+        dfurnishing_wt_dfus_len_1 = 0.0
+        dfurnishing_wt_dscaler_1 = 0.0
+        dfurnishing_wt_dacabin_1 = 0.0
+        # gross_wt_init > 10000.0:
+        if PAX >= 50:
+            if empirical:
+                furnishing_wt_additional = scaler * PAX
+                dfurnishing_wt_additional_dgross_wt_init = 0.0
+                dfurnishing_wt_additional_dcabin_width = 0.0
+                dfurnishing_wt_additional_dfus_len = 0.0
+                dfurnishing_wt_additional_dscaler = PAX
+                dfurnishing_wt_additional_dacabin = 0.0
+            else:
+                furnishing_wt_additional = 118.4 * PAX - 4190.0
+                dfurnishing_wt_additional_dgross_wt_init = 0.0
+                dfurnishing_wt_additional_dcabin_width = 0.0
+                dfurnishing_wt_additional_dfus_len = 0.0
+                dfurnishing_wt_additional_dscaler = 0.0
+                dfurnishing_wt_additional_dacabin = 0.0
+            cabin_len = 0.75 * fus_len
+            agalley = 0.50 * PAX
+            furnishing_wt_2 = (
+                furnishing_wt_additional
+                + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
+                + num_flight_attendants * 30.0
+                + lavatories * 240.0
+                + agalley * 12.0
+                + 1.5 * cabin_len * cabin_width * np.pi / 2.0
+                + 0.5 * acabin
+            )
+            dfurnishing_wt_dgross_wt_init_2 = dfurnishing_wt_additional_dgross_wt_init + 0.0
+            dfurnishing_wt_dcabin_width_2 = (
+                dfurnishing_wt_additional_dcabin_width
+                + num_pilots * (1.0 / 12.0) * 90.0
+                + 1.5 * 0.75 * fus_len * np.pi / 2.0
+            )
+            dfurnishing_wt_dfus_len_2 = (
+                dfurnishing_wt_additional_dfus_len + 1.5 * 0.75 * cabin_width * np.pi / 2.0
+            )
+            dfurnishing_wt_dscaler_2 = dfurnishing_wt_additional_dscaler + 0.0
+            dfurnishing_wt_dacabin_2 = dfurnishing_wt_additional_dacabin + 0.5
+        else:
+            CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
+            CPX = (
+                28 * sigmoidX(CPX_lin / 28, 1, -0.01)
+                + CPX_lin * sigmoidX(CPX_lin / 28, 1, 0.01) * sigmoidX(CPX_lin / 62, 1, -0.01)
+                + 62 * sigmoidX(CPX_lin / 62, 1, 0.01)
+            )
+            furnishing_wt_2 = CPX * PAX + 310.0
+
+            dCPX_lin_dcabin_width = 10.516
+            dCPX_dcabin_width_2 = (
+                1 * dSigmoidXdx(CPX_lin / 28, 1, 0.01) * -dCPX_lin_dcabin_width
+                + dCPX_lin_dcabin_width
+                * CPX_lin
+                * sigmoidX(CPX_lin / 28, 1, 0.01)
+                * sigmoidX(CPX_lin / 62, 1, -0.01)
+                + CPX_lin
+                * dSigmoidXdx(CPX_lin / 28, 1, 0.01)
+                / 28
+                * sigmoidX(CPX_lin / 62, 1, -0.01)
+                * dCPX_lin_dcabin_width
+                + CPX_lin
+                * sigmoidX(CPX_lin / 28, 1, 0.01)
+                * dSigmoidXdx(CPX_lin / 62, 1, -0.01)
+                / 62
+                * -dCPX_lin_dcabin_width
+                + 1 * dSigmoidXdx(CPX_lin / 62, 1, 0.01) * dCPX_lin_dcabin_width
+            )
+
+            dfurnishing_wt_dcabin_width_2 = PAX * dCPX_dcabin_width_2
+            dfurnishing_wt_dgross_wt_init_2 = 0.0
+            dfurnishing_wt_dfus_len_2 = 0.0
+            dfurnishing_wt_dscaler_2 = 0.0
+            dfurnishing_wt_dacabin_2 = 0.0
+
+        smoother = sigmoidX(gross_wt_init, 10000.0, 0.01)
+        dsmoother_dgross_wt_init = dSigmoidXdx(gross_wt_init, 10000.0, 0.01)
+        furnishing_wt = (1 - smoother) * furnishing_wt_1 + smooth * furnishing_wt_2
+        dfurnishing_wt_dcabin_width = (
+            1 - smoother
+        ) * dfurnishing_wt_dcabin_width_1 + smoother * dfurnishing_wt_dcabin_width_2
+        dfurnishing_wt_dgross_wt_init = (
+            -dsmoother_dgross_wt_init * furnishing_wt_1
+            + (1 - smoother) * dfurnishing_wt_dgross_wt_init_1
+            + dsmoother_dgross_wt_init * furnishing_wt_2
+            + smoother * dfurnishing_wt_dgross_wt_init_2
+        )
+        dfurnishing_wt_dfus_len = (
+            1 - smoother
+        ) * dfurnishing_wt_dfus_len_1 + smoother * dfurnishing_wt_dfus_len_2
+        dfurnishing_wt_dscaler = (
+            1 - smoother
+        ) * dfurnishing_wt_dscaler_1 + smoother * dfurnishing_wt_dscaler_2
+        dfurnishing_wt_dacabin = (
+            1 - smoother
+        ) * dfurnishing_wt_dacabin_1 + smoother * dfurnishing_wt_dacabin_2
+
+        sm_fac = d_smooth_max(furnishing_wt, 30.0, mu)
+        dfurnishing_wt_dcabin_width = sm_fac * dfurnishing_wt_dcabin_width
+        dfurnishing_wt_dgross_wt_init = sm_fac * dfurnishing_wt_dgross_wt_init
+        dfurnishing_wt_dfus_len = sm_fac * dfurnishing_wt_dfus_len
+        dfurnishing_wt_dscaler = sm_fac * dfurnishing_wt_dscaler
+        dfurnishing_wt_dacabin = sm_fac * dfurnishing_wt_dacabin
+    else:
+        if gross_wt_init <= 10000.0:
+            furnishing_wt = 0.065 * gross_wt_init - 59.0
+            dfurnishing_wt_dgross_wt_init = 0.065
+            dfurnishing_wt_dcabin_width = 0.0
+            dfurnishing_wt_dfus_len = 0.0
+            dfurnishing_wt_dscaler = 0.0
+            dfurnishing_wt_dacabin = 0.0
+        else:
+            if PAX >= 50:
+                if empirical:
+                    furnishing_wt_additional = scaler * PAX
+                    dfurnishing_wt_additional_dgross_wt_init = 0.0
+                    dfurnishing_wt_additional_dcabin_width = 0.0
+                    dfurnishing_wt_additional_dfus_len = 0.0
+                    dfurnishing_wt_additional_dscaler = PAX
+                    dfurnishing_wt_additional_dacabin = 0.0
+                else:
+                    furnishing_wt_additional = 118.4 * PAX - 4190.0
+                    dfurnishing_wt_additional_dgross_wt_init = 0.0
+                    dfurnishing_wt_additional_dcabin_width = 0.0
+                    dfurnishing_wt_additional_dfus_len = 0.0
+                    dfurnishing_wt_additional_dscaler = 0.0
+                    dfurnishing_wt_additional_dacabin = 0.0
+                cabin_len = 0.75 * fus_len
+                agalley = 0.50 * PAX
+                furnishing_wt = (
+                    furnishing_wt_additional
+                    + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
+                    + num_flight_attendants * 30.0
+                    + lavatories * 240.0
+                    + agalley * 12.0
+                    + 1.5 * cabin_len * cabin_width * np.pi / 2.0
+                    + 0.5 * acabin
+                )
+                dfurnishing_wt_dgross_wt_init = dfurnishing_wt_additional_dgross_wt_init + 0.0
+                dfurnishing_wt_dcabin_width = (
+                    dfurnishing_wt_additional_dcabin_width
+                    + num_pilots * (1.0 / 12.0) * 90.0
+                    + 1.5 * 0.75 * fus_len * np.pi / 2.0
+                )
+                dfurnishing_wt_dfus_len = (
+                    dfurnishing_wt_additional_dfus_len + 1.5 * 0.75 * cabin_width * np.pi / 2.0
+                )
+                dfurnishing_wt_dscaler = dfurnishing_wt_additional_dscaler + 0.0
+                dfurnishing_wt_dacabin = dfurnishing_wt_additional_dacabin + 0.5
+            else:
+                CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
+                if cabin_width <= 5.667:
+                    CPX = 28.0
+                elif cabin_width > 8.90:
+                    CPX = 62.0
+                furnishing_wt = CPX * PAX + 310.0
+
+                dCPX_lin_dcabin_width = 10.516
+                if cabin_width <= 5.667:
+                    dCPX_dcabin_width = 0.0
+                if cabin_width > 8.90:
+                    dCPX_dcabin_width = 0.0
+
+                dfurnishing_wt_dcabin_width = PAX * dCPX_dcabin_width
+                dfurnishing_wt_dgross_wt_init = 0.0
+                dfurnishing_wt_dfus_len = 0.0
+                dfurnishing_wt_dscaler = 0.0
+                dfurnishing_wt_dacabin = 0.0
+
+        if furnishing_wt < 30.0:
+            dfurnishing_wt_dcabin_width = 0.0
+            dfurnishing_wt_dgross_wt_init = 0.0
+            dfurnishing_wt_dfus_len = 0.0
+            dfurnishing_wt_dscaler = 0.0
+            dfurnishing_wt_dacabin = 0.0
+
+    return [
+        dfurnishing_wt_dcabin_width,
+        dfurnishing_wt_dgross_wt_init,
+        dfurnishing_wt_dfus_len,
+        dfurnishing_wt_dscaler,
+        dfurnishing_wt_dacabin,
+    ]
+
+
 class FurnishingMass(om.ExplicitComponent):
     """
     Computation of furnishing mass.
@@ -92,196 +366,45 @@ class FurnishingMass(om.ExplicitComponent):
         PAX = self.options[Aircraft.CrewPayload.Design.NUM_PASSENGERS]
         smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
         empirical = self.options[Aircraft.Furnishings.USE_EMPIRICAL_EQUATION]
-        engine_type = self.options[Aircraft.Engine.TYPE][0]
+        en_type = self.options[Aircraft.Engine.TYPE][0]
         mu = self.options['mu']
 
-        num_pilots = get_num_of_pilots(PAX, engine_type)
-        num_flight_attendants = get_num_of_flight_attendent(PAX)
-        lavatories = get_num_of_lavatories(PAX)
-
-        gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
+        gross_wt_init = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         cabin_width = inputs[Aircraft.Fuselage.AVG_DIAMETER]
         scaler = inputs[Aircraft.Furnishings.MASS_SCALER]
         acabin = inputs[Aircraft.Fuselage.CABIN_AREA]
 
-        if gross_wt_initial <= 10000.0:
-            # note: this technically creates a discontinuity
-            # TODO: Doesn't occur in large single aisle
-            furnishing_wt = 0.065 * gross_wt_initial - 59.0
-        else:
-            if PAX >= 50:
-                if empirical:
-                    # commonly used empirical furnishing weight equation
-                    furnishing_wt_additional = scaler * PAX
-                else:
-                    # linear regression formula
-                    furnishing_wt_additional = 118.4 * PAX - 4190.0
-                # baseline furnishings (crew seats, cockpit, lavatories, galleys)
-                cabin_len = 0.75 * fus_len
-                agalley = 0.50 * PAX
-                furnishing_wt = (
-                    furnishing_wt_additional
-                    + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
-                    + num_flight_attendants * 30.0
-                    + lavatories * 240.0
-                    + agalley * 12.0
-                    + 1.5 * cabin_len * cabin_width * np.pi / 2.0
-                    + 0.5 * acabin
-                )
-            else:
-                CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
-                if smooth:
-                    CPX = (
-                        28 * sigmoidX(CPX_lin / 28, 1, -0.01)
-                        + CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        + 62 * sigmoidX(CPX_lin / 62, 1, 0.01)
-                    )
-                else:
-                    if cabin_width <= 5.667:  # note: this technically creates a discontinuity
-                        CPX = 28.0
-                    elif cabin_width > 8.90:  # note: this technically creates a discontinuity
-                        CPX = 62.0
-                furnishing_wt = CPX * PAX + 310.0
-        # Theoretically, we should make sure that furnishing_wt >= 0 here
-
-        if smooth:
-            furnishing_wt = smooth_max(furnishing_wt, 30.0, mu)
-        else:
-            furnishing_wt = np.maximum(furnishing_wt, 30.0)
-
+        furnishing_wt = common_compute(
+            PAX, smooth, empirical, en_type, mu, gross_wt_init, fus_len, cabin_width, scaler, acabin
+        )
         outputs[Aircraft.Furnishings.MASS] = furnishing_wt / GRAV_ENGLISH_LBM
 
     def compute_partials(self, inputs, partials):
         PAX = self.options[Aircraft.CrewPayload.Design.NUM_PASSENGERS]
         smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
         empirical = self.options[Aircraft.Furnishings.USE_EMPIRICAL_EQUATION]
-        engine_type = self.options[Aircraft.Engine.TYPE][0]
+        en_type = self.options[Aircraft.Engine.TYPE][0]
         mu = self.options['mu']
 
-        num_pilots = get_num_of_pilots(PAX, engine_type)
-        num_flight_attendants = get_num_of_flight_attendent(PAX)
-        lavatories = get_num_of_lavatories(PAX)
-
-        gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
+        gross_wt_init = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         cabin_width = inputs[Aircraft.Fuselage.AVG_DIAMETER]
         scaler = inputs[Aircraft.Furnishings.MASS_SCALER]
         acabin = inputs[Aircraft.Fuselage.CABIN_AREA]
 
-        if gross_wt_initial <= 10000.0:
-            furnishing_wt = 0.065 * gross_wt_initial - 59.0
-            dfurnishing_wt_dgross_wt_initial = 0.065
-            dfurnishing_wt_dcabin_width = 0.0
-            dfurnishing_wt_dfus_len = 0.0
-            dfurnishing_wt_dscaler = 0.0
-            dfurnishing_wt_dacabin = 0.0
-        else:
-            if PAX >= 50:
-                if empirical:
-                    furnishing_wt_additional = scaler * PAX
-                    dfurnishing_wt_additional_dgross_wt_initial = 0.0
-                    dfurnishing_wt_additional_dcabin_width = 0.0
-                    dfurnishing_wt_additional_dfus_len = 0.0
-                    dfurnishing_wt_additional_dscaler = PAX
-                    dfurnishing_wt_additional_dacabin = 0.0
-                else:
-                    furnishing_wt_additional = 118.4 * PAX - 4190.0
-                    dfurnishing_wt_additional_dgross_wt_initial = 0.0
-                    dfurnishing_wt_additional_dcabin_width = 0.0
-                    dfurnishing_wt_additional_dfus_len = 0.0
-                    dfurnishing_wt_additional_dscaler = 0.0
-                    dfurnishing_wt_additional_dacabin = 0.0
-                cabin_len = 0.75 * fus_len
-                agalley = 0.50 * PAX
-                furnishing_wt = (
-                    furnishing_wt_additional
-                    + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
-                    + num_flight_attendants * 30.0
-                    + lavatories * 240.0
-                    + agalley * 12.0
-                    + 1.5 * cabin_len * cabin_width * np.pi / 2.0
-                    + 0.5 * acabin
-                )
-                dfurnishing_wt_dgross_wt_initial = dfurnishing_wt_additional_dgross_wt_initial + 0.0
-                dfurnishing_wt_dcabin_width = (
-                    dfurnishing_wt_additional_dcabin_width
-                    + num_pilots * (1.0 / 12.0) * 90.0
-                    + 1.5 * 0.75 * fus_len * np.pi / 2.0
-                )
-                dfurnishing_wt_dfus_len = (
-                    dfurnishing_wt_additional_dfus_len + 1.5 * 0.75 * cabin_width * np.pi / 2.0
-                )
-                dfurnishing_wt_dscaler = dfurnishing_wt_additional_dscaler + 0.0
-                dfurnishing_wt_dacabin = dfurnishing_wt_additional_dacabin + 0.5
-            else:
-                CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
-                if smooth:
-                    CPX = (
-                        28 * sigmoidX(CPX_lin / 28, 1, -0.01)
-                        + CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        + 62 * sigmoidX(CPX_lin / 62, 1, 0.01)
-                    )
-                else:
-                    if cabin_width <= 5.667:  # note: this technically creates a discontinuity
-                        CPX = 28.0
-                    elif cabin_width > 8.90:  # note: this technically creates a discontinuity
-                        CPX = 62.0
-                furnishing_wt = CPX * PAX + 310.0
-
-                dCPX_lin_dcabin_width = 10.516
-                if smooth:
-                    dCPX_dcabin_width = (
-                        1 * dSigmoidXdx(CPX_lin / 28, 1, 0.01) * -dCPX_lin_dcabin_width
-                        + dCPX_lin_dcabin_width
-                        * CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        + CPX_lin
-                        * dSigmoidXdx(CPX_lin / 28, 1, 0.01)
-                        / 28
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        * dCPX_lin_dcabin_width
-                        + CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * dSigmoidXdx(CPX_lin / 62, 1, -0.01)
-                        / 62
-                        * -dCPX_lin_dcabin_width
-                        + 1 * dSigmoidXdx(CPX_lin / 62, 1, 0.01) * dCPX_lin_dcabin_width
-                    )
-                else:
-                    if cabin_width <= 5.667:  # note: this technically creates a discontinuity
-                        dCPX_dcabin_width = 0.0
-                    if cabin_width > 8.90:  # note: this technically creates a discontinuity
-                        dCPX_dcabin_width = 0.0
-
-                dfurnishing_wt_dcabin_width = PAX * dCPX_dcabin_width
-                dfurnishing_wt_dgross_wt_initial = 0.0
-                dfurnishing_wt_dfus_len = 0.0
-                dfurnishing_wt_dscaler = 0.0
-                dfurnishing_wt_dacabin = 0.0
-
-        if smooth:
-            sm_fac = d_smooth_max(furnishing_wt, 30.0, mu)
-            dfurnishing_wt_dcabin_width = sm_fac * dfurnishing_wt_dcabin_width
-            dfurnishing_wt_dgross_wt_initial = sm_fac * dfurnishing_wt_dgross_wt_initial
-            dfurnishing_wt_dfus_len = sm_fac * dfurnishing_wt_dfus_len
-            dfurnishing_wt_dscaler = sm_fac * dfurnishing_wt_dscaler
-            dfurnishing_wt_dacabin = sm_fac * dfurnishing_wt_dacabin
-        else:
-            if furnishing_wt < 30.0:  # note: this technically creates a discontinuity
-                dfurnishing_wt_dcabin_width = 0.0
-                dfurnishing_wt_dgross_wt_initial = 0.0
-                dfurnishing_wt_dfus_len = 0.0
-                dfurnishing_wt_dscaler = 0.0
-                dfurnishing_wt_dacabin = 0.0
+        [
+            dfurnishing_wt_dcabin_width,
+            dfurnishing_wt_dgross_wt_init,
+            dfurnishing_wt_dfus_len,
+            dfurnishing_wt_dscaler,
+            dfurnishing_wt_dacabin,
+        ] = common_compute_partials(
+            PAX, smooth, empirical, en_type, mu, gross_wt_init, fus_len, cabin_width, scaler, acabin
+        )
 
         partials[Aircraft.Furnishings.MASS, Aircraft.Design.GROSS_MASS] = (
-            dfurnishing_wt_dgross_wt_initial
+            dfurnishing_wt_dgross_wt_init
         )
         partials[Aircraft.Furnishings.MASS, Aircraft.Fuselage.AVG_DIAMETER] = (
             dfurnishing_wt_dcabin_width / GRAV_ENGLISH_LBM
@@ -333,64 +456,18 @@ class BWBFurnishingMass(om.ExplicitComponent):
         PAX = self.options[Aircraft.CrewPayload.Design.NUM_PASSENGERS]
         smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
         empirical = self.options[Aircraft.Furnishings.USE_EMPIRICAL_EQUATION]
-        engine_type = self.options[Aircraft.Engine.TYPE][0]
+        en_type = self.options[Aircraft.Engine.TYPE][0]
         mu = self.options['mu']
 
-        num_pilots = get_num_of_pilots(PAX, engine_type)
-        num_flight_attendants = get_num_of_flight_attendent(PAX)
-        lavatories = get_num_of_lavatories(PAX)
-
-        gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
+        gross_wt_init = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         cabin_width = inputs[Aircraft.Fuselage.HYDRAULIC_DIAMETER]
         scaler = inputs[Aircraft.Furnishings.MASS_SCALER]
         acabin = inputs[Aircraft.Fuselage.CABIN_AREA]
 
-        if gross_wt_initial <= 10000.0:
-            # note: this technically creates a discontinuity
-            # TODO: Doesn't occur in large single aisle
-            furnishing_wt = 0.065 * gross_wt_initial - 59.0
-        else:
-            if PAX >= 50:
-                if empirical:
-                    # commonly used empirical furnishing weight equation
-                    furnishing_wt_additional = scaler * PAX
-                else:
-                    # linear regression formula
-                    furnishing_wt_additional = 118.4 * PAX - 4190.0
-                # baseline furnishings (crew seats, cockpit, lavatories, galleys)
-                cabin_len = 0.75 * fus_len
-                agalley = 0.50 * PAX
-                furnishing_wt = (
-                    furnishing_wt_additional
-                    + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
-                    + num_flight_attendants * 30.0
-                    + lavatories * 240.0
-                    + agalley * 12.0
-                    + 1.5 * cabin_len * cabin_width * np.pi / 2.0
-                    + 0.5 * acabin
-                )
-            else:
-                CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
-                if smooth:
-                    CPX = (
-                        28 * sigmoidX(CPX_lin / 28, 1, -0.01)
-                        + CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        + 62 * sigmoidX(CPX_lin / 62, 1, 0.01)
-                    )
-                else:
-                    if cabin_width <= 5.667:  # note: this technically creates a discontinuity
-                        CPX = 28.0
-                    elif cabin_width > 8.90:  # note: this technically creates a discontinuity
-                        CPX = 62.0
-                furnishing_wt = CPX * PAX + 310.0
-
-        if smooth:
-            furnishing_wt = smooth_max(furnishing_wt, 30.0, mu)
-        else:
-            furnishing_wt = np.maximum(furnishing_wt, 30.0)
+        furnishing_wt = common_compute(
+            PAX, smooth, empirical, en_type, mu, gross_wt_init, fus_len, cabin_width, scaler, acabin
+        )
 
         outputs[Aircraft.Furnishings.MASS] = furnishing_wt / GRAV_ENGLISH_LBM
 
@@ -398,130 +475,27 @@ class BWBFurnishingMass(om.ExplicitComponent):
         PAX = self.options[Aircraft.CrewPayload.Design.NUM_PASSENGERS]
         smooth = self.options[Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES]
         empirical = self.options[Aircraft.Furnishings.USE_EMPIRICAL_EQUATION]
-        engine_type = self.options[Aircraft.Engine.TYPE][0]
+        en_type = self.options[Aircraft.Engine.TYPE][0]
         mu = self.options['mu']
 
-        num_pilots = get_num_of_pilots(PAX, engine_type)
-        num_flight_attendants = get_num_of_flight_attendent(PAX)
-        lavatories = get_num_of_lavatories(PAX)
-
-        gross_wt_initial = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
+        gross_wt_init = inputs[Aircraft.Design.GROSS_MASS] * GRAV_ENGLISH_LBM
         fus_len = inputs[Aircraft.Fuselage.LENGTH]
         cabin_width = inputs[Aircraft.Fuselage.HYDRAULIC_DIAMETER]
         scaler = inputs[Aircraft.Furnishings.MASS_SCALER]
         acabin = inputs[Aircraft.Fuselage.CABIN_AREA]
 
-        if gross_wt_initial <= 10000.0:
-            furnishing_wt = 0.065 * gross_wt_initial - 59.0
-            dfurnishing_wt_dgross_wt_initial = 0.065
-            dfurnishing_wt_dcabin_width = 0.0
-            dfurnishing_wt_dfus_len = 0.0
-            dfurnishing_wt_dscaler = 0.0
-            dfurnishing_wt_dacabin = 0.0
-        else:
-            if PAX >= 50:
-                if empirical:
-                    furnishing_wt_additional = scaler * PAX
-                    dfurnishing_wt_additional_dgross_wt_initial = 0.0
-                    dfurnishing_wt_additional_dcabin_width = 0.0
-                    dfurnishing_wt_additional_dfus_len = 0.0
-                    dfurnishing_wt_additional_dscaler = PAX
-                    dfurnishing_wt_additional_dacabin = 0.0
-                else:
-                    furnishing_wt_additional = 118.4 * PAX - 4190.0
-                    dfurnishing_wt_additional_dgross_wt_initial = 0.0
-                    dfurnishing_wt_additional_dcabin_width = 0.0
-                    dfurnishing_wt_additional_dfus_len = 0.0
-                    dfurnishing_wt_additional_dscaler = 0.0
-                    dfurnishing_wt_additional_dacabin = 0.0
-                cabin_len = 0.75 * fus_len
-                agalley = 0.50 * PAX
-                furnishing_wt = (
-                    furnishing_wt_additional
-                    + num_pilots * (1.0 + cabin_width / 12.0) * 90.0
-                    + num_flight_attendants * 30.0
-                    + lavatories * 240.0
-                    + agalley * 12.0
-                    + 1.5 * cabin_len * cabin_width * np.pi / 2.0
-                    + 0.5 * acabin
-                )
-                dfurnishing_wt_dgross_wt_initial = dfurnishing_wt_additional_dgross_wt_initial + 0.0
-                dfurnishing_wt_dcabin_width = (
-                    dfurnishing_wt_additional_dcabin_width
-                    + num_pilots * (1.0 / 12.0) * 90.0
-                    + 1.5 * 0.75 * fus_len * np.pi / 2.0
-                )
-                dfurnishing_wt_dfus_len = (
-                    dfurnishing_wt_additional_dfus_len + 1.5 * 0.75 * cabin_width * np.pi / 2.0
-                )
-                dfurnishing_wt_dscaler = dfurnishing_wt_additional_dscaler + 0.0
-                dfurnishing_wt_dacabin = dfurnishing_wt_additional_dacabin + 0.5
-            else:
-                CPX_lin = 28.0 + 10.516 * (cabin_width - 5.667)
-                if smooth:
-                    CPX = (
-                        28 * sigmoidX(CPX_lin / 28, 1, -0.01)
-                        + CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        + 62 * sigmoidX(CPX_lin / 62, 1, 0.01)
-                    )
-                else:
-                    if cabin_width <= 5.667:  # note: this technically creates a discontinuity
-                        CPX = 28.0
-                    elif cabin_width > 8.90:  # note: this technically creates a discontinuity
-                        CPX = 62.0
-                furnishing_wt = CPX * PAX + 310.0
-
-                dCPX_lin_dcabin_width = 10.516
-                if smooth:
-                    dCPX_dcabin_width = (
-                        1 * dSigmoidXdx(CPX_lin / 28, 1, 0.01) * -dCPX_lin_dcabin_width
-                        + dCPX_lin_dcabin_width
-                        * CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        + CPX_lin
-                        * dSigmoidXdx(CPX_lin / 28, 1, 0.01)
-                        / 28
-                        * sigmoidX(CPX_lin / 62, 1, -0.01)
-                        * dCPX_lin_dcabin_width
-                        + CPX_lin
-                        * sigmoidX(CPX_lin / 28, 1, 0.01)
-                        * dSigmoidXdx(CPX_lin / 62, 1, -0.01)
-                        / 62
-                        * -dCPX_lin_dcabin_width
-                        + 1 * dSigmoidXdx(CPX_lin / 62, 1, 0.01) * dCPX_lin_dcabin_width
-                    )
-                else:
-                    if cabin_width <= 5.667:  # note: this technically creates a discontinuity
-                        dCPX_dcabin_width = 0.0
-                    if cabin_width > 8.90:  # note: this technically creates a discontinuity
-                        dCPX_dcabin_width = 0.0
-
-                dfurnishing_wt_dcabin_width = PAX * dCPX_dcabin_width
-                dfurnishing_wt_dgross_wt_initial = 0.0
-                dfurnishing_wt_dfus_len = 0.0
-                dfurnishing_wt_dscaler = 0.0
-                dfurnishing_wt_dacabin = 0.0
-
-        if smooth:
-            sm_fac = d_smooth_max(furnishing_wt, 30.0, mu)
-            dfurnishing_wt_dcabin_width = sm_fac * dfurnishing_wt_dcabin_width
-            dfurnishing_wt_dgross_wt_initial = sm_fac * dfurnishing_wt_dgross_wt_initial
-            dfurnishing_wt_dfus_len = sm_fac * dfurnishing_wt_dfus_len
-            dfurnishing_wt_dscaler = sm_fac * dfurnishing_wt_dscaler
-            dfurnishing_wt_dacabin = sm_fac * dfurnishing_wt_dacabin
-        else:
-            if furnishing_wt < 30.0:  # note: this technically creates a discontinuity
-                dfurnishing_wt_dcabin_width = 0.0
-                dfurnishing_wt_dgross_wt_initial = 0.0
-                dfurnishing_wt_dfus_len = 0.0
-                dfurnishing_wt_dscaler = 0.0
-                dfurnishing_wt_dacabin = 0.0
+        [
+            dfurnishing_wt_dcabin_width,
+            dfurnishing_wt_dgross_wt_init,
+            dfurnishing_wt_dfus_len,
+            dfurnishing_wt_dscaler,
+            dfurnishing_wt_dacabin,
+        ] = common_compute_partials(
+            PAX, smooth, empirical, en_type, mu, gross_wt_init, fus_len, cabin_width, scaler, acabin
+        )
 
         partials[Aircraft.Furnishings.MASS, Aircraft.Design.GROSS_MASS] = (
-            dfurnishing_wt_dgross_wt_initial
+            dfurnishing_wt_dgross_wt_init
         )
         partials[Aircraft.Furnishings.MASS, Aircraft.Fuselage.HYDRAULIC_DIAMETER] = (
             dfurnishing_wt_dcabin_width / GRAV_ENGLISH_LBM

--- a/aviary/subsystems/mass/gasp_based/oxygen_system.py
+++ b/aviary/subsystems/mass/gasp_based/oxygen_system.py
@@ -36,7 +36,7 @@ class OxygenSystemMass(om.ExplicitComponent):
             if smooth:
                 oxygen_system_wt = 3 * sigmoidX(gross_wt_initial / 3000, 1.0, 0.01)
             else:
-                if gross_wt_initial > 3000.0:  # note: this technically creates a discontinuity
+                if gross_wt_initial > 3000.0:
                     oxygen_system_wt = 3.0
                 else:
                     oxygen_system_wt = 0.0

--- a/aviary/subsystems/mass/gasp_based/test/test_air_conditioning.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_air_conditioning.py
@@ -2,18 +2,21 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.air_conditioning import ACMass, BWBACMass
 from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class ACMassTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
         options = get_option_defaults()
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -43,10 +46,33 @@ class ACMassTestCase1(unittest.TestCase):
         self.prob.setup(check=False, force_alloc_complex=True)
 
     def test_case1(self):
+        """case gross_wt_initial > 3500.0"""
         self.prob.run_model()
 
         tol = 1e-7
         assert_near_equal(self.prob[Aircraft.AirConditioning.MASS], 1324.0561, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+
+    def test_case2(self):
+        """case gross_wt_initial < 3500.0"""
+        self.prob.set_val(Aircraft.Design.GROSS_MASS, 3400.0, units='lbm')
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.AirConditioning.MASS], 5.0, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+
+    def test_case3(self):
+        """case gross_wt_initial = 3500.0"""
+        self.prob.set_val(Aircraft.Design.GROSS_MASS, 3500.0, units='lbm')
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.AirConditioning.MASS], 664.52807185, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
@@ -69,7 +95,7 @@ class ACMassTestCase2(unittest.TestCase):
 
     def test_case1(self):
         options = get_option_defaults()
-        options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -100,6 +126,7 @@ class ACMassTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class BWBACMassTestCase1(unittest.TestCase):
     """
     Created based on GASP BWB model
@@ -107,7 +134,7 @@ class BWBACMassTestCase1(unittest.TestCase):
 
     def setUp(self):
         options = get_option_defaults()
-        options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         prob = self.prob = om.Problem()
         self.prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_anti_icing.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_anti_icing.py
@@ -2,6 +2,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.anti_icing import AntiIcingMass
 from aviary.variable_info.functions import setup_model_options
@@ -9,8 +10,9 @@ from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class AntiIcingTestCase1(unittest.TestCase):
-    """this is the large single aisle 1 V3 test case"""
+    """this is the large single aisle 1 V3 test case where SMOOTH_MASS_DISCONTINUITIES is false."""
 
     def setUp(self):
         options = get_option_defaults()
@@ -46,6 +48,19 @@ class AntiIcingTestCase1(unittest.TestCase):
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
+    def test_case2(self):
+        """non-realistic case"""
+        self.prob.set_val(Aircraft.VerticalTail.AREA, 1.0, units='ft**2')
+        self.prob.set_val(Aircraft.Wing.AREA, 1.0, units='ft**2')
+        self.prob.set_val(Aircraft.HorizontalTail.AREA, 1.0, units='ft**2')
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.AntiIcing.MASS], 0.0, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+
 
 class AntiIcingTestCase2(unittest.TestCase):
     """
@@ -54,7 +69,7 @@ class AntiIcingTestCase2(unittest.TestCase):
 
     def setUp(self):
         options = get_option_defaults()
-        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=False, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -96,8 +111,9 @@ class AntiIcingTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class AntiIcingTestCase3(unittest.TestCase):
-    """this is the large single aisle 1 V3 test case"""
+    """this is the large single aisle 1 V3 test case where SMOOTH_MASS_DISCONTINUITIES is true."""
 
     def setUp(self):
         options = get_option_defaults()

--- a/aviary/subsystems/mass/gasp_based/test/test_electrical.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_electrical.py
@@ -2,13 +2,15 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.electrical import ElectricalMass
 from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class ElectricalTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
@@ -90,6 +92,7 @@ class ElectricalTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class ElectricalTestCase3(unittest.TestCase):
     """BWB Parameters"""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_fuel_capacity.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fuel_capacity.py
@@ -2,6 +2,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.fuel_capacity import TrappedFuelCapacity
 from aviary.variable_info.functions import setup_model_options
@@ -9,11 +10,12 @@ from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class TrappedFuelCapacityCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = self.options = get_option_defaults()
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -43,7 +45,21 @@ class TrappedFuelCapacityCase1(unittest.TestCase):
         assert_near_equal(self.prob[Aircraft.Fuel.UNUSABLE_FUEL_MASS], 619.7611152, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
+
+    def test_case2(self):
+        self.options.set_val(
+            Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless'
+        )
+        setup_model_options(self.prob, self.options)
+        self.prob.setup(force_alloc_complex=True)
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.Fuel.UNUSABLE_FUEL_MASS], 619.7611152, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
 
 class TrappedFuelCapacityCase2(unittest.TestCase):

--- a/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
@@ -53,7 +53,7 @@ class FurnishingMassTestCase1(unittest.TestCase):
         assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 13266.56, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
 
 class FurnishingMassTestCase2(unittest.TestCase):
@@ -101,7 +101,7 @@ class FurnishingMassTestCase2(unittest.TestCase):
         self.prob.run_model()
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
 
 @use_tempdirs
@@ -155,7 +155,7 @@ class FurnishingMassTestCase3(unittest.TestCase):
         assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 3348.0, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
     def test_case2(self):
         """
@@ -171,7 +171,7 @@ class FurnishingMassTestCase3(unittest.TestCase):
         assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 3348.0, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
 
 @use_tempdirs
@@ -226,7 +226,7 @@ class BWBFurnishingMassTestCase1(unittest.TestCase):
         assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 11269.863, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
     def test_case2(self):
         # case 2A
@@ -244,7 +244,7 @@ class BWBFurnishingMassTestCase1(unittest.TestCase):
         assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 18839.863, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
         # case 2B
         self.options.set_val(
@@ -261,7 +261,7 @@ class BWBFurnishingMassTestCase1(unittest.TestCase):
         # assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 11269.863, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
         # case 2C
         self.options.set_val(
@@ -278,7 +278,7 @@ class BWBFurnishingMassTestCase1(unittest.TestCase):
         assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 18839.863, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
 
 
 @use_tempdirs

--- a/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
@@ -2,13 +2,15 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.furnishings import BWBFurnishingMass, FurnishingMass
 from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class FurnishingMassTestCase1(unittest.TestCase):
     """Created based on EquipMassTestCase1"""
 
@@ -102,6 +104,7 @@ class FurnishingMassTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class FurnishingMassTestCase3(unittest.TestCase):
     """
     Created based on GASP BWB model where SWF is DHYDRAL
@@ -171,9 +174,11 @@ class FurnishingMassTestCase3(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class BWBFurnishingMassTestCase1(unittest.TestCase):
     """
     Created based on GASP BWB model
+    GROSS_MASS > 10000.0
     """
 
     def setUp(self):
@@ -276,6 +281,7 @@ class BWBFurnishingMassTestCase1(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class BWBFurnishingMassTestCase2(unittest.TestCase):
     """
     Created based on GASP BWB model

--- a/aviary/utils/math.py
+++ b/aviary/utils/math.py
@@ -171,7 +171,7 @@ def d_smooth_max(x, b, mu=10.0):
     m = np.maximum(mu_x, mu_b)
     numerator = np.exp(mu_x - m)
     denominator = np.exp(mu_x - m) + np.exp(mu_b - m)
-    d_sum_log_exp = mu * numerator / denominator
+    d_sum_log_exp = numerator / denominator
     return d_sum_log_exp
 
 


### PR DESCRIPTION
### Summary

There are a few if-else code blocks in GASP based mass subsystems that result in discontinuities. They are removed. More unit tests are added.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None