### PR TITLE
Use built-in dymos methods for setting states/controls/time

### DIFF
--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -1579,7 +1579,7 @@ class AviaryGroup(om.Group):
             for key, val_dict in initial_guesses.items():
                 # Process the guess variable (handles array interpolation)
                 val = process_guess_var(val_dict['val'], key, phase)
-                units=val_dict.get('units', None)
+                units = val_dict.get('units', None)
 
                 # Identify the type of the guess (state or control)
                 var_type = val_dict['type']

--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -1499,6 +1499,7 @@ class AviaryGroup(om.Group):
         # any mission that does not have any dymos phases, there is nothing to set.
         if not hasattr(self, 'traj'):
             return
+
         # `self.verbosity` is "true" verbosity for entire run. `verbosity` is verbosity
         # override for just this method
         if verbosity is not None:
@@ -1511,7 +1512,7 @@ class AviaryGroup(om.Group):
         if parent_prob is not None and parent_prefix != '':
             target_prob = parent_prob
 
-        traj = self.traj
+        traj = target_prob.traj
 
         # Determine which phases to loop over, fetching them from the trajectory
         phase_items = traj._phases.items()
@@ -1519,12 +1520,6 @@ class AviaryGroup(om.Group):
         # Loop over each phase and set initial guesses for the state and control
         # variables
         for idx, (phase_name, phase) in enumerate(phase_items):
-            # TODO: This will be uncommented when an openmdao bug is fixed.
-            # We are using a workaround for now.
-            # if not phase._is_local:
-            #     # Don't set anything if phase is not on this proc.
-            #     continue
-
             if self.mission_method is SOLVED_2DOF:
                 self.phase_objects[idx].apply_initial_guesses(self, 'traj', phase)
 
@@ -1539,14 +1534,14 @@ class AviaryGroup(om.Group):
                 guesses = {}
 
             # Add subsystem guesses
-            self._add_subsystem_guesses(phase_name, phase, target_prob, parent_prefix)
+            self._add_subsystem_guesses(phase_name, phase)
 
             # Set initial guesses for states, controls and time for each phase.
             self.configurator.set_phase_initial_guesses(
                 self, phase_name, phase, guesses, target_prob, parent_prefix
             )
 
-    def _add_subsystem_guesses(self, phase_name, phase, target_prob, parent_prefix):
+    def _add_subsystem_guesses(self, phase_name, phase):
         """
         Adds the initial guesses for each subsystem of a given phase to the problem. This method
         first fetches all subsystems associated with the given phase. It then loops over each
@@ -1582,23 +1577,17 @@ class AviaryGroup(om.Group):
 
             # Loop over each guess
             for key, val_dict in initial_guesses.items():
+                # Process the guess variable (handles array interpolation)
+                val = process_guess_var(val_dict['val'], key, phase)
+                units=val_dict.get('units', None)
+
                 # Identify the type of the guess (state or control)
                 var_type = val_dict['type']
                 if 'state' in var_type:
-                    path_string = 'states'
+                    phase.set_state_val(key, vals=val, units=units)
+
                 elif 'control' in var_type:
-                    path_string = 'controls'
-
-                # Process the guess variable (handles array interpolation)
-                # val['val'] = self.process_guess_var(val['val'], key, phase)
-                val = process_guess_var(val_dict['val'], key, phase)
-
-                # Set the initial guess in the problem
-                target_prob.set_val(
-                    parent_prefix + f'traj.{phase_name}.{path_string}:{key}',
-                    val,
-                    units=val_dict.get('units', None),
-                )
+                    phase.set_control_val(key, vals=val, units=units)
 
     def add_fuel_reserve_component(
         self, post_mission=True, reserves_name=Mission.TOTAL_RESERVE_FUEL

--- a/aviary/core/aviary_problem.py
+++ b/aviary/core/aviary_problem.py
@@ -1247,7 +1247,7 @@ class AviaryProblem(om.Problem):
 
         Parameters
         ----------
-        parent_prob : AviaryGroup optional
+        parent_prob : AviaryGroup, optional
             If provided along with ``parent_prefix``, initial guesses are set on this parent problem
             instead of ``self``. Used internally for nested problem setups.
         parent_prefix : str, optional

--- a/aviary/core/aviary_problem.py
+++ b/aviary/core/aviary_problem.py
@@ -1247,7 +1247,7 @@ class AviaryProblem(om.Problem):
 
         Parameters
         ----------
-        parent_prob : om.Problem, optional
+        parent_prob : AviaryGroup optional
             If provided along with ``parent_prefix``, initial guesses are set on this parent problem
             instead of ``self``. Used internally for nested problem setups.
         parent_prefix : str, optional

--- a/aviary/mission/solved_two_dof_problem_configurator.py
+++ b/aviary/mission/solved_two_dof_problem_configurator.py
@@ -337,25 +337,8 @@ class SolvedTwoDOFProblemConfigurator(ProblemConfiguratorBase):
 
             # Set initial guess for control variables
             if guess_key in control_keys:
-                try:
-                    target_prob.set_val(
-                        parent_prefix + f'traj.{phase_name}.controls:{guess_key}',
-                        process_guess_var(val, guess_key, phase),
-                        units=units,
-                    )
-
-                except KeyError:
-                    try:
-                        target_prob.set_val(
-                            parent_prefix + f'traj.{phase_name}.polynomial_controls:{guess_key}',
-                            process_guess_var(val, guess_key, phase),
-                            units=units,
-                        )
-
-                    except KeyError:
-                        target_prob.set_val(
-                            parent_prefix + f'traj.{phase_name}.bspline_controls:',
-                            {guess_key},
-                            process_guess_var(val, guess_key, phase),
-                            units=units,
-                        )
+                phase.set_control_val(
+                    guess_key,
+                    vals=process_guess_var(val, guess_key, phase),
+                    units=units,
+                )

--- a/aviary/mission/two_dof_problem_configurator.py
+++ b/aviary/mission/two_dof_problem_configurator.py
@@ -701,10 +701,6 @@ class TwoDOFProblemConfigurator(ProblemConfiguratorBase):
             # Breguet phase should have nothing else to set.
             return
 
-        # Set initial guesses for the rotation mass and flight duration
-        rotation_mass = aviary_group.initialization_guesses['rotation_mass']
-        flight_duration = aviary_group.initialization_guesses['flight_duration']
-
         control_keys = ['velocity_rate', 'throttle']
         state_keys = [
             'altitude',
@@ -728,47 +724,25 @@ class TwoDOFProblemConfigurator(ProblemConfiguratorBase):
             if 'time' == guess_key:
                 if phase_name == 'ascent':
                     # These variables are promoted to the top.
-                    init_path = Mission.Takeoff.ASCENT_T_INITIAL
-                    dura_path = Mission.Takeoff.ASCENT_DURATION
+                    target_prob.set_val(Mission.Takeoff.ASCENT_T_INITIAL, val[0], units=units)
+                    target_prob.set_val(Mission.Takeoff.ASCENT_DURATION, val[1], units=units)
                 else:
-                    init_path = parent_prefix + f'traj.{phase_name}.t_initial'
-                    dura_path = parent_prefix + f'traj.{phase_name}.t_duration'
-
-                target_prob.set_val(init_path, val[0], units=units)
-                target_prob.set_val(dura_path, val[1], units=units)
+                    phase.set_time_val(initial=val[0], duration=val[1], units=units)
 
             else:
                 # Set initial guess for control variables
                 if guess_key in control_keys:
-                    try:
-                        target_prob.set_val(
-                            parent_prefix + f'traj.{phase_name}.controls:{guess_key}',
-                            process_guess_var(val, guess_key, phase),
-                            units=units,
-                        )
-
-                    except KeyError:
-                        try:
-                            target_prob.set_val(
-                                parent_prefix
-                                + f'traj.{phase_name}.polynomial_controls:{guess_key}',
-                                process_guess_var(val, guess_key, phase),
-                                units=units,
-                            )
-
-                        except KeyError:
-                            target_prob.set_val(
-                                parent_prefix + f'traj.{phase_name}.bspline_controls:',
-                                {guess_key},
-                                process_guess_var(val, guess_key, phase),
-                                units=units,
-                            )
+                    phase.set_control_val(
+                        guess_key,
+                        vals=process_guess_var(val, guess_key, phase),
+                        units=units,
+                    )
 
                 # Set initial guess for state variables
                 elif guess_key in state_keys:
-                    target_prob.set_val(
-                        parent_prefix + f'traj.{phase_name}.states:{guess_key}',
-                        process_guess_var(val, guess_key, phase),
+                    phase.set_state_val(
+                        guess_key,
+                        vals=process_guess_var(val, guess_key, phase),
                         units=units,
                     )
 
@@ -791,12 +765,9 @@ class TwoDOFProblemConfigurator(ProblemConfiguratorBase):
         # initial guesses using some knowledge of the mission duration and other variables
         # that are only available after calling `create_vehicle`. Thus these initial guess
         # values are not included in the `phase_info` object.
-        base_phase = phase_name.removeprefix('reserve_')
-
         if 'mass' not in guesses:
-            mass_guess = rotation_mass
+            # Set initial guesses for the rotation mass and flight duration
+            rotation_mass = aviary_group.initialization_guesses['rotation_mass']
 
             # Set the mass guess as the initial value for the mass state variable
-            target_prob.set_val(
-                parent_prefix + f'traj.{phase_name}.states:mass', mass_guess, units='lbm'
-            )
+            phase.set_state_val('mass', rotation_mass, units='lbm')


### PR DESCRIPTION
### Summary

Dymos has some built-in methods for setting states, controls, and time. These methods need to be used instead of prob.set_val to assure proper behavior  in some upcoming dymos refactors.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None