### PR TITLE
Fixed pre-made objectives to correctly minimize targets

### DIFF
--- a/aviary/core/aviary_problem.py
+++ b/aviary/core/aviary_problem.py
@@ -767,8 +767,8 @@ class AviaryProblem(om.Problem):
 
         # Dictionary for default reference values
         default_ref_values = {
-            'mass': -5e4,
-            'hybrid_objective': -5e4,
+            'mass': 5e4,
+            'hybrid_objective': 5e4,
             'fuel_burned': 1e4,
             'fuel': 1e4,
         }
@@ -2019,7 +2019,7 @@ class AviaryProblem(om.Problem):
         takeoff_mass = self.model.aviary_inputs.get_val(Aircraft.Design.GROSS_MASS, units='lbm')
 
         obj_comp = om.ExecComp(
-            f'obj = -final_mass / {takeoff_mass} + final_time / 5.',
+            f'obj = final_mass / {takeoff_mass} + final_time / 5.',
             final_mass={'units': 'lbm'},
             final_time={'units': 'h'},
         )


### PR DESCRIPTION
### Summary

Changed default refs for mass & hybrid objective to positive values. Previously both had negative components. Mass objective now properly minimized mass - improvements in results were seen in external battery subsystem example problem, where gross mass successfully reached a lower value and mission profile was significantly improved, better resembling a typical and expected trajectory. Hybrid objective previously minimized mass and maximized final mission time - objective was changed to minimize both of these objectives.

### Related Issues

- Resolves #899

### Backwards incompatibilities

Users using the "mass" or "hybrid_objective" pre-made objective setups will now get different results

### New Dependencies

None