### PR TITLE
Fix landing altitude connection

### DIFF
--- a/aviary/mission/energy_state_problem_configurator.py
+++ b/aviary/mission/energy_state_problem_configurator.py
@@ -511,7 +511,7 @@ class EnergyStateProblemConfigurator(ProblemConfiguratorBase):
         aviary_group.connect(
             f'traj.{last_regular_phase}.control_values:altitude',
             Mission.Landing.INITIAL_ALTITUDE,
-            src_indices=[0],
+            src_indices=[-1],
         )
 
     def set_phase_initial_guesses(


### PR DESCRIPTION
### Summary

This PR fixes a bug where the wrong end of the altitude array from the last phase is connected to landing.
Aviary now grabs the final altitude rather than the initial altitude from the last phase for landing calculations.

### Related Issues

- Resolves #1138 

### Backwards incompatibilities

None

### New Dependencies

None