### PR TITLE
Fix image width not rendering in external_subsystems docs

### DIFF
--- a/aviary/docs/examples/external_subsystems.ipynb
+++ b/aviary/docs/examples/external_subsystems.ipynb
@@ -236,21 +236,7 @@
    "cell_type": "markdown",
    "id": "4e9d5407",
    "metadata": {},
-   "source": [
-    "We can see that the values for {glue:md}`Aircraft.Wing.MASS` is indeed equal to the equation defined by our external subsystem: 5 * {glue:md}`Aircraft.HorizontalTail.MASS` * {glue:md}`Aircraft.Wing.MASS_SCALER` when checked by hand.\n",
-    "\n",
-    "Next let's look at the N<sup>2</sup> diagram and view where our external subsystems ended up inside Aviary. First, let's look inside pre-mission to view our external mass subsystem.\n",
-    "![](./images/external_subsystem_premission.png){width=75%}\n",
-    "\n",
-    "We can see our external wing mass subsystem exists inside the pre-mission alongside Aviary's core subsystems. There is a feedback loop with our external subsystem, which needs tail mass from the core mass subsystem, and outputs wing mass, which is needed by the core mass subsystem's mass summation component. In this simple example, the optimizer managed to resolve this feedback, with both components agreeing on the values of variables in the feedback loop. However, in this case adding a solver to Aviary's pre-mission group is recommended. You can do this via [phase_info options](../source_docs/phase_info_detailed.ipynb).\n",
-    "\n",
-    "We can verify that Aviary is correctly using the wing mass our external subsystem computes, and not the internal wing mass calculation in the core mass subsystem, by looking at the component inside the core mass subsystem that would normally compute wing mass.\n",
-    "![](./images/external_subsystem_override.png){width=75%}\n",
-    "\n",
-    "The popout box is showing more details about that component's wing mass output. The important thing to see here is the promoted name of the variable, which has the phrase `EXTERNAL_SUBSYSTEM_OVERRIDE` added to the name of the variable being outputted in the core mass subsystem. Aviary tries to automatically detect variable name duplicates and de-conflict them via overrides.<!-- TODO: link to overriding docs page once finished --> This means that OpenMDAO will not connect the core mass subsystem's wing mass variable anywhere that {glue:md}`Aircraft.Wing.MASS` is called, because OpenMDAO will be looking for the string `aircraft:wing:mass`. Note that this automatic overriding only applies to outputs. The core mass subsystem also has a component that takes wing mass as an input (to sum total aircraft mass), and this input is untouched by Aviary. Therefore, it is correctly connected to our external subsystem, creating the feedback loop we saw earlier.\n",
-    "\n",
-    "To go even further in verifying only our subsystem's mass is being used, let's compare these two masses:"
-   ]
+   "source": "We can see that the values for {glue:md}`Aircraft.Wing.MASS` is indeed equal to the equation defined by our external subsystem: 5 * {glue:md}`Aircraft.HorizontalTail.MASS` * {glue:md}`Aircraft.Wing.MASS_SCALER` when checked by hand.\n\nNext let's look at the N<sup>2</sup> diagram and view where our external subsystems ended up inside Aviary. First, let's look inside pre-mission to view our external mass subsystem.\n```{image} ./images/external_subsystem_premission.png\n:width: 75%\n```\n\nWe can see our external wing mass subsystem exists inside the pre-mission alongside Aviary's core subsystems. There is a feedback loop with our external subsystem, which needs tail mass from the core mass subsystem, and outputs wing mass, which is needed by the core mass subsystem's mass summation component. In this simple example, the optimizer managed to resolve this feedback, with both components agreeing on the values of variables in the feedback loop. However, in this case adding a solver to Aviary's pre-mission group is recommended. You can do this via [phase_info options](../source_docs/phase_info_detailed.ipynb).\n\nWe can verify that Aviary is correctly using the wing mass our external subsystem computes, and not the internal wing mass calculation in the core mass subsystem, by looking at the component inside the core mass subsystem that would normally compute wing mass.\n```{image} ./images/external_subsystem_override.png\n:width: 75%\n```\n\nThe popout box is showing more details about that component's wing mass output. The important thing to see here is the promoted name of the variable, which has the phrase `EXTERNAL_SUBSYSTEM_OVERRIDE` added to the name of the variable being outputted in the core mass subsystem. Aviary tries to automatically detect variable name duplicates and de-conflict them via overrides.<!-- TODO: link to overriding docs page once finished --> This means that OpenMDAO will not connect the core mass subsystem's wing mass variable anywhere that {glue:md}`Aircraft.Wing.MASS` is called, because OpenMDAO will be looking for the string `aircraft:wing:mass`. Note that this automatic overriding only applies to outputs. The core mass subsystem also has a component that takes wing mass as an input (to sum total aircraft mass), and this input is untouched by Aviary. Therefore, it is correctly connected to our external subsystem, creating the feedback loop we saw earlier.\n\nTo go even further in verifying only our subsystem's mass is being used, let's compare these two masses:"
   },
   {
    "cell_type": "code",
@@ -273,17 +259,12 @@
    "cell_type": "markdown",
    "id": "bf13423a",
    "metadata": {},
-   "source": [
-    "The calculated masses are different, which helps further demonstrate that Aviary is not confusing the \"duplicate\" computed masses. The value we get for `aircraft:wing:mass` matches the expected output of our external subsystem that we manually verified earlier.\n",
-    "\n",
-    "Now that we have verified that our mass external subsystem was correctly added where we wanted to, let's look at our aerodynamics subsystem. Below, we are looking inside the cruise phase of the mission. We can see many parts of the mission that are always present, such as the atmosphere, equations of motion, and others. We can see our external aerodynamics subsystem, which has the default name \"simple_aero\", and no other aerodynamics components present (the core Aviary aerodynamics subsystem has the default name {glue:md}\"aerodynamics\").\n",
-    "![](./images/external_subsystem_mission.png){width=75%}"
-   ]
+   "source": "The calculated masses are different, which helps further demonstrate that Aviary is not confusing the \"duplicate\" computed masses. The value we get for `aircraft:wing:mass` matches the expected output of our external subsystem that we manually verified earlier.\n\nNow that we have verified that our mass external subsystem was correctly added where we wanted to, let's look at our aerodynamics subsystem. Below, we are looking inside the cruise phase of the mission. We can see many parts of the mission that are always present, such as the atmosphere, equations of motion, and others. We can see our external aerodynamics subsystem, which has the default name \"simple_aero\", and no other aerodynamics components present (the core Aviary aerodynamics subsystem has the default name {glue:md}\"aerodynamics\").\n```{image} ./images/external_subsystem_mission.png\n:width: 75%\n```"
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "openmdao_312",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
### Summary

The `![](image.png){width=75%}` markdown syntax was being rendered as literal text in the built HTML docs. This syntax relies on the MyST `attrs_inline` extension, which does not actually support image attributes in MyST-Parser 3.x despite the extension name suggesting otherwise.

Fix: Replace all three markdown image references in `external_subsystems.ipynb` with the MyST `{image}` directive, which is natively supported without any extensions and correctly passes the width attribute through to the rendered HTML.

### Related Issues

- Resolves #1200

### Backwards incompatibilities

None

### New Dependencies

None