### PR TITLE
Move some of TODOs to issue database from source code

### DIFF
--- a/aviary/docs/examples/external_subsystems.ipynb
+++ b/aviary/docs/examples/external_subsystems.ipynb
@@ -225,7 +225,7 @@
    },
    "outputs": [],
    "source": [
-    "from aviary.interface.utils import round_it\n",
+    "from aviary.utils.utils import round_it\n",
     "\n",
     "print(f'Tail mass: {round_it(tail_mass, 6)} lbm')\n",
     "print(f'Wing mass scaler: {round_it(mass_scaler, 3)}')\n",

--- a/aviary/interface/reports.py
+++ b/aviary/interface/reports.py
@@ -162,7 +162,7 @@ def subsystem_report(prob: AviaryProblem):
 
     multi_mission = prob.problem_type is ProblemType.MULTI_MISSION
     if multi_mission:
-        # TODO: We need to rewrite the reports to support multimission. This may require
+        # See issue #1186. We need to rewrite the reports to support multimission. This may require
         # standardizing how all attributes work in AviaryProblem (things like prob.model.get_val
         # don't work with multi-mission but does for normal problems). End goal is to loop through
         # each mission and get reports for each mission. Show in dashboard in nested tabs (new
@@ -172,7 +172,7 @@ def subsystem_report(prob: AviaryProblem):
     else:
         model = prob.model
 
-    subsystems = model.subsystems  # TODO: redo for multimissions
+    subsystems = model.subsystems  # See issue #1186. redo for multimissions
 
     for subsystem in subsystems:
         subsystem.report(prob, reports_folder)
@@ -242,7 +242,7 @@ def mission_report(prob: AviaryProblem, **kwargs):
     for name, model in models.items():
         # read per-phase data from trajectory
         data = {}
-        for idx, phase in enumerate(model.mission_info):  # TODO: redo for multimissions
+        for idx, phase in enumerate(model.mission_info):  # See issue #1186. redo for multimissions
             # TODO for traj in trajectories, currently assuming single one named "traj"
             # TODO delta mass and fuel consumption need to be tracked separately
             fuel_burn = _get_phase_diff(model, 'traj', phase, 'mass', 'lbm', [-1, 0])
@@ -497,7 +497,7 @@ def timeseries_csv(prob: AviaryProblem, **kwargs):
     multi_mission = prob.problem_type == ProblemType.MULTI_MISSION
     if multi_mission:
         for _, model in prob.aviary_groups_dict.items():
-            # TODO: We need to rewrite this report to support multimission
+            # See issue #1186. We need to rewrite this report to support multimission
             # For now, just write the first mission's csv file.
             break
     else:

--- a/aviary/interface/test/test_interface_bugs.py
+++ b/aviary/interface/test/test_interface_bugs.py
@@ -123,7 +123,7 @@ class PreMissionGroupTest(unittest.TestCase):
 
         assert not isinstance(
             prob.model.traj.phases, om.ParallelGroup
-        )  # TODO: redo for multimissions
+        )  # See issue #1186. redo for multimissions
 
 
 if __name__ == '__main__':

--- a/aviary/interface/utils.py
+++ b/aviary/interface/utils.py
@@ -1,53 +1,14 @@
 import warnings
-from math import floor, log10
 
 import numpy as np
 import openmdao.api as om
 
 from aviary.variable_info.enums import Verbosity
+from aviary.utils.utils import round_it
 
 # TODO openMDAO has generate_table() that might be able to replace this
 
-# TODO rounding might have other use cases, move to utils if so
-# It is confirmed that both functions are used else where.
-
-
-def round_it(x, sig=None):
-    """
-    Round a float to a specified significance.
-    If the number is equal to zero, "0" will be returned, regardless of the number of significant digits specified
-    If the number is NaN, directly returns it (stays NaN).
-
-    Parameters
-    ----------
-    x : str or float
-        the float that needs to be rounded.
-    sig : int
-        the number of significant digits to include (If this is unspecified, the number will be rounded to two decimal places).
-
-    Returns
-    -------
-        The rounded number, or provided string if not convertible to float, or original
-        number if it is NaN
-    """
-    # default sig figs to 2 decimal places out
-    if isinstance(x, str):
-        try:
-            x = float(x)
-        except ValueError:
-            return x
-
-    if np.isnan(x):
-        # return NaNs directly back to markdown report
-        return x
-
-    if not sig:
-        sig = len(str(round(x))) + 2
-
-    if x != 0:
-        return round(x, sig - int(floor(log10(abs(x)))) - 1)
-    else:
-        return 0
+# It is confirmed that all three functions are used else where.
 
 
 def write_markdown_variable_table(open_file, problem, outputs, metadata):

--- a/aviary/subsystems/geometry/flops_based/characteristic_lengths.py
+++ b/aviary/subsystems/geometry/flops_based/characteristic_lengths.py
@@ -230,7 +230,7 @@ class FuselageCharacteristicLengths(om.ExplicitComponent):
 
         J[Aircraft.Fuselage.FINENESS, Aircraft.Fuselage.REF_DIAMETER] = -length / avg_diam**2.0
 
-    # NOTE this code is currently unused!!
+    # See issue #1182. NOTE this code is currently unused!!
     def _compute_additional_fuselages(
         self, inputs, outputs, discrete_inputs=None, discrete_outputs=None
     ):
@@ -261,7 +261,7 @@ class FuselageCharacteristicLengths(om.ExplicitComponent):
 
             idx += 1
 
-    # NOTE this code is currently unused!!
+    # See issue #1182. NOTE this code is currently unused!!
     def _compute_additional_vertical_tails(
         self, inputs, outputs, discrete_inputs=None, discrete_outputs=None
     ):

--- a/aviary/subsystems/geometry/flops_based/landing_gear.py
+++ b/aviary/subsystems/geometry/flops_based/landing_gear.py
@@ -38,7 +38,7 @@ class MainGearLength(om.ExplicitComponent):
     """
     Computation of main gear length.
 
-    TODO does not support more than two wing engines, or more than one engine model
+    See issue #1183 does not support more than two wing engines, or more than one engine model
     """
 
     def initialize(self):
@@ -76,10 +76,10 @@ class MainGearLength(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         num_eng = self.options[Aircraft.Engine.NUM_ENGINES][0]
 
-        # TODO temp using first engine, heterogeneous engines not supported
+        # See issue #1183. temp using first engine, heterogeneous engines not supported
         num_wing_eng = self.options[Aircraft.Engine.NUM_WING_ENGINES][0]
 
-        # TODO: high engine-count configuration.
+        # See issue #1183. high engine-count configuration.
         y_eng_aft = 0
 
         if num_wing_eng > 0:
@@ -114,7 +114,7 @@ class MainGearLength(om.ExplicitComponent):
         outputs[Aircraft.LandingGear.MAIN_GEAR_OLEO_LENGTH] = cmlg
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
-        # TODO temp using first engine, heterogeneous engines not supported
+        # See issue #1183. temp using first engine, heterogeneous engines not supported
         num_eng = self.options[Aircraft.Engine.NUM_ENGINES][0]
         num_wing_eng = self.options[Aircraft.Engine.NUM_WING_ENGINES][0]
 

--- a/aviary/subsystems/mass/flops_based/crew.py
+++ b/aviary/subsystems/mass/flops_based/crew.py
@@ -101,7 +101,7 @@ class FlightCrewMass(om.ExplicitComponent):
         Return the mass, in pounds, of one member of the flight crew and
         their baggage.
         """
-        # TODO this should be its own variable
+        # See issue #1190. This should be its own variable
         mass_per_flight_crew = 225.0  # lbm
 
         return mass_per_flight_crew

--- a/aviary/subsystems/mass/flops_based/unusable_fuel.py
+++ b/aviary/subsystems/mass/flops_based/unusable_fuel.py
@@ -63,7 +63,7 @@ class TransportUnusableFuelMass(om.ExplicitComponent):
         thrust_factor = distributed_thrust_factor(max_sls_thrust, num_eng)
         wing_area = inputs[Aircraft.Wing.AREA]
 
-        # TODO: check if this is really a volume
+        # This is a volume: lbm / (lbm/galUS)
         # outputs[Aircraft.Fuel.TOTAL_VOLUME] = total_capacity / density_ratio
 
         outputs[Aircraft.Fuel.UNUSABLE_FUEL_MASS] = (

--- a/aviary/subsystems/mass/flops_based/wing_detailed.py
+++ b/aviary/subsystems/mass/flops_based/wing_detailed.py
@@ -113,7 +113,7 @@ class DetailedWingBendingFact(om.ExplicitComponent):
         add_aviary_output(self, Aircraft.Wing.ENG_POD_INERTIA_FACTOR, units='unitless')
 
     def setup_partials(self):
-        # TODO: Analytic derivs will be challenging, but possible.
+        # See issue #1188. Analytic derivs will be challenging, but possible.
         self.declare_partials('*', '*', method='cs')
 
     def compute(self, inputs, outputs):
@@ -142,7 +142,7 @@ class DetailedWingBendingFact(om.ExplicitComponent):
         # NOTE changes to FLOPS routines based on LEAPS1 improved multiengine effort
         # odd numbers of wing mounted engines assume the "odd" engine out is not on the
         # wing and is ignored
-        # TODO There are also no checks that number of engine locations is consistent with
+        # See issue #1189. There are also no checks that number of engine locations is consistent with
         # half of number of wing mounted engines, which should get added to preprocessor
 
         target_dy = (inp_stations[-1] - inp_stations[0]) / num_integration_stations
@@ -354,7 +354,7 @@ class BWBDetailedWingBendingFact(om.ExplicitComponent):
         self.add_output('calculated_wing_area', units='ft**2')
 
     def setup_partials(self):
-        # TODO: Analytic derivs will be challenging, but possible.
+        # See issue #1188. Analytic derivs will be challenging, but possible.
         self.declare_partials('*', '*', method='cs')
 
     def compute(self, inputs, outputs):
@@ -418,7 +418,7 @@ class BWBDetailedWingBendingFact(om.ExplicitComponent):
         # NOTE changes to FLOPS routines based on LEAPS1 improved multiengine effort
         # odd numbers of wing mounted engines assume the "odd" engine out is not on the
         # wing and is ignored
-        # TODO There are also no checks that number of engine locations is consistent with
+        # See issue #1189. There are also no checks that number of engine locations is consistent with
         # half of number of wing mounted engines, which should get added to preprocessor
 
         target_dy = (inp_stations_mod[-1] - inp_stations_mod[0]) / num_integration_stations

--- a/aviary/subsystems/propulsion/engine_deck.py
+++ b/aviary/subsystems/propulsion/engine_deck.py
@@ -29,7 +29,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.units import convert_units
 
-from aviary.interface.utils import round_it
+from aviary.utils.utils import round_it
 from aviary.subsystems.propulsion.engine_model import EngineModel
 from aviary.subsystems.propulsion.engine_scaling import EngineScaling
 from aviary.subsystems.propulsion.engine_sizing import SizeEngine

--- a/aviary/utils/aero_table_conversion.py
+++ b/aviary/utils/aero_table_conversion.py
@@ -9,11 +9,11 @@ from scipy.interpolate import interp1d
 import numpy as np
 from openmdao.components.interp_util.interp import InterpND
 
-from aviary.interface.utils import round_it
 from aviary.utils.conversion_utils import _parse, _read_map, _rep
 from aviary.utils.csv_data_file import write_data_file
 from aviary.utils.functions import get_path
 from aviary.utils.named_values import NamedValues
+from aviary.utils.utils import round_it
 from aviary.variable_info.enums import CodeOrigin
 
 

--- a/aviary/utils/engine_deck_conversion.py
+++ b/aviary/utils/engine_deck_conversion.py
@@ -7,7 +7,6 @@ import numpy as np
 import openmdao.api as om
 from openmdao.components.interp_util.interp import InterpND
 
-from aviary.interface.utils import round_it
 from aviary.subsystems.atmosphere.atmosphere import Atmosphere
 from aviary.subsystems.propulsion.engine_deck import normalize
 from aviary.subsystems.propulsion.utils import EngineModelVariables, default_units
@@ -15,6 +14,7 @@ from aviary.utils.conversion_utils import _parse, _read_map, _rep
 from aviary.utils.csv_data_file import write_data_file
 from aviary.utils.functions import get_aviary_resource_path, get_path
 from aviary.utils.named_values import NamedValues
+from aviary.utils.utils import round_it
 from aviary.variable_info.enums import EngineDeckType
 from aviary.variable_info.variables import Dynamic
 

--- a/aviary/utils/propeller_map_conversion.py
+++ b/aviary/utils/propeller_map_conversion.py
@@ -7,11 +7,11 @@ from enum import Enum
 
 import numpy as np
 
-from aviary.interface.utils import round_it
-from aviary.utils.named_values import NamedValues
+from aviary.utils.conversion_utils import _parse, _read_map, _rep
 from aviary.utils.csv_data_file import write_data_file
 from aviary.utils.functions import get_path
-from aviary.utils.conversion_utils import _parse, _read_map, _rep
+from aviary.utils.named_values import NamedValues
+from aviary.utils.utils import round_it
 
 
 class PropMapType(Enum):

--- a/aviary/utils/utils.py
+++ b/aviary/utils/utils.py
@@ -5,6 +5,7 @@ Helps to avoid circular imports. These functions do not rely on imports from oth
 
 from copy import deepcopy
 from enum import Enum
+from math import floor, log10
 
 import numpy as np
 from openmdao.utils.units import convert_units
@@ -256,3 +257,41 @@ def cast_type(key, val, meta_data=CoreMetaData):
                     break
 
     return cast_val
+
+
+def round_it(x, sig=None):
+    """
+    Round a float to a specified significance.
+    If the number is equal to zero, "0" will be returned, regardless of the number of significant digits specified
+    If the number is NaN, directly returns it (stays NaN).
+
+    Parameters
+    ----------
+    x : str or float
+        the float that needs to be rounded.
+    sig : int
+        the number of significant digits to include (If this is unspecified, the number will be rounded to two decimal places).
+
+    Returns
+    -------
+        The rounded number, or provided string if not convertible to float, or original
+        number if it is NaN
+    """
+    # default sig figs to 2 decimal places out
+    if isinstance(x, str):
+        try:
+            x = float(x)
+        except ValueError:
+            return x
+
+    if np.isnan(x):
+        # return NaNs directly back to markdown report
+        return x
+
+    if not sig:
+        sig = len(str(round(x))) + 2
+
+    if x != 0:
+        return round(x, sig - int(floor(log10(abs(x)))) - 1)
+    else:
+        return 0

--- a/aviary/variable_info/functions.py
+++ b/aviary/variable_info/functions.py
@@ -354,7 +354,7 @@ def override_aviary_vars(
                 # These variables are ones that are computed in both GASP and FLOPS when both
                 # geometries are present. Aviary determines which one to favor, and which to
                 # remove by overriding it.
-                # TODO: What if user wants to override one of these?
+                # See issue #1176. What if user wants to override one of these?
                 continue
 
             elif name in external_overrides:
@@ -421,7 +421,7 @@ def setup_trajectory_params(
     are being used in the trajectory, and for the variables which are
     not options it adds them as a parameter of the trajectory.
     """
-    # TODO: variables_to_add is required, so should be an arg, not a kwarg.
+    # See note # 1178: variables_to_add is required, so should be an arg, not a kwarg.
     if variables_to_add is None:
         variables_to_add = []
 
@@ -448,7 +448,7 @@ def setup_trajectory_params(
 
     # Process the core mission inputs last, because some of them might have already
     # been covered by the phase builders.
-    # TODO: As we use more builders, we may reach the point where we don't need
+    # See issue #1179: As we use more builders, we may reach the point where we don't need
     # to do these anymore.
     for key in sorted(variables_to_add):
         if key in already_added:
@@ -468,7 +468,7 @@ def setup_trajectory_params(
                 except TypeError:
                     val = aviary_variables.get_val(key)
 
-            # TODO temp line to ignore dynamic mission variables, will not work
+            # See note #1180 temp line to ignore dynamic mission variables, will not work
             #      if names change to 'dynamic:mission:*'
             if ':' not in key:
                 continue
@@ -578,7 +578,7 @@ def setup_model_options(
         prefix = ''  # the original default value
     prob.model_options[f'{prefix}*'] = extract_options(aviary_inputs, meta_data)
 
-    # TODO: Modify this method for multi mission/model.
+    # See issue #1177. Modify this method for multi mission/model
 
     if engine_models is None:
         # Required in multi-mission cases
@@ -596,7 +596,7 @@ def setup_model_options(
     for idx, engine_model in enumerate(engine_models):
         eng_name = engine_model.name
 
-        # TODO: For future flexibility, need get a list of options per engine (these are
+        # See issue #1175. For future flexibility, need get a list of options per engine (these are
         # EngineDeck required options), so custom multiengine works
         opt_names = [
             Aircraft.Engine.Motor.DATA_FILE,

--- a/aviary/variable_info/test/test_var_structure.py
+++ b/aviary/variable_info/test/test_var_structure.py
@@ -32,7 +32,7 @@ class MetaDataTest(unittest.TestCase):
         assert_no_duplicates(flops_names)
 
     def test_alphabetization(self):
-        # TODO currently excluding Dynamic variables that do not have proper full
+        # See issue #1181. currently excluding Dynamic variables that do not have proper full
         #      names mirroring the hierarchy
         metadata_var_names = [key for key in CoreMetaData if ':' in key]
 
@@ -175,7 +175,7 @@ class VariableStructureTest(unittest.TestCase):
         # Note: Dynamic variables don't have the full path prefix, they're just the variable name
         # Pass empty hierarchy_name to indicate no prefix should be used
 
-        # TODO: Should dynamic variables be updated to match hierarchy names?
+        # See issue #1181. Should dynamic variables be updated to match hierarchy names?
         # dynamic_mismatches = check_hierarchy(Dynamic, '', '', 'Dynamic')
         # all_mismatches.extend(dynamic_mismatches)
 

--- a/aviary/variable_info/variable_meta_data.py
+++ b/aviary/variable_info/variable_meta_data.py
@@ -1185,7 +1185,7 @@ add_meta_data(
     default_value=0.0,
 )
 
-# TODO this should be removed from metadata (intermediate calculation)
+# See issue #1182. this should be removed from metadata (intermediate calculation)
 add_meta_data(
     Aircraft.Design.CHARACTERISTIC_LENGTHS,
     meta_data=_MetaData,

--- a/aviary/variable_info/variables.py
+++ b/aviary/variable_info/variables.py
@@ -612,11 +612,11 @@ class Dynamic:
         typically used by the Equations of Motion to determine vehicle states at each timestep.
         """
 
-        # TODO Vehicle summary forces, torques, etc. in X,Y,Z axes should also go here
+        # See issue #1173. Vehicle summary forces, torques, etc. in X,Y,Z axes should also go here
         ALTITUDE = 'altitude'
         ALTITUDE_RATE = 'altitude_rate'
         ALTITUDE_RATE_MAX = 'altitude_rate_max'
-        # TODO Angle of Attack
+        # See issue #1173. Angle of Attack
         DISTANCE = 'distance'
         DISTANCE_RATE = 'distance_rate'
         FLIGHT_PATH_ANGLE = 'flight_path_angle'

--- a/aviary/visualization/dashboard.py
+++ b/aviary/visualization/dashboard.py
@@ -1025,7 +1025,7 @@ def dashboard(script_name, port=0, run_in_background=False):
     if not os.path.isfile(problem_recorder_path):
         issue_warning(f'Problem case recorder file {problem_recorder_path} does not exist.')
 
-    # TODO - use lists and functions to do this with a lot less code
+    # See issue #1174. Use lists and functions to do this with a lot less code
     ####### Model Tab #######
     model_tabs_list = []
 


### PR DESCRIPTION
### Summary

I was trying to move many TODO comments in the source code to issue database but it turned out to be difficult. So, this is only a small part of the effort.

I did it in two steps:

1. Create a new issue and copy the TODO comment to it.
2. Write the issue number back to the original location (as a pointer to the issue database).

I also moved `round_it()` function definition from `interface/utils.py` to `utils/utils.py` because it is used in multiple files. Note that all three other functions defined in `interface/utils.py` are used elsewhere. So, I think all of them should be moved to `utils/utils.py`.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None