### PR TITLE
More check partials in GASP based mass subsystem

### DIFF
--- a/aviary/subsystems/mass/gasp_based/fixed.py
+++ b/aviary/subsystems/mass/gasp_based/fixed.py
@@ -2262,7 +2262,6 @@ class HighLiftMass(om.ExplicitComponent):
                     * VFLAP**0.2733
                     / GRAV_ENGLISH_LBM
                 )
-
         elif (
             flap_type is FlapType.SINGLE_SLOTTED
             or flap_type is FlapType.DOUBLE_SLOTTED

--- a/aviary/subsystems/mass/gasp_based/fuel.py
+++ b/aviary/subsystems/mass/gasp_based/fuel.py
@@ -1140,13 +1140,13 @@ class BWBFuselageMass(om.ExplicitComponent):
         ) / GRAV_ENGLISH_LBM
         dFusWt_dgross_wt_initial = (
             0.167 * c_fuselage * 1.8 * (gross_wt_initial**-0.833) * (area_cabin**1.06)
-        ) / GRAV_ENGLISH_LBM
+        )
         dFusWt_darea_cabin = (
             1.06 * c_fuselage * 1.8 * (gross_wt_initial**0.167) * (area_cabin**0.06)
-        )
-        dFusWt_darea_aft_to_total = c_fuselage * fus_SA * uwt_aft
+        ) / GRAV_ENGLISH_LBM
+        dFusWt_darea_aft_to_total = c_fuselage * fus_SA * uwt_aft / GRAV_ENGLISH_LBM
         dFusWt_duwt_aft = c_fuselage * fus_SA * area_aft_to_total
-        dFusWt_dfus_SA = c_fuselage * area_aft_to_total * uwt_aft
+        dFusWt_dfus_SA = c_fuselage * area_aft_to_total * uwt_aft / GRAV_ENGLISH_LBM
 
         J[Aircraft.Fuselage.MASS, Aircraft.Fuselage.MASS_COEFFICIENT] = dFusWt_dc_fuselage
         J[Aircraft.Fuselage.MASS, Aircraft.Design.GROSS_MASS] = dFusWt_dgross_wt_initial

--- a/aviary/subsystems/mass/gasp_based/hydraulics.py
+++ b/aviary/subsystems/mass/gasp_based/hydraulics.py
@@ -1,6 +1,5 @@
 import openmdao.api as om
 
-from aviary.constants import GRAV_ENGLISH_LBM
 from aviary.variable_info.functions import add_aviary_input, add_aviary_option, add_aviary_output
 from aviary.variable_info.variables import Aircraft
 

--- a/aviary/subsystems/mass/gasp_based/instruments.py
+++ b/aviary/subsystems/mass/gasp_based/instruments.py
@@ -1,9 +1,8 @@
 import openmdao.api as om
 
-from aviary.constants import GRAV_ENGLISH_LBM
 from aviary.variable_info.enums import GASPEngineType
 from aviary.variable_info.functions import add_aviary_input, add_aviary_option, add_aviary_output
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 class InstrumentMass(om.ExplicitComponent):

--- a/aviary/subsystems/mass/gasp_based/passenger_service.py
+++ b/aviary/subsystems/mass/gasp_based/passenger_service.py
@@ -5,7 +5,6 @@ equipment.
 
 import openmdao.api as om
 
-from aviary.constants import GRAV_ENGLISH_LBM
 from aviary.variable_info.functions import add_aviary_input, add_aviary_option, add_aviary_output
 from aviary.variable_info.variables import Aircraft
 

--- a/aviary/subsystems/mass/gasp_based/test/test_air_conditioning.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_air_conditioning.py
@@ -175,5 +175,63 @@ class BWBACMassTestCase1(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
+class BWBACMassTestCase2(unittest.TestCase):
+    """
+    Test mass-weight conversion
+    """
+
+    def setUp(self):
+        import aviary.subsystems.mass.gasp_based.air_conditioning as ac
+
+        ac.GRAV_ENGLISH_LBM = 1.1
+
+    def tearDown(self):
+        import aviary.subsystems.mass.gasp_based.air_conditioning as ac
+
+        ac.GRAV_ENGLISH_LBM = 1.0
+
+    def test_case1(self):
+        options = get_option_defaults()
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
+
+        prob = self.prob = om.Problem()
+        self.prob.model.add_subsystem(
+            'ac',
+            BWBACMass(),
+            promotes=['*'],
+        )
+
+        prob.model.set_input_defaults(
+            Aircraft.AirConditioning.MASS_COEFFICIENT,
+            1.155,
+            units='unitless',  # generic_BWB_GASP.csv
+        )
+        prob.model.set_input_defaults(
+            Aircraft.Design.GROSS_MASS, 150000.0, units='lbm'
+        )  # generic_BWB_GASP.csv
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.LENGTH, 71.52455, units='ft'
+        )  # dont know where from
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.PRESSURE_DIFFERENTIAL, 10.0, units='psi'
+        )  # generic_BWB_GASP.csv
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.HYDRAULIC_DIAMETER, 19.365, units='ft'
+        )  # dont know where from
+
+        setup_model_options(self.prob, options)
+
+        self.prob.setup(check=False, force_alloc_complex=True)
+
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.AirConditioning.MASS], 1183.24239307, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/aviary/subsystems/mass/gasp_based/test/test_apu.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_apu.py
@@ -2,6 +2,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.apu import APUMass
 from aviary.variable_info.functions import setup_model_options
@@ -9,6 +10,7 @@ from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class ApuTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
@@ -38,6 +40,7 @@ class ApuTestCase1(unittest.TestCase):
         )  # large_single_aisle_1_GASP.csv
 
 
+@use_tempdirs
 class ApuTestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
@@ -76,6 +79,7 @@ class ApuTestCase2(unittest.TestCase):
         )  # large_single_aisle_1_GASP.csv
 
 
+@use_tempdirs
 class ApuTestCase3(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_avionics.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_avionics.py
@@ -2,6 +2,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.avionics import AvionicsMass
 from aviary.variable_info.functions import setup_model_options
@@ -9,6 +10,7 @@ from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Mission
 
 
+@use_tempdirs
 class AvionicsTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
@@ -46,6 +48,7 @@ class AvionicsTestCase1(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class AvionicsTestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
@@ -92,6 +95,7 @@ class AvionicsTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class AvionicsTestCase3(unittest.TestCase):
     """this is a mix of BWB conditions with lower passengers and discontinuities off test case"""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_cargo_containers.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_cargo_containers.py
@@ -2,6 +2,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.cargo_containers import CargoContainerMass
 from aviary.variable_info.functions import setup_model_options
@@ -9,6 +10,7 @@ from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class CargoTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
@@ -42,6 +44,7 @@ class CargoTestCase1(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class CargoTestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
@@ -84,6 +87,7 @@ class CargoTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class CargoTestCase3(unittest.TestCase):
     """BWB Parameters."""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_crew.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_crew.py
@@ -2,6 +2,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.crew import CabinCrewMass, FlightCrewMass
 from aviary.variable_info.enums import GASPEngineType
@@ -10,6 +11,7 @@ from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class CrewTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
@@ -54,6 +56,7 @@ class CrewTestCase1(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class CrewTestCase2(unittest.TestCase):
     """Gravity Modification Test."""
 
@@ -107,6 +110,7 @@ class CrewTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class CrewTestCase3(unittest.TestCase):
     """BWB Parameters."""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_design_load.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_design_load.py
@@ -16,7 +16,7 @@ from aviary.subsystems.mass.gasp_based.design_load import (
 )
 from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 class LoadSpeedsTestCase1(unittest.TestCase):
@@ -1462,7 +1462,6 @@ class BWBDesignLoadGroupTestCaseNonsmooth(unittest.TestCase):
         assert_check_partials(partial_data, atol=1e-15, rtol=1e-15)
 
 
-@use_tempdirs
 class BWBDesignLoadGroupTestCaseSmooth(unittest.TestCase):
     def setUp(self):
         options = get_option_defaults()

--- a/aviary/subsystems/mass/gasp_based/test/test_fixed.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fixed.py
@@ -761,6 +761,51 @@ class HighLiftTestCase(unittest.TestCase):
         assert_check_partials(data, atol=5e-10, rtol=1e-12)
 
 
+class HighLiftTestCase2(unittest.TestCase):
+    def setUp(self):
+        self.prob = om.Problem()
+
+        aviary_options = get_option_defaults()
+        aviary_options.set_val(Aircraft.Wing.NUM_FLAP_SEGMENTS, val=2)
+
+        self.prob.model.add_subsystem('HL', HighLiftMass(), promotes=['*'])
+
+        self.prob.model.set_input_defaults(Aircraft.Wing.HIGH_LIFT_MASS_COEFFICIENT, val=1.9)
+        self.prob.model.set_input_defaults(Aircraft.Wing.AREA, val=1370.3125, units='ft**2')
+        self.prob.model.set_input_defaults(Aircraft.Wing.SLAT_CHORD_RATIO, val=0.15)
+        self.prob.model.set_input_defaults(Aircraft.Wing.FLAP_CHORD_RATIO, val=0.15)
+        self.prob.model.set_input_defaults(Aircraft.Wing.TAPER_RATIO, val=0.33, units='unitless')
+        self.prob.model.set_input_defaults(Aircraft.Wing.SLAT_SPAN_RATIO, val=0.9, units='unitless')
+        self.prob.model.set_input_defaults(Aircraft.Wing.FLAP_SPAN_RATIO, val=0.65)
+        self.prob.model.set_input_defaults(
+            Aircraft.Design.WING_LOADING, val=128.0, units='lbf/ft**2'
+        )
+        self.prob.model.set_input_defaults(Aircraft.Wing.THICKNESS_TO_CHORD_ROOT, val=0.15)
+        self.prob.model.set_input_defaults(Aircraft.Wing.SPAN, val=117.81878299, units='ft')
+        self.prob.model.set_input_defaults(Aircraft.Fuselage.AVG_DIAMETER, val=13.1, units='ft')
+        self.prob.model.set_input_defaults(Aircraft.Wing.CENTER_CHORD, val=17.48974356, units='ft')
+        self.prob.model.set_input_defaults(Mission.Landing.LIFT_COEFFICIENT_MAX, val=2.3648)
+
+        setup_model_options(self.prob, aviary_options)
+
+        self.prob.setup(check=False, force_alloc_complex=True)
+
+    def test_case1(self):
+        self.prob.run_model()
+
+        expected_values = {
+            Aircraft.Wing.HIGH_LIFT_MASS: 2940.12660159,
+        }
+        tol = 5e-4
+
+        for var_name, expected_val in expected_values.items():
+            with self.subTest(var=var_name):
+                assert_near_equal(self.prob[var_name], expected_val, tol)
+
+        data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(data, atol=5e-10, rtol=1e-12)
+
+
 # this is the large single aisle 1 V3 test case
 @use_tempdirs
 class ControlMassTestCase(unittest.TestCase):
@@ -2136,4 +2181,7 @@ class BWBFixedMassGroupTestCase1(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    # unittest.main()
+    test = HighLiftTestCase2()
+    test.setUp()
+    test.test_case1()

--- a/aviary/subsystems/mass/gasp_based/test/test_fuel.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fuel.py
@@ -704,6 +704,44 @@ class BWBFuselageMassTestCase(unittest.TestCase):
         assert_check_partials(partial_data, atol=4e-11, rtol=1e-12)
 
 
+class BWBFuselageMassTestCase2(unittest.TestCase):
+    """GASP data. Test mass-weight conversion"""
+
+    def setUp(self):
+        import aviary.subsystems.mass.gasp_based.fuel as fuel
+
+        fuel.GRAV_ENGLISH_LBM = 1.1
+
+    def tearDown(self):
+        import aviary.subsystems.mass.gasp_based.fuel as fuel
+
+        fuel.GRAV_ENGLISH_LBM = 1.0
+
+    def test_case1(self):
+        prob = self.prob = om.Problem()
+        prob.model.add_subsystem('fuselage', BWBFuselageMass(), promotes=['*'])
+
+        prob.model.set_input_defaults(Aircraft.Fuselage.MASS_COEFFICIENT, 0.889, units='unitless')
+        prob.model.set_input_defaults(Aircraft.Fuselage.WETTED_AREA, 4573.8833, units='ft**2')
+        prob.model.set_input_defaults(Aircraft.Design.GROSS_MASS, 150000.0, units='lbm')
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.WETTED_AREA_RATIO_AFTBODY_TO_TOTAL, 0.2, units='unitless'
+        )
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.AFTBODY_MASS_PER_UNIT_AREA, 5.0, units='lbm/ft**2'
+        )
+        prob.model.set_input_defaults(Aircraft.Fuselage.CABIN_AREA, 1283.5249, units='ft**2')
+
+        prob.setup(check=False, force_alloc_complex=True)
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.Fuselage.MASS], 25397.12037004, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=4e-11, rtol=1e-12)
+
+
 class BWBFuelMassTestCase(unittest.TestCase):
     """Using BWB data."""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
@@ -60,14 +60,14 @@ class FurnishingMassTestCase2(unittest.TestCase):
     """Test mass-weight conversion"""
 
     def setUp(self):
-        import aviary.subsystems.mass.gasp_based.equipment_and_operating_items as equip
+        import aviary.subsystems.mass.gasp_based.furnishings as furnishings
 
-        equip.GRAV_ENGLISH_LBM = 1.1
+        furnishings.GRAV_ENGLISH_LBM = 1.1
 
     def tearDown(self):
-        import aviary.subsystems.mass.gasp_based.equipment_and_operating_items as equip
+        import aviary.subsystems.mass.gasp_based.furnishings as furnishings
 
-        equip.GRAV_ENGLISH_LBM = 1.0
+        furnishings.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
         options = get_option_defaults()

--- a/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
@@ -325,5 +325,114 @@ class BWBFurnishingMassTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
+class BWBFurnishingMassTestCase3(unittest.TestCase):
+    """
+    Created based on GASP BWB model
+    GROSS_MASS > 10000.0
+    Test mass-weight conversion
+    """
+
+    def setUp(self):
+        import aviary.subsystems.mass.gasp_based.furnishings as furnishings
+
+        furnishings.GRAV_ENGLISH_LBM = 1.1
+
+    def tearDown(self):
+        import aviary.subsystems.mass.gasp_based.furnishings as furnishings
+
+        furnishings.GRAV_ENGLISH_LBM = 1.0
+
+    def test_case1(self):
+        """
+        USE_EMPIRICAL_EQUATION = True
+        SMOOTH_MASS_DISCONTINUITIES = False
+        """
+        self.options = get_option_defaults()
+        self.options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
+        self.options.set_val(
+            Aircraft.Furnishings.USE_EMPIRICAL_EQUATION, val=True, units='unitless'
+        )
+
+        prob = self.prob = om.Problem()
+        prob.model.add_subsystem(
+            'furnishing',
+            BWBFurnishingMass(),
+            promotes=['*'],
+        )
+
+        prob.model.set_input_defaults(
+            Aircraft.Design.GROSS_MASS, 150000, units='lbm'
+        )  # generic_BWB_GASP.csv
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.HYDRAULIC_DIAMETER, 19.365, units='ft'
+        )  # generic_BWB_GASP.csv
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.LENGTH, 71.5245514, units='ft'
+        )  # generic_BWB_GASP.csv
+        prob.model.set_input_defaults(
+            Aircraft.Furnishings.MASS_SCALER, 40.0, units='unitless'
+        )  # generic_BWB_GASP.csv
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.CABIN_AREA, 1283.5249, units='ft**2'
+        )  # generic_BWB_GASP.csv
+
+        setup_model_options(self.prob, self.options)
+
+        self.prob.setup(check=False, force_alloc_complex=True)
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 10245.33033502, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=1e-12, rtol=1e-12)
+
+
+@use_tempdirs
+class BWBFurnishingMassTestCase4(unittest.TestCase):
+    """
+    Created based on GASP BWB model
+    GROSS_MASS < 10000
+    Test mass-weight conversion
+    """
+
+    def setUp(self):
+        options = get_option_defaults()
+        options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
+
+        prob = self.prob = om.Problem()
+        prob.model.add_subsystem(
+            'furnishing',
+            BWBFurnishingMass(),
+            promotes=['*'],
+        )
+
+        prob.model.set_input_defaults(Aircraft.Design.GROSS_MASS, 9999.0, units='lbm')  # arbitrary
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.HYDRAULIC_DIAMETER, 19.365, units='ft'
+        )  # arbitrary
+        prob.model.set_input_defaults(Aircraft.Fuselage.LENGTH, 71.5245514, units='ft')  # arbitrary
+        prob.model.set_input_defaults(
+            Aircraft.Furnishings.MASS_SCALER, 40.0, units='unitless'
+        )  # generic_BWB_GASP.csv
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.CABIN_AREA, 1283.5249, units='ft**2'
+        )  # arbitrary
+
+        setup_model_options(self.prob, options)
+
+        self.prob.setup(check=False, force_alloc_complex=True)
+
+    def test_case1(self):
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob[Aircraft.Furnishings.MASS], 590.935, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/aviary/subsystems/mass/gasp_based/test/test_mass_premission.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_mass_premission.py
@@ -3430,45 +3430,6 @@ class StructMassTestCase1(unittest.TestCase):
         assert_check_partials(partial_data, atol=4e-12, rtol=1e-12)
 
 
-class StructMassTestCase2(unittest.TestCase):
-    """Test mass-weight conversion."""
-
-    def setUp(self):
-        import aviary.subsystems.mass.gasp_based.fuel as fuel
-
-        fuel.GRAV_ENGLISH_LBM = 1.1
-
-    def tearDown(self):
-        import aviary.subsystems.mass.gasp_based.fuel as fuel
-
-        fuel.GRAV_ENGLISH_LBM = 1.0
-
-    def test_case1(self):
-        self.prob = om.Problem()
-        self.prob.model.add_subsystem('struct', StructureMass(), promotes=['*'])
-
-        self.prob.model.set_input_defaults(Aircraft.Fuselage.MASS, val=18763, units='lbm')
-        self.prob.model.set_input_defaults(Aircraft.Wing.MASS, val=15830, units='lbm')
-        self.prob.model.set_input_defaults(Aircraft.Design.EMPENNAGE_MASS, val=4572, units='lbm')
-
-        self.prob.model.set_input_defaults(Aircraft.LandingGear.TOTAL_MASS, val=7511, units='lbm')
-        self.prob.model.set_input_defaults(
-            Aircraft.Propulsion.TOTAL_ENGINE_POD_MASS, val=3785, units='lbm'
-        )
-        self.prob.model.set_input_defaults(
-            Aircraft.Design.STRUCTURAL_MASS_INCREMENT, val=0, units='lbm'
-        )
-
-        setup_model_options(
-            self.prob, AviaryValues({Aircraft.Engine.NUM_ENGINES: ([2], 'unitless')})
-        )
-
-        self.prob.setup(check=False, force_alloc_complex=True)
-
-        partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=1e-11, rtol=1e-12)
-
-
 class BWBStructMassTestCase(unittest.TestCase):
     """Using BWB data."""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_wing.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_wing.py
@@ -643,7 +643,7 @@ class WingMassGroupTestCase4(unittest.TestCase):
 
 
 class BWBWingMassSolveTestCase(unittest.TestCase):
-    """this is the large single aisle 1 V3 test case"""
+    """this is BWB test case"""
 
     def setUp(self):
         prob = self.prob = om.Problem()
@@ -699,6 +699,74 @@ class BWBWingMassSolveTestCase(unittest.TestCase):
         assert_near_equal(
             self.prob['isolated_wing_mass'], 6946.57966315, tol
         )  # 7645.-107.9-682.6=6854.5
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)
+
+
+class BWBWingMassSolveTestCase2(unittest.TestCase):
+    """this is BWB test case, Test mass-weight conversion"""
+
+    def setUp(self):
+        import aviary.subsystems.mass.gasp_based.wing as wing
+
+        wing.GRAV_ENGLISH_LBM = 1.1
+
+    def tearDown(self):
+        import aviary.subsystems.mass.gasp_based.wing as wing
+
+        wing.GRAV_ENGLISH_LBM = 1.0
+
+    def test_case1(self):
+        prob = self.prob = om.Problem()
+        prob.model.add_subsystem('wingfuel', BWBWingMassSolve(), promotes=['*'])
+
+        prob.model.set_input_defaults(Aircraft.Design.GROSS_MASS, 150000, units='lbm')
+        prob.model.set_input_defaults(Aircraft.Wing.HIGH_LIFT_MASS, 1068.88854499, units='lbm')
+        prob.model.set_input_defaults('c_strut_braced', 1.0, units='unitless')
+        prob.model.set_input_defaults(
+            Aircraft.Wing.ULTIMATE_LOAD_FACTOR, 3.77335889, units='unitless'
+        )
+        prob.model.set_input_defaults(Aircraft.Wing.MASS_COEFFICIENT, 75.78, units='unitless')
+        prob.model.set_input_defaults(Aircraft.Wing.MATERIAL_FACTOR, 1.19461189, units='unitless')
+        prob.model.set_input_defaults(Aircraft.Engine.POSITION_FACTOR, 1.05, units='unitless')
+        prob.model.set_input_defaults('c_gear_loc', 0.95, units='unitless')
+        prob.model.set_input_defaults(Aircraft.Wing.SPAN, 146.38501, units='ft')
+        prob.model.set_input_defaults(Aircraft.Fuselage.AVG_DIAMETER, 38.0, units='ft')
+        prob.model.set_input_defaults(Aircraft.Wing.TAPER_RATIO, 0.27444, units='unitless')
+        prob.model.set_input_defaults(
+            Aircraft.Wing.THICKNESS_TO_CHORD_ROOT, 0.165, units='unitless'
+        )
+        prob.model.set_input_defaults('half_sweep', 0.479839474, units='rad')
+        prob.model.set_input_defaults(
+            Aircraft.Fuselage.LIFT_COEFFICIENT_RATIO_BODY_TO_WING, 0.35, units='unitless'
+        )
+
+        newton = self.prob.model.nonlinear_solver = om.NewtonSolver()
+        newton.options['atol'] = 1e-9
+        newton.options['rtol'] = 1e-9
+        newton.options['iprint'] = 2
+        newton.options['maxiter'] = 10
+        newton.options['solve_subsystems'] = True
+        newton.options['max_sub_solves'] = 10
+        newton.options['err_on_non_converge'] = True
+        newton.options['reraise_child_analysiserror'] = False
+        newton.linesearch = om.BoundsEnforceLS()
+        newton.linesearch.options['bound_enforcement'] = 'scalar'
+        newton.linesearch.options['iprint'] = -1
+        newton.options['err_on_non_converge'] = False
+
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
+
+        setup_model_options(
+            self.prob, AviaryValues({Aircraft.Engine.NUM_ENGINES: ([2], 'unitless')})
+        )
+
+        prob.setup(check=False, force_alloc_complex=True)
+        self.prob.run_model()
+
+        tol = 1e-7
+        assert_near_equal(self.prob['isolated_wing_mass'], 6815.17818273, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
         assert_check_partials(partial_data, atol=1e-8, rtol=1e-8)

--- a/aviary/subsystems/test/test_gasp_based_premission.py
+++ b/aviary/subsystems/test/test_gasp_based_premission.py
@@ -114,7 +114,7 @@ class PreMissionGroupTest(unittest.TestCase):
                 assert_near_equal(prob[var_name], expected, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=1e-5, rtol=1e-5)
+        assert_check_partials(partial_data, atol=3e-5, rtol=3e-5)
 
     def test_case2(self):
         """premission: propulsion + geometry + aerodynamics + mass."""

--- a/aviary/subsystems/test/test_gasp_based_premission.py
+++ b/aviary/subsystems/test/test_gasp_based_premission.py
@@ -46,7 +46,7 @@ class PreMissionGroupTest(unittest.TestCase):
         )
 
         setup_model_options(prob, self.gasp_inputs)
-        prob.setup(check=False)
+        prob.setup(check=False, force_alloc_complex=True)
         set_aviary_initial_values(prob, self.gasp_inputs)
 
         prob.set_val(Mission.Landing.LIFT_COEFFICIENT_MAX, val=2.3648, units='unitless')
@@ -114,7 +114,7 @@ class PreMissionGroupTest(unittest.TestCase):
                 assert_near_equal(prob[var_name], expected, tol)
 
         partial_data = self.prob.check_partials(out_stream=None, method='cs')
-        assert_check_partials(partial_data, atol=3e-5, rtol=3e-5)
+        assert_check_partials(partial_data, atol=3e-9, rtol=3e-9)
 
     def test_case2(self):
         """premission: propulsion + geometry + aerodynamics + mass."""
@@ -203,6 +203,9 @@ class PreMissionGroupTest(unittest.TestCase):
             with self.subTest(var=var_name):
                 assert_near_equal(prob[var_name], expected, tol)
 
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=3e-9, rtol=3e-9)
+
 
 @use_tempdirs
 class BWBPreMissionGroupTest(unittest.TestCase):
@@ -273,7 +276,7 @@ class BWBPreMissionGroupTest(unittest.TestCase):
         )
 
         setup_model_options(prob, self.gasp_inputs)
-        prob.setup(check=False)
+        prob.setup(check=False, force_alloc_complex=True)
         set_aviary_initial_values(prob, self.gasp_inputs)
 
         prob.run_model()
@@ -342,6 +345,9 @@ class BWBPreMissionGroupTest(unittest.TestCase):
             with self.subTest(var=var_name):
                 assert_near_equal(prob[var_name], expected, tol)
 
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=3e-9, rtol=3e-9)
+
     def test_case_geom(self):
         """premission: geometry."""
         prob = self.prob
@@ -361,7 +367,7 @@ class BWBPreMissionGroupTest(unittest.TestCase):
         )
 
         setup_model_options(prob, self.gasp_inputs)
-        prob.setup(check=False)
+        prob.setup(check=False, force_alloc_complex=True)
         set_aviary_initial_values(prob, self.gasp_inputs)
 
         prob.run_model()
@@ -398,6 +404,9 @@ class BWBPreMissionGroupTest(unittest.TestCase):
             with self.subTest(var=var_name):
                 assert_near_equal(prob[var_name], expected, tol)
 
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=3e-9, rtol=3e-9)
+
     def test_case_geom_mass(self):
         """premission: geometry + mass."""
         prob = self.prob
@@ -417,7 +426,7 @@ class BWBPreMissionGroupTest(unittest.TestCase):
         )
 
         setup_model_options(prob, self.gasp_inputs)
-        prob.setup(check=False)
+        prob.setup(check=False, force_alloc_complex=True)
         set_aviary_initial_values(prob, self.gasp_inputs)
 
         prob.set_val(
@@ -496,9 +505,9 @@ class BWBPreMissionGroupTest(unittest.TestCase):
             with self.subTest(var=var_name):
                 assert_near_equal(prob[var_name], expected, tol)
 
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=3e-9, rtol=3e-9)
+
 
 if __name__ == '__main__':
-    # unittest.main()
-    test = PreMissionGroupTest()
-    test.setUp()
-    test.test_case1()
+    unittest.main()

--- a/aviary/subsystems/test/test_gasp_based_premission.py
+++ b/aviary/subsystems/test/test_gasp_based_premission.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.core.aviary_problem import AviaryProblem
@@ -112,6 +112,9 @@ class PreMissionGroupTest(unittest.TestCase):
         for var_name, expected in expected_values.items():
             with self.subTest(var=var_name):
                 assert_near_equal(prob[var_name], expected, tol)
+
+        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        assert_check_partials(partial_data, atol=1e-5, rtol=1e-5)
 
     def test_case2(self):
         """premission: propulsion + geometry + aerodynamics + mass."""
@@ -495,4 +498,7 @@ class BWBPreMissionGroupTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    # unittest.main()
+    test = PreMissionGroupTest()
+    test.setUp()
+    test.test_case1()


### PR DESCRIPTION
### Summary

More unit test for check partials in GASP based mass subsystem, especially in mass-weight conversion.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None