### PR TITLE
Fix a setup error for when a static and dynamic variable are promoted together.

### DIFF
--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -129,7 +129,7 @@ class AviaryGroup(om.Group):
                 prom_name, abs_name = data
                 if prom_name.startswith('parameters:'):
                     # Parameters haven't been pully promoted out of traj at this point.
-                    prom_name = prom_name.lstrip('parameters:')
+                    prom_name = prom_name.removeprefix('parameters:')
                 meta = abs2meta[abs_name]
                 if meta.get('shape_by_conn') is True:
                     sbc_vars.add(prom_name)

--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -116,12 +116,12 @@ class AviaryGroup(om.Group):
         for sub in self.system_iter(recurse=False, typ=om.Group):
             pr2abs = sub._resolver.prom2abs_iter('input')
             if sub.pathname == 'traj':
-                sub_inputs = [
-                    (k, v[0]) for k, v in pr2abs if k.startswith('parameters:')
-                ]
+                sub_inputs = [(k, v[0]) for k, v in pr2abs if k.startswith('parameters:')]
             else:
                 sub_inputs = [
-                    (k, v[0]) for k, v in pr2abs if k.startswith('aircraft') or k.startswith('mission')
+                    (k, v[0])
+                    for k, v in pr2abs
+                    if k.startswith('aircraft') or k.startswith('mission')
                 ]
             abs2meta = sub._var_abs2meta['input']
 

--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -115,13 +115,21 @@ class AviaryGroup(om.Group):
         non_sbc_vars = set()
         for sub in self.system_iter(recurse=False, typ=om.Group):
             pr2abs = sub._resolver.prom2abs_iter('input')
-            sub_inputs = [
-                (k, v[0]) for k, v in pr2abs if k.startswith('aircraft') or k.startswith('mission')
-            ]
+            if sub.pathname == 'traj':
+                sub_inputs = [
+                    (k, v[0]) for k, v in pr2abs if k.startswith('parameters:')
+                ]
+            else:
+                sub_inputs = [
+                    (k, v[0]) for k, v in pr2abs if k.startswith('aircraft') or k.startswith('mission')
+                ]
             abs2meta = sub._var_abs2meta['input']
 
             for data in sub_inputs:
                 prom_name, abs_name = data
+                if prom_name.startswith('parameters:'):
+                    # Parameters haven't been pully promoted out of traj at this point.
+                    prom_name = prom_name.lstrip('parameters:')
                 meta = abs2meta[abs_name]
                 if meta.get('shape_by_conn') is True:
                     sbc_vars.add(prom_name)

--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -111,7 +111,8 @@ class AviaryGroup(om.Group):
         # Find all variables that are shape_by_conn so we don't set their shape with a stale value
         # from the default metadata. We can only find these on the next level down because
         # aviary_group's setup is not complete until after configure.
-        sbc_vars = []
+        sbc_vars = set()
+        non_sbc_vars = set()
         for sub in self.system_iter(recurse=False, typ=om.Group):
             pr2abs = sub._resolver.prom2abs_iter('input')
             sub_inputs = [
@@ -123,7 +124,11 @@ class AviaryGroup(om.Group):
                 prom_name, abs_name = data
                 meta = abs2meta[abs_name]
                 if meta.get('shape_by_conn') is True:
-                    sbc_vars.append(prom_name)
+                    sbc_vars.add(prom_name)
+                else:
+                    non_sbc_vars.add(prom_name)
+
+        sbc_only_vars = sbc_vars - non_sbc_vars
 
         for key in aviary_metadata:
             if ':' not in key or key.startswith('dynamic:'):
@@ -147,7 +152,7 @@ class AviaryGroup(om.Group):
                     continue
 
             kwargs = {'units': units}
-            if key not in sbc_vars:
+            if key not in sbc_only_vars:
                 # Default val if var doesn't use shape_by_conn.
                 kwargs['val'] = val
 

--- a/aviary/interface/test/test_shape_by_conn.py
+++ b/aviary/interface/test/test_shape_by_conn.py
@@ -6,10 +6,14 @@ import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.core.aviary_problem import AviaryProblem
-from aviary.utils.develop_metadata import add_meta_data
 from aviary.models.external_subsystems.detailed_battery.battery_variables import Aircraft, Dynamic
 from aviary.models.missions.energy_state_default import phase_info as energy_phase_info
 from aviary.subsystems.subsystem_builder import SubsystemBuilder
+from aviary.utils.csv_data_file import read_data_file
+from aviary.utils.develop_metadata import add_meta_data
+from aviary.utils.named_values import NamedValues
+from aviary.variable_info.enums import LegacyCode
+from aviary.variable_info.functions import add_aviary_input
 from aviary.variable_info.variable_meta_data import CoreMetaData
 from aviary.variable_info.variables import Aircraft
 
@@ -97,6 +101,92 @@ class TestShapebyConn(unittest.TestCase):
         prob.set_val(ExtendedAircraft.Wing.CG2, np.ones((4, 2)))
 
         prob.final_setup()
+
+    def test_shape_bug_two(self):
+        # Verifies another shape_by_conn bug, where variables that are dynamic in some compoennts
+        # and static in others need to have their value set.
+
+        class PostComponent(om.ExplicitComponent):
+
+            def setup(self):
+
+                self.add_input(Aircraft.Design.DRAG_POLAR, shape_by_conn=True, units='unitless')
+                add_aviary_input(self, Aircraft.Design.LIFT_POLAR, shape_by_conn=True, units='unitless')
+
+                self.add_output('z')
+
+        class PostSystem(om.Group):
+
+            def setup(self):
+
+                self.add_subsystem('c', PostComponent(), promotes=['*'])
+
+
+        class PostBuilder(SubsystemBuilder):
+
+            def build_post_mission(
+                self,
+                aviary_inputs=None,
+                mission_info=None,
+                subsystem_options=None,
+                phase_mission_bus_lengths=None
+            ):
+                return PostSystem()
+
+
+        polar_file = 'models/large_single_aisle_1/aerodynamics_tables/large_single_aisle_1_aero_free_reduced_alpha.csv'
+
+        phase_info = deepcopy(energy_phase_info)
+        phase_info['pre_mission']['include_takeoff'] = False
+        phase_info['post_mission']['include_landing'] = False
+
+        data, _, _ = read_data_file(polar_file)
+        ALTITUDE = data.get_val('Altitude', 'ft')
+        MACH = data.get_val('Mach', 'unitless')
+        ALPHA = data.get_val('Angle_of_Attack', 'deg')
+
+        shape = (np.unique(ALTITUDE).size, np.unique(MACH).size, np.unique(ALPHA).size)
+        CL = data.get_val('CL').reshape(shape)
+        CD = data.get_val('CD').reshape(shape)
+
+        ph_in = deepcopy(phase_info)
+
+        aero_data = NamedValues()
+        aero_data.set_val('altitude', ALTITUDE, 'ft')
+        aero_data.set_val('mach', MACH, 'unitless')
+        aero_data.set_val('angle_of_attack', ALPHA, 'deg')
+
+        subsystem_options = {
+            'method': 'tabular_cruise',
+            'solve_alpha': True,
+            'aero_data': aero_data,
+            'connect_training_data': True,
+        }
+        ph_in['climb']['subsystem_options'] = {'aerodynamics': subsystem_options}
+        ph_in['cruise']['subsystem_options'] = {'aerodynamics': subsystem_options}
+        ph_in['descent']['subsystem_options'] = {'aerodynamics': subsystem_options}
+
+        prob = AviaryProblem()
+
+        prob.load_inputs(
+            'validation_cases/validation_data/test_models/high_wing_single_aisle.csv',
+            ph_in,
+        )
+
+        prob.model.aero_method = LegacyCode.GASP
+
+        prob.load_external_subsystems([PostBuilder()])
+
+        prob.aviary_inputs.set_val(Aircraft.Design.LIFT_POLAR, CL, units='unitless')
+        prob.aviary_inputs.set_val(Aircraft.Design.DRAG_POLAR, CD, units='unitless')
+
+        prob.check_and_preprocess_inputs()
+
+        prob.build_model()
+
+        prob.setup()
+        prob.set_solver_print(0)
+        prob.run_model()
 
 
 if __name__ == '__main__':

--- a/aviary/interface/test/test_shape_by_conn.py
+++ b/aviary/interface/test/test_shape_by_conn.py
@@ -107,9 +107,7 @@ class TestShapebyConn(unittest.TestCase):
         # and static in others need to have their value set.
 
         class PostComponent(om.ExplicitComponent):
-
             def setup(self):
-
                 self.add_input(Aircraft.Design.DRAG_POLAR, shape_by_conn=True, units='unitless')
                 add_aviary_input(
                     self, Aircraft.Design.LIFT_POLAR, shape_by_conn=True, units='unitless'
@@ -118,14 +116,11 @@ class TestShapebyConn(unittest.TestCase):
                 self.add_output('z')
 
         class PostSystem(om.Group):
-
             def setup(self):
-
                 self.add_subsystem('c', PostComponent(), promotes=['*'])
 
 
         class PostBuilder(SubsystemBuilder):
-
             def build_post_mission(
                 self,
                 aviary_inputs=None,

--- a/aviary/interface/test/test_shape_by_conn.py
+++ b/aviary/interface/test/test_shape_by_conn.py
@@ -119,7 +119,6 @@ class TestShapebyConn(unittest.TestCase):
             def setup(self):
                 self.add_subsystem('c', PostComponent(), promotes=['*'])
 
-
         class PostBuilder(SubsystemBuilder):
             def build_post_mission(
                 self,
@@ -129,7 +128,6 @@ class TestShapebyConn(unittest.TestCase):
                 phase_mission_bus_lengths=None,
             ):
                 return PostSystem()
-
 
         polar_file = 'models/large_single_aisle_1/aerodynamics_tables/large_single_aisle_1_aero_free_reduced_alpha.csv'
 

--- a/aviary/interface/test/test_shape_by_conn.py
+++ b/aviary/interface/test/test_shape_by_conn.py
@@ -111,7 +111,9 @@ class TestShapebyConn(unittest.TestCase):
             def setup(self):
 
                 self.add_input(Aircraft.Design.DRAG_POLAR, shape_by_conn=True, units='unitless')
-                add_aviary_input(self, Aircraft.Design.LIFT_POLAR, shape_by_conn=True, units='unitless')
+                add_aviary_input(
+                    self, Aircraft.Design.LIFT_POLAR, shape_by_conn=True, units='unitless'
+                )
 
                 self.add_output('z')
 
@@ -129,7 +131,7 @@ class TestShapebyConn(unittest.TestCase):
                 aviary_inputs=None,
                 mission_info=None,
                 subsystem_options=None,
-                phase_mission_bus_lengths=None
+                phase_mission_bus_lengths=None,
             ):
                 return PostSystem()
 

--- a/aviary/subsystems/aerodynamics/aerodynamics_builder.py
+++ b/aviary/subsystems/aerodynamics/aerodynamics_builder.py
@@ -633,7 +633,7 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilder):
                             'static_target': True,
                         }
                     else:
-                        lift_opts = {'shape': shape, 'static_target': True}
+                        lift_opts = {'val': np.ones(shape), 'static_target': True}
 
                     if aviary_inputs is not None and Aircraft.Design.DRAG_POLAR in aviary_inputs:
                         drag_opts = {
@@ -641,7 +641,7 @@ class CoreAerodynamicsBuilder(AerodynamicsBuilder):
                             'static_target': True,
                         }
                     else:
-                        drag_opts = {'shape': shape, 'static_target': True}
+                        drag_opts = {'val': np.ones(shape), 'static_target': True}
 
                     params[Aircraft.Design.LIFT_POLAR] = lift_opts
                     params[Aircraft.Design.DRAG_POLAR] = drag_opts


### PR DESCRIPTION
### Summary

Fix for a bug when a subsystem promotes a dynamically and statically shaped inputs together. In this case, if there is a default value, then `set_input_defaults` needs to be called on it in the configure method of aviary group.

This fix amends the previous fix so that mixed variables are not filtered out of the process.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None