### PR TITLE
Cleaned up a warning message when using fixed throttle allocation for multi-engine.

### DIFF
--- a/aviary/mission/flight_phase_builder.py
+++ b/aviary/mission/flight_phase_builder.py
@@ -287,14 +287,19 @@ class FlightPhaseBase(PhaseBuilder):
                 )
 
             else:
+                opt = allocation == ThrottleAllocation.STATIC
+                kwargs = {}
+                if opt:
+                    kwargs['lower'] = 0.0
+                    kwargs['upper'] = 1.0
+
                 phase.add_parameter(
                     'throttle_allocations',
                     units='unitless',
                     val=val,
                     shape=(num_engine_type - 1,),
-                    opt=allocation == ThrottleAllocation.STATIC,
-                    lower=0.0,
-                    upper=1.0,
+                    opt=opt,
+                    **kwargs,
                 )
 
         ##################


### PR DESCRIPTION
### Summary

Cleaned up a warning message when using fixed throttle allocation for multi-engine.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### AI Usage

None