### PR TITLE
nacelle mass update

### DIFF
--- a/aviary/subsystems/mass/flops_based/engine_pod.py
+++ b/aviary/subsystems/mass/flops_based/engine_pod.py
@@ -80,6 +80,8 @@ class EnginePodMass(om.ExplicitComponent):
 
         # NOTE if this value gets needed elsewhere, calculate in pre-mission propulsion
         #      and pass to this component as input
+        # add new factor to FLOPS equations, which assumes for multiple engine types that mass of
+        # "extra" items in the pod are distributed according to engine thrust
         engine_thrust_ratio = (eng_thrust * num_eng) / total_thrust
 
         m_eng = inputs[Aircraft.Engine.MASS]
@@ -103,10 +105,13 @@ class EnginePodMass(om.ExplicitComponent):
         pod_mass = np.array([])
 
         # calculate engine pod mass for single engine of each type
+        # note num_eng/nacelle_count is 1 or less - this is because for centerline nacelles, not
+        # all nacelle mass is bookkept as part of the engine pod
         for i in range(len(num_eng)):
             pod_mass = np.append(
                 pod_mass,
-                nacelle_content_mass[i] / max(1, num_eng[i]) + m_nac[i] / max(1, nacelle_count[i]),
+                nacelle_content_mass[i] / max(1, num_eng[i])
+                + m_nac[i] * num_eng[i] / max(1, nacelle_count[i]),
             )
 
         outputs[Aircraft.Engine.POD_MASS] = pod_mass
@@ -151,7 +156,7 @@ class EnginePodMass(om.ExplicitComponent):
 
         partials[Aircraft.Engine.POD_MASS, Aircraft.Fuel.FUEL_SYSTEM_MASS] = 0.25 * fact1 * ratio
 
-        partials[Aircraft.Engine.POD_MASS, Aircraft.Nacelle.MASS] = fact2
+        partials[Aircraft.Engine.POD_MASS, Aircraft.Nacelle.MASS] = fact2 * num_eng
 
         partials[Aircraft.Engine.POD_MASS, Aircraft.Engine.SCALED_SLS_THRUST] = (
             num_eng * nac_fact * fact1

--- a/aviary/subsystems/mass/flops_based/mass_summation.py
+++ b/aviary/subsystems/mass/flops_based/mass_summation.py
@@ -117,14 +117,19 @@ class StructureMass(om.ExplicitComponent):
         add_aviary_output(self, Aircraft.Design.STRUCTURE_MASS, units='lbm')
 
     def setup_partials(self):
-        num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
+        num_engines = self.options[Aircraft.Engine.NUM_ENGINES]
+        num_engine_type = len(num_engines)
 
         self.declare_partials(Aircraft.Design.STRUCTURE_MASS, '*', val=1)
         self.declare_partials(
-            Aircraft.Design.STRUCTURE_MASS, Aircraft.Nacelle.MASS, val=np.ones(num_engine_type)
+            Aircraft.Design.STRUCTURE_MASS,
+            Aircraft.Nacelle.MASS,
+            val=np.ones(num_engine_type) * num_engines,
         )
 
     def compute(self, inputs, outputs):
+        num_engines = self.options[Aircraft.Engine.NUM_ENGINES]
+
         empennage_mass = inputs[Aircraft.Design.EMPENNAGE_MASS]
         fuselage_mass = inputs[Aircraft.Fuselage.MASS]
         landing_gear_mass = inputs[Aircraft.LandingGear.TOTAL_MASS]
@@ -137,7 +142,7 @@ class StructureMass(om.ExplicitComponent):
             + empennage_mass
             + fuselage_mass
             + landing_gear_mass
-            + np.sum(nacelle_mass)
+            + np.dot(nacelle_mass, num_engines)
             + paint_mass
         )
 

--- a/aviary/subsystems/mass/flops_based/mass_summation.py
+++ b/aviary/subsystems/mass/flops_based/mass_summation.py
@@ -29,7 +29,9 @@ class MassSummation(om.Group):
         self.add_subsystem(
             'propulsion_mass', PropulsionMass(), promotes_inputs=['*'], promotes_outputs=['*']
         )
-
+        self.add_subsystem(
+            'controls_mass', FlightControls(), promotes_inputs=['*'], promotes_outputs=['*']
+        )
         # Systems and equipment mass calculations are not combined into a single group to avoid an
         # additional layer of groups (standard is one component, alternate would be a group)
         if alt_mass:
@@ -170,6 +172,20 @@ class PropulsionMass(om.ExplicitComponent):
         outputs[Aircraft.Propulsion.MASS] = (
             thrust_rev_mass + misc_prop_mass + fuel_sys_mass + total_eng_mass + battery_mass
         )
+
+
+# "compute" controls mass for reporting. FLOPS only computes one variable in this category
+class FlightControls(om.ExplicitComponent):
+    def setup(self):
+        add_aviary_input(self, Aircraft.Wing.SURFACE_CONTROL_MASS)
+
+        add_aviary_output(self, Aircraft.Controls.MASS)
+
+    def setup_partials(self):
+        self.declare_partials(Aircraft.Controls.MASS, Aircraft.Wing.SURFACE_CONTROL_MASS, val=1)
+
+    def compute(self, inputs, outputs):
+        outputs[Aircraft.Controls.MASS] = inputs[Aircraft.Wing.SURFACE_CONTROL_MASS]
 
 
 class SystemsEquipmentMass(om.ExplicitComponent):

--- a/aviary/subsystems/mass/flops_based/nacelle.py
+++ b/aviary/subsystems/mass/flops_based/nacelle.py
@@ -64,7 +64,9 @@ class NacelleMass(om.ExplicitComponent):
         avg_length = inputs[Aircraft.Nacelle.AVG_LENGTH]
         scaler = inputs[Aircraft.Nacelle.MASS_SCALER]
 
-        count_factor = nacelle_count_factor(num_eng)
+        # Original FLOPS nacelle equation was mass of all nacelles - here we average it to nacelle
+        # mass per individual engine
+        count_factor = nacelle_count_factor(num_eng) / num_eng
         # This should be distributed thrust factor, see issue #1096.
         thrust = inputs[Aircraft.Engine.SCALED_SLS_THRUST]
 
@@ -78,7 +80,7 @@ class NacelleMass(om.ExplicitComponent):
         avg_length = inputs[Aircraft.Nacelle.AVG_LENGTH]
         scaler = inputs[Aircraft.Nacelle.MASS_SCALER]
 
-        count_factor = nacelle_count_factor(num_eng)
+        count_factor = nacelle_count_factor(num_eng) / num_eng
         # This should be distributed thrust factor, see issue #1096.
         thrust = inputs[Aircraft.Engine.SCALED_SLS_THRUST]
 

--- a/aviary/subsystems/mass/flops_based/test/test_engine_pod.py
+++ b/aviary/subsystems/mass/flops_based/test/test_engine_pod.py
@@ -93,7 +93,7 @@ class EnginePodMassTest(unittest.TestCase):
         prob.run_model()
 
         mass = prob.get_val(Aircraft.Engine.POD_MASS)
-        expected_mass = np.array([525.0, 60.0, 362.14285714])
+        expected_mass = np.array([575.0, 75.0, 416.4285714])
 
         assert_near_equal(mass, expected_mass, tolerance=1e-10)
 

--- a/aviary/subsystems/mass/flops_based/test/test_mass_summation.py
+++ b/aviary/subsystems/mass/flops_based/test/test_mass_summation.py
@@ -223,7 +223,7 @@ class StructureMassTest(unittest.TestCase):
         prob.set_val(Aircraft.Fuselage.MASS, val=30.0, units='lbm')
         prob.set_val(Aircraft.Design.EMPENNAGE_MASS, 150.0, units='lbm')
         prob.set_val(Aircraft.LandingGear.TOTAL_MASS, 110.0, units='lbm')
-        prob.set_val(Aircraft.Nacelle.MASS, val=np.array([1000.0, 500.0, 1500.0]), units='lbm')
+        prob.set_val(Aircraft.Nacelle.MASS, val=np.array([250.0, 250.0, 750.0]), units='lbm')
         prob.set_val(Aircraft.Paint.MASS, val=70.0, units='lbm')
         prob.set_val(Aircraft.Wing.MASS, val=90.0, units='lbm')
 

--- a/aviary/subsystems/mass/flops_based/test/test_nacelle.py
+++ b/aviary/subsystems/mass/flops_based/test/test_nacelle.py
@@ -95,7 +95,7 @@ class NacelleMassTest(unittest.TestCase):
         prob.run_model()
 
         nacelle_mass = prob.get_val(Aircraft.Nacelle.MASS, 'lbm')
-        nacelle_mass_expected = np.array([2793.02569, 778.05716, 1915.21762])
+        nacelle_mass_expected = np.array([698.25642407, 389.02857912, 957.60881015])
         assert_near_equal(nacelle_mass, nacelle_mass_expected, tolerance=1e-8)
 
         partial_data = prob.check_partials(

--- a/aviary/subsystems/mass/mass_builder.py
+++ b/aviary/subsystems/mass/mass_builder.py
@@ -10,6 +10,8 @@ CoreMassBuilder : the interface for Aviary's core mass subsystem builder
 
 import numpy as np
 
+from openmdao.utils.units import convert_units
+
 from aviary.interface.utils import find_variable_in_problem
 from aviary.subsystems.mass.flops_based.mass_premission import MassPremission as MassPremissionFLOPS
 from aviary.subsystems.mass.gasp_based.mass_premission import MassPremission as MassPremissionGASP
@@ -107,71 +109,80 @@ class CoreMassBuilder(MassBuilder):
             method = self.code_origin.value + '-derived relations'
             f.write(f'# Mass estimation: {method}')
 
-            f.write('||||\n')
-            f.write('|####**AIRCRAFT DESIGN DETAILS:**####|||\n')
-            f.write('||||\n')
-
             f.write('\n| Name | Value | Units |\n')
             f.write('|:-|:-|:-|\n')
             val, units = find_variable_in_problem(Aircraft.Wing.MASS, prob, self.meta_data)
             f.write(f'|Wing|{val}|{units}|\n')
-            f.write('||||\n')
 
+            # EMPENNAGE MASS GROUP #
             val, units = find_variable_in_problem(
                 Aircraft.Design.EMPENNAGE_MASS, prob, self.meta_data
             )
             f.write(f'|Empennage Group|{val}|{units}|\n')
 
+            # canard reporting optional
             val, units = find_variable_in_problem(Aircraft.Canard.MASS, prob, self.meta_data)
-            if val != 0.0 or val != 'Not Found in Model':
+            if val != 'Not Found in Model':
                 f.write(f'|{tab}Canard|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(
                 Aircraft.HorizontalTail.MASS, prob, self.meta_data
             )
-            if val != 0.0 or val != 'Not Found in Model':
-                f.write(f'|{tab}Horizontal Tail|{val}|{units}|\n')
+            f.write(f'|{tab}Horizontal Tail|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.VerticalTail.MASS, prob, self.meta_data)
-            if val != 0.0 or val != 'Not Found in Model':
-                f.write(f'|{tab}Vertical Tail|{val}|{units}|\n')
+            f.write(f'|{tab}Vertical Tail|{val}|{units}|\n')
 
+            # fin reporting optional
             val, units = find_variable_in_problem(Aircraft.Fins.MASS, prob, self.meta_data)
-            if val != 0.0 or val != 'Not Found in Model':
+            if val != 'Not Found in Model':
                 f.write(f'|{tab}Fins|{val}|{units}|\n')
-            f.write('||||\n')
 
             val, units = find_variable_in_problem(Aircraft.Fuselage.MASS, prob, self.meta_data)
             f.write(f'|Fuselage|{val}|{units}|\n')
-            f.write('||||\n')
 
+            # LANDING GEAR GROUP #
             val, units = find_variable_in_problem(
                 Aircraft.LandingGear.TOTAL_MASS, prob, self.meta_data
             )
             f.write(f'|Landing Gear Group|{val}|{units}|\n')
+
+            # main gear reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.LandingGear.MAIN_GEAR_MASS, prob, self.meta_data
             )
-            if val != 0.0 or val != 'Not Found in Model':
+            if val != 'Not Found in Model':
                 f.write(f'|{tab}Main Gear|{val}|{units}|\n')
 
+            # nose gear reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.LandingGear.NOSE_GEAR_MASS, prob, self.meta_data
             )
-            if val != 0.0 or val != 'Not Found in Model':
+            if val != 'Not Found in Model':
                 f.write(f'|{tab}Nose Gear|{val}|{units}|\n')
-            f.write('||||\n')
+
+            # OTHER STRUCTURES (NOT IN GROUP) #
+            f.write('|Nacelles|||\n')
+            val, units = find_variable_in_problem(Aircraft.Nacelle.MASS, prob, self.meta_data)
+            for i, engine in enumerate(engine_models):
+                if isinstance(val, (np.ndarray, list, tuple)):
+                    val = val[i]
+                f.write(f'|{tab}{engine.name}|{val} ({val * num_engines[i]} total)|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.Nacelle.MASS, prob, self.meta_data)
             if val == 0.0:
                 val = [val]
-            f.write(f'|Nacelles|{np.dot(val, num_engines)}|{units}|\n')
-            f.write('||||\n')
 
+            # paint reporting optional
+            val, units = find_variable_in_problem(Aircraft.Paint.MASS, prob, self.meta_data)
+            if val != 'Not Found in Model':
+                f.write(f'|Paint|{val}|{units}|\n')
+
+            # additional structural mass reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.Design.STRUCTURAL_MASS_INCREMENT, prob, self.meta_data
             )
-            if val != 0.0 or val != 'Not Found in Model':
+            if val != 'Not Found in Model':
                 f.write(f'|{tab}Additional Structural Mass|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(
@@ -180,138 +191,178 @@ class CoreMassBuilder(MassBuilder):
             f.write(f'|**Structure Mass**|**{val}**|**{units}**|\n')
             f.write('||||\n')
 
+            # PROPULSION GROUP #
             val, units = find_variable_in_problem(Aircraft.Propulsion.MASS, prob, self.meta_data)
             f.write(f'|Propulsion Group|{val}|{units}|\n')
+
             val, units = find_variable_in_problem(
                 Aircraft.Propulsion.TOTAL_ENGINE_MASS, prob, self.meta_data
             )
             f.write(f'|{tab}Engines|{val}|{units}|\n')
+
             val, units = find_variable_in_problem(Aircraft.Engine.MASS, prob, self.meta_data)
             for i, engine in enumerate(engine_models):
                 if isinstance(val, (np.ndarray, list, tuple)):
                     val = val[i]
                 f.write(f'|{tab}{tab}{engine.name}|{val} ({val * num_engines[i]} total)|{units}|\n')
 
+            # thrust reverser reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.Propulsion.TOTAL_THRUST_REVERSERS_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Thrust Reversers|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Thrust Reversers|{val}|{units}|\n')
 
+            # fuel system reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.Fuel.FUEL_SYSTEM_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Fuel System|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Fuel System|{val}|{units}|\n')
 
+            # misc propulsion mass reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.Propulsion.TOTAL_MISC_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Miscellaneous|{val}|{units}|\n')
-            f.write('||||\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Miscellaneous|{val}|{units}|\n')
 
+            # battery reporting optional
             val, units = find_variable_in_problem(Aircraft.Battery.MASS, prob, self.meta_data)
-            if val != 0.0 and val != 'Not Found in Model':
+            if val != 'Not Found in Model':
                 f.write(f'|{tab}Battery|{val}|{units}|\n')
-            f.write('|||\n')
 
+            # SYSTEMS AND EQUIPMENT GROUP #
             val, units = find_variable_in_problem(
                 Aircraft.Design.SYSTEMS_AND_EQUIPMENT_MASS, prob, self.meta_data
             )
             f.write(f'|Systems and Equipment|{val}|{units}|\n')
+
+            # all systems and equipment group items reporting optional
             val, units = find_variable_in_problem(Aircraft.Controls.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Flight Controls|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Flight Controls|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.APU.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Auxiliary Power|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Auxiliary Power|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.Instruments.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Instruments|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Instruments|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.Hydraulics.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Hydraulics|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Hydraulics|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.Electrical.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Electrical|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Electrical|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.Avionics.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Avionics|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Avionics|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.Furnishings.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Furnishings|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Furnishings|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(
                 Aircraft.AirConditioning.MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Environmental Control|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Environmental Control|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.APU.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Auxiliary Power|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Auxiliary Power|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.AntiIcing.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Anti-Icing|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Anti-Icing|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Aircraft.OxygenSystem.MASS, prob, self.meta_data)
-            f.write(f'|{tab}Oxygen System|{val}|{units}|\n')
-            f.write('||||\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Oxygen System|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(
                 Aircraft.Design.EXTERNAL_SUBSYSTEMS_MASS, prob, self.meta_data
             )
+            # TODO find individual mass names that got added by each subsystem and report?
             f.write(f'|External Subsystems|{val}|{units}|\n')
-            f.write('||||\n')
 
+            # empty mass margin reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.Design.EMPTY_MASS_MARGIN, prob, self.meta_data
             )
-            if val != 0.0 or val != 'Not Found in Model':
+            if val != 'Not Found in Model':
                 f.write(f'|Empty Mass Margin|{val}|{units}|\n')
-            f.write('||||\n')
 
             val, units = find_variable_in_problem(Aircraft.Design.EMPTY_MASS, prob, self.meta_data)
             f.write(f'|**Empty Mass**|**{val}**|**{units}**|\n')
             f.write('||||\n')
 
-            f.write('||||\n')
-            f.write(f'|####**MISSION SPECIFIC DETAILS:**####|||\n')
-            f.write('||||\n')
-
+            # OPERATING ITEMS GROUP #
             val, units = find_variable_in_problem(
                 Mission.OPERATING_ITEMS_MASS, prob, self.meta_data
             )
             f.write(f'|Operating Items|{val}|{units}|\n')
 
-            val1, units = find_variable_in_problem(
-                Aircraft.CrewPayload.CABIN_CREW_MASS, prob, self.meta_data
-            )
-            val2, units = find_variable_in_problem(
+            # crew mass reporting optional
+            val1, units1 = find_variable_in_problem(
                 Aircraft.CrewPayload.FLIGHT_CREW_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Crew|{val1 + val2}|{units}|\n')
+            val2, units2 = find_variable_in_problem(
+                Aircraft.CrewPayload.CABIN_CREW_MASS, prob, self.meta_data
+            )
+            if val1 != 'Not Found in Model' or val2 != 'Not Found in Model':
+                crew_sum = 0
+                units = units1
+                if not isinstance(val1, str):
+                    crew_sum += val1
+                if not isinstance(val2, str):
+                    # need to make sure summing masses of the same units
+                    if units1 != units2:
+                        crew_sum += convert_units(val2, units2, units1)
+                    else:
+                        crew_sum += val2
+                f.write(f'|{tab}Total Crew|{crew_sum}|{units}|\n')
+                f.write(f'|{tab}{tab}Flight Crew|{val1}|{units1}|\n')
+                f.write(f'|{tab}{tab}Cabin Crew|{val2}|{units2}|\n')
 
+            # passenger service reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.CrewPayload.PASSENGER_SERVICE_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Passenger Service|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Passenger Service|{val}|{units}|\n')
 
+            # cargo container reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.CrewPayload.CARGO_CONTAINER_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Cargo Containers|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Cargo Containers|{val}|{units}|\n')
 
+            # unusable fuel mass reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.Fuel.UNUSABLE_FUEL_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Unusable Fuel|{val}|{units}|\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Unusable Fuel|{val}|{units}|\n')
 
+            # engine oil reporting optional
             val, units = find_variable_in_problem(
                 Aircraft.Propulsion.TOTAL_ENGINE_OIL_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Oil|{val}|{units}|\n')
-            f.write('||||\n')
+            if val != 'Not Found in Model':
+                f.write(f'|{tab}Oil|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(Mission.OPERATING_MASS, prob, self.meta_data)
             f.write(f'|**Operating Mass**|**{val}**|**{units}**|\n')
             f.write('||||\n')
 
+            # PAYLOAD MASS GROUP #
             val, units = find_variable_in_problem(
                 Aircraft.CrewPayload.TOTAL_PAYLOAD_MASS, prob, self.meta_data
             )
@@ -320,17 +371,34 @@ class CoreMassBuilder(MassBuilder):
             val, units = find_variable_in_problem(
                 Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS, prob, self.meta_data
             )
-            f.write(f'|{tab}Passengers|{val}|{units}|\n')
+            f.write(f'|{tab}Passengers and Baggage|{val}|{units}|\n')
 
             val, units = find_variable_in_problem(
                 Aircraft.CrewPayload.CARGO_MASS, prob, self.meta_data
             )
             f.write(f'|{tab}Cargo|{val}|{units}|\n')
-            f.write('||||\n')
 
             val, units = find_variable_in_problem(Mission.ZERO_FUEL_MASS, prob, self.meta_data)
             f.write(f'|**Zero Fuel Mass**|**{val}**|**{units}**|\n')
             f.write('||||\n')
+
+            # FUEL GROUP #
+            val1, units1 = find_variable_in_problem(Mission.FUEL, prob, self.meta_data)
+            val2, units2 = find_variable_in_problem(Mission.RESERVE_FUEL, prob, self.meta_data)
+            if val1 != 'Not Found in Model' or val2 != 'Not Found in Model':
+                fuel_sum = 0
+                units = units1
+                if not isinstance(val1, str):
+                    fuel_sum += val1
+                if not isinstance(val2, str):
+                    # need to make sure summing masses of the same units
+                    if units1 != units2:
+                        fuel_sum += convert_units(val2, units2, units1)
+                    else:
+                        fuel_sum += val2
+                f.write(f'|Total Fuel|{fuel_sum}|{units}|\n')
+                f.write(f'|{tab}Mission Fuel|{val1}|{units1}|\n')
+                f.write(f'|{tab}Reserve Fuel|{val2}|{units2}|\n')
 
             val, units = find_variable_in_problem(Mission.GROSS_MASS, prob, self.meta_data)
             f.write(f'|**Gross Mass**|**{val}**|**{units}**|\n')

--- a/aviary/subsystems/mass/mass_builder.py
+++ b/aviary/subsystems/mass/mass_builder.py
@@ -162,8 +162,8 @@ class CoreMassBuilder(MassBuilder):
                 f.write(f'|{tab}Nose Gear|{val}|{units}|\n')
 
             # OTHER STRUCTURES (NOT IN GROUP) #
-            f.write('|Nacelles|||\n')
             val, units = find_variable_in_problem(Aircraft.Nacelle.MASS, prob, self.meta_data)
+            f.write(f'|Nacelles|{np.dot(val, num_engines)[0]}||\n')
             for i, engine in enumerate(engine_models):
                 if isinstance(val, (np.ndarray, list, tuple)):
                     val = val[i]

--- a/aviary/validation_cases/validation_data/test_data/large_single_aisle_1_FLOPS_data.py
+++ b/aviary/validation_cases/validation_data/test_data/large_single_aisle_1_FLOPS_data.py
@@ -321,7 +321,7 @@ outputs.set_val(Aircraft.LandingGear.TOTAL_MASS, 8780.91, 'lbm')
 
 outputs.set_val(Aircraft.Nacelle.CHARACTERISTIC_LENGTH, np.array([12.30]), 'ft')
 outputs.set_val(Aircraft.Nacelle.FINENESS, np.array([1.5491]))
-outputs.set_val(Aircraft.Nacelle.MASS, 1971.4, 'lbm')
+outputs.set_val(Aircraft.Nacelle.MASS, 985.691, 'lbm')
 
 nacelle_wetted_area = np.array([273.45])
 nacelle_wetted_area_units = 'ft**2'

--- a/aviary/validation_cases/validation_data/test_data/large_single_aisle_2_FLOPS_data.py
+++ b/aviary/validation_cases/validation_data/test_data/large_single_aisle_2_FLOPS_data.py
@@ -323,7 +323,7 @@ outputs.set_val(Aircraft.LandingGear.TOTAL_MASS, 7148.277290864326, 'lbm')
 outputs.set_val(Aircraft.Nacelle.CHARACTERISTIC_LENGTH, np.array([11.65]), 'ft')
 outputs.set_val(Aircraft.Nacelle.FINENESS, np.array([1.6643]))
 outputs.set_val(Aircraft.Nacelle.TOTAL_WETTED_AREA, 2 * 228.34, 'ft**2')
-outputs.set_val(Aircraft.Nacelle.MASS, 1612.2, 'lbm')
+outputs.set_val(Aircraft.Nacelle.MASS, 806.0988, 'lbm')
 outputs.set_val(Aircraft.Nacelle.WETTED_AREA, np.array([228.34]), 'ft**2')
 
 outputs.set_val(Aircraft.Paint.MASS, 582.3, 'lbm')

--- a/aviary/validation_cases/validation_data/test_data/large_single_aisle_2_altwt_FLOPS_data.py
+++ b/aviary/validation_cases/validation_data/test_data/large_single_aisle_2_altwt_FLOPS_data.py
@@ -336,7 +336,7 @@ outputs.set_val(Aircraft.LandingGear.TOTAL_MASS, 5778, 'lbm')
 outputs.set_val(Aircraft.Nacelle.CHARACTERISTIC_LENGTH, 11.65, 'ft')
 outputs.set_val(Aircraft.Nacelle.FINENESS, 1.6643)
 outputs.set_val(Aircraft.Nacelle.TOTAL_WETTED_AREA, 2 * 228.34, 'ft**2')
-outputs.set_val(Aircraft.Nacelle.MASS, 1612.2, 'lbm')
+outputs.set_val(Aircraft.Nacelle.MASS, 806.0988, 'lbm')
 outputs.set_val(Aircraft.Nacelle.WETTED_AREA, 228.34, 'ft**2')
 
 outputs.set_val(Aircraft.Paint.MASS, 582.3, 'lbm')

--- a/aviary/validation_cases/validation_data/test_data/large_single_aisle_2_detailwing_FLOPS_data.py
+++ b/aviary/validation_cases/validation_data/test_data/large_single_aisle_2_detailwing_FLOPS_data.py
@@ -319,7 +319,7 @@ outputs.set_val(Aircraft.LandingGear.TOTAL_MASS, 7148.277290864326, 'lbm')
 
 outputs.set_val(Aircraft.Nacelle.CHARACTERISTIC_LENGTH, np.array([11.65]), 'ft')
 outputs.set_val(Aircraft.Nacelle.FINENESS, np.array([1.6643]))
-outputs.set_val(Aircraft.Nacelle.MASS, 1612.2, 'lbm')
+outputs.set_val(Aircraft.Nacelle.MASS, 806.0988, 'lbm')
 nacelle_wetted_area = np.array([228.34])
 nacelle_wetted_area_units = 'ft**2'
 outputs.set_val(Aircraft.Nacelle.WETTED_AREA, nacelle_wetted_area, nacelle_wetted_area_units)

--- a/aviary/variable_info/variable_meta_data.py
+++ b/aviary/variable_info/variable_meta_data.py
@@ -4342,7 +4342,7 @@ add_meta_data(
         'FLOPS': None,
     },
     units='lbm',
-    desc='estimated mass of the nacelles for each engine model',
+    desc='estimated mass of a single nacelle for each engine model',
     default_value=0.0,
     multivalue=True,
 )

--- a/aviary/variable_info/variable_meta_data.py
+++ b/aviary/variable_info/variable_meta_data.py
@@ -973,7 +973,8 @@ add_meta_data(
     meta_data=_MetaData,
     historical_name={'GASP': 'INGASP.CW(14)', 'FLOPS': None},
     units='lbm',
-    desc='unit mass of ULD (unit load device) for cargo handling per passenger',
+    desc='unit mass of ULD (unit load device) for cargo handling per passenger. Used to calculate'
+    'Aicraft.CrewPayload.CARGO_CONTAINER_MASS',
     default_value=0.0,
     types=float,
     option=True,
@@ -1064,7 +1065,8 @@ add_meta_data(
         'FLOPS': 'WTIN.NPF',  # ['&DEFINE.WTIN.NPF', 'WTS.NPF'],
     },
     units='unitless',
-    desc='number of first class passengers that the aircraft is designed to accommodate. In GASP, the input is the percentage of total number of passengers.',
+    desc='number of first class passengers that the aircraft is designed to accommodate. In GASP, '
+    'the input is the percentage of total number of passengers.',
     types=int,
     option=True,
     default_value=0,
@@ -1183,6 +1185,7 @@ add_meta_data(
     default_value=0.0,
 )
 
+# TODO this should be removed from metadata (intermediate calculation)
 add_meta_data(
     Aircraft.Design.CHARACTERISTIC_LENGTHS,
     meta_data=_MetaData,

--- a/aviary/variable_info/variables.py
+++ b/aviary/variable_info/variables.py
@@ -124,8 +124,7 @@ class Aircraft:
             SEAT_PITCH_FIRST = 'aircraft:crew_and_payload:design:seat_pitch_first'
 
     class Design:
-        # These variables are values that do not fall into a particular aircraft
-        # component.
+        # These variables are values that do not fall into a particular aircraft component.
         BASE_AREA = 'aircraft:design:base_area'
         CG_DELTA = 'aircraft:design:cg_delta'
         CHARACTERISTIC_LENGTHS = 'aircraft:design:characteristic_lengths'


### PR DESCRIPTION
### Summary

Updates the mass report with some requested changes, as well as fixes the nacelle mass equation - it now properly contains mass per individual nacelle for each engine type instead of the sum of all nacelle masses. This now matches how all other nacelle variables work.

### Related Issues

- Resolves #1131

### Backwards incompatibilities

Nacelle mass is now reported differently (per single nacelle instead of per nacelle set). This doesn't change any calculations or results but will now show different values if users were previously tracking this variable

### New Dependencies

None