### PR TITLE
Extended the args for get_linked_variables in the subsystem API.

### DIFF
--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -1153,10 +1153,17 @@ class AviaryGroup(om.Group):
 
         lists_to_link = []
         for idx, phase_name in enumerate(self.mission_info):
+            phase_info = self.mission_info[phase_name]
+            all_subsystem_options = phase_info.get('subsystem_options', {})
+
             lists_to_link.append([])
-            for external_subsystem in self.external_subsystems:
+            for subsys in self.external_subsystems:
                 lists_to_link[idx].extend(
-                    external_subsystem.get_linked_variables(aviary_inputs=self.aviary_inputs)
+                    subsys.get_linked_variables(
+                        aviary_inputs=self.aviary_inputs,
+                        user_options=self.mission_info[phase_name]['user_options'],
+                        subsystem_options=all_subsystem_options.get(subsys.name, {}),
+                    )
                 )
 
         # get unique variable names from lists_to_link

--- a/aviary/models/external_subsystems/detailed_battery/detailed_battery_builder.py
+++ b/aviary/models/external_subsystems/detailed_battery/detailed_battery_builder.py
@@ -87,7 +87,7 @@ class DetailedBatteryBuilder(SubsystemBuilder):
 
         return states_dict
 
-    def get_linked_variables(self, aviary_inputs=None):
+    def get_linked_variables(self, aviary_inputs=None, user_options=None, subsystem_options=None):
         """
         Return the list of linked variables for the battery subsystem; in this case
         it's our two state variables.

--- a/aviary/subsystems/energy/battery_builder.py
+++ b/aviary/subsystems/energy/battery_builder.py
@@ -118,6 +118,6 @@ class BatteryBuilder(SubsystemBuilder):
         }
         return params
 
-    def get_linked_variables(self, aviary_inputs=None):
+    def get_linked_variables(self, aviary_inputs=None, user_options=None, subsystem_options=None):
         # link cumulative electric energy between phases
         return [Dynamic.Vehicle.CUMULATIVE_ELECTRIC_ENERGY_USED]

--- a/aviary/subsystems/propulsion/propulsion_builder.py
+++ b/aviary/subsystems/propulsion/propulsion_builder.py
@@ -190,11 +190,15 @@ class CorePropulsionBuilder(PropulsionBuilder):
         return constraints
 
     # NOTE no unittests!
-    def get_linked_variables(self, aviary_inputs=None):
+    def get_linked_variables(self, aviary_inputs=None, user_options=None, subsystem_options=None):
         """Call get_linked_variables() on all engine models and return combined result."""
         linked_vars = {}
         for engine in self.engine_models:
-            engine_linked_vars = engine.get_linked_variables(aviary_inputs=aviary_inputs)
+            engine_linked_vars = engine.get_linked_variables(
+                aviary_inputs=aviary_inputs,
+                user_options=user_options,
+                subsystem_options=subsystem_options,
+            )
             linked_vars.update(engine_linked_vars)
 
         return linked_vars

--- a/aviary/subsystems/propulsion/turboprop_model.py
+++ b/aviary/subsystems/propulsion/turboprop_model.py
@@ -417,14 +417,26 @@ class TurbopropModel(EngineModel):
 
         return params
 
-    def get_linked_variables(self, aviary_inputs=None):
+    def get_linked_variables(self, aviary_inputs=None, user_options=None, subsystem_options=None):
         linked_vars = super().get_linked_variables()  # calls from EngineModel
         if self.shaft_power_model is not None:
-            linked_vars += self.shaft_power_model.get_linked_variables(aviary_inputs=aviary_inputs)
+            linked_vars += self.shaft_power_model.get_linked_variables(
+                aviary_inputs=aviary_inputs,
+                user_options=user_options,
+                subsystem_options=subsystem_options,
+            )
         if self.gearbox_model is not None:
-            linked_vars += self.gearbox_model.get_linked_variables(aviary_inputs=aviary_inputs)
+            linked_vars += self.gearbox_model.get_linked_variables(
+                aviary_inputs=aviary_inputs,
+                user_options=user_options,
+                subsystem_options=subsystem_options,
+            )
         if self.propeller_model is not None:
-            linked_vars += self.propeller_model.get_linked_variables(aviary_inputs=aviary_inputs)
+            linked_vars += self.propeller_model.get_linked_variables(
+                aviary_inputs=aviary_inputs,
+                user_options=user_options,
+                subsystem_options=subsystem_options,
+            )
 
         return linked_vars
 

--- a/aviary/subsystems/subsystem_builder.py
+++ b/aviary/subsystems/subsystem_builder.py
@@ -192,14 +192,19 @@ class SubsystemBuilder(ABC):
         """
         return {}
 
-    def get_linked_variables(self, aviary_inputs=None):
+    def get_linked_variables(self, aviary_inputs=None, user_options=None, subsystem_options=None):
         """
-        Return a list of variable names that will be linked between phases.
+        Return a list of variable names that will be linked when this phase is connected to another
+        phase that shares the variable.
 
         Parameters
         ----------
         aviary_inputs : dict
             A dictionary containing the inputs to the subsystem.
+        user_options : dict
+            Dictionary of user options for this phase.
+        subsystem_options : dict
+            Dictionary of optional arguments for this subsystem in this phase.
 
         Returns
         -------


### PR DESCRIPTION
### Summary

This was a method I neglected to update in the big API PR, mostly because I didn't fully appreciate how it should be used. This update is needed for further work on simplifying and generalizing the phase linking.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None