### PR TITLE
Fixed problem preventing external subsystem tests from running

### DIFF
--- a/aviary/models/external_subsystems/detailed_battery/test/test_battery_builder.py
+++ b/aviary/models/external_subsystems/detailed_battery/test/test_battery_builder.py
@@ -3,7 +3,9 @@ import unittest
 import aviary.api as av
 from aviary.subsystems.test.subsystem_tester import skipIfMissingDependencies
 
-BatteryBuilder = av.TestSubsystemBuilder.import_builder('battery.battery_builder.BatteryBuilder')
+BatteryBuilder = av.TestSubsystemBuilder.import_builder(
+    'detailed_battery.detailed_battery_builder.DetailedBatteryBuilder'
+)
 
 
 @skipIfMissingDependencies(BatteryBuilder)

--- a/aviary/models/external_subsystems/open_aero_struct/test/test_OAS_wing_mass_builder.py
+++ b/aviary/models/external_subsystems/open_aero_struct/test/test_OAS_wing_mass_builder.py
@@ -4,7 +4,7 @@ import unittest
 import aviary.api as av
 from aviary.subsystems.test.subsystem_tester import skipIfMissingDependencies
 
-path_to_builder = 'OAS_weight.OAS_wing_weight_builder.OASWingWeightBuilder'
+path_to_builder = 'open_aero_struct.OAS_wing_mass_builder.OASWingMassBuilder'
 OASWingWeightBuilder = av.TestSubsystemBuilder.import_builder(path_to_builder)
 
 

--- a/aviary/subsystems/test/subsystem_tester.py
+++ b/aviary/subsystems/test/subsystem_tester.py
@@ -16,24 +16,35 @@ def skipIfMissingDependencies(builder):
 
 class TestSubsystemBuilder(unittest.TestCase):
     @staticmethod
-    def import_builder(path_to_builder: str, base_package='aviary.models.external_subsystems'):
+    def import_builder(path_to_builder: str):
         """
-        Import a subsystem builder.
+        Import a subsystem builder class. If the path can not be found, the "base path"
+        `aviary.models.external_subsystems` is prepended to the provided `path_to_builder`.
 
-        This is intended to be used with skipIfMissingDependencies
+        Intended for use with `skipIfMissingDependencies`.
+
+        Parameters
+        ----------
+        path_to_builder : str
+            Path to the builder class.
+
+        Returns
+        -------
+        type or str
+            The builder class, or an error string for `skipIfMissingDependencies`.
         """
+        base_path = 'aviary.models.external_subsystems'
+        module_path, class_name = path_to_builder.rsplit('.', 1)
         try:
-            package, method = path_to_builder.rsplit('.', 1)
-            package_path, package_name = package.rsplit('.', 1)
-            module_path = (
-                '.'.join([path_to_builder, package_path]) if package_path else path_to_builder
-            )
-            module = import_module(package_name, module_path)
-            builder = getattr(module, method)
+            try:
+                module = import_module(module_path)
+            except ModuleNotFoundError:
+                module = import_module(base_path + '.' + module_path)
+            builder = getattr(module, class_name)
         except ImportError:
             builder = 'Skipping due to missing dependencies'
         except AttributeError:
-            builder = method + ' could not be imported from ' + base_package + '.' + package
+            builder = class_name + ' could not be imported from ' + module_path
         return builder
 
     def setUp(self):


### PR DESCRIPTION
### Summary

Updated SubsystemBuilderTest to properly resolve module path, allowing the external subsystem tests using it to actually run (previously when the import failed the test was automatically skipped)

Claude Opus 4.6 was used to help explain the usage of import_module() and update the docstring