### PR TITLE
Moved the total nacelle wetted area calc into its own component.

### DIFF
--- a/aviary/subsystems/aerodynamics/flops_based/test/test_computed_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_computed_aero_group.py
@@ -254,6 +254,7 @@ class MissionDragTest(unittest.TestCase):
         varnames = [
             Aircraft.Fuselage.WETTED_AREA,
             Aircraft.HorizontalTail.WETTED_AREA,
+            Aircraft.Nacelle.WETTED_AREA,
             Aircraft.VerticalTail.WETTED_AREA,
             Aircraft.Wing.AREA,
             Aircraft.Wing.ASPECT_RATIO,

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_tabular_aero_group.py
@@ -636,6 +636,7 @@ def _run_computed_aero_harness(flops_inputs, dynamic_inputs, num_nodes):
     varnames = [
         Aircraft.Fuselage.WETTED_AREA,
         Aircraft.HorizontalTail.WETTED_AREA,
+        Aircraft.Nacelle.WETTED_AREA,
         Aircraft.VerticalTail.WETTED_AREA,
         Aircraft.Wing.AREA,
         Aircraft.Wing.ASPECT_RATIO,

--- a/aviary/subsystems/geometry/flops_based/nacelle.py
+++ b/aviary/subsystems/geometry/flops_based/nacelle.py
@@ -25,23 +25,12 @@ class NacelleWettedArea(om.ExplicitComponent):
             self, Aircraft.Engine.SCALE_FACTOR, shape=num_engine_type, units='unitless'
         )
 
-        add_aviary_output(self, Aircraft.Nacelle.TOTAL_WETTED_AREA, units='ft**2')
         add_aviary_output(self, Aircraft.Nacelle.WETTED_AREA, shape=num_engine_type, units='ft**2')
 
     def setup_partials(self):
         # derivatives w.r.t vectorized engine inputs have known sparsity pattern
         num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
         shape = np.arange(num_engine_type)
-
-        self.declare_partials(
-            Aircraft.Nacelle.TOTAL_WETTED_AREA,
-            [
-                Aircraft.Nacelle.AVG_DIAMETER,
-                Aircraft.Nacelle.AVG_LENGTH,
-                Aircraft.Nacelle.WETTED_AREA_SCALER,
-                Aircraft.Engine.SCALE_FACTOR,
-            ],
-        )
 
         self.declare_partials(
             Aircraft.Nacelle.WETTED_AREA,
@@ -80,10 +69,6 @@ class NacelleWettedArea(om.ExplicitComponent):
         )
 
         outputs[Aircraft.Nacelle.WETTED_AREA] = wetted_area
-
-        total_wetted_area = sum(num_engines * wetted_area)
-
-        outputs[Aircraft.Nacelle.TOTAL_WETTED_AREA] = total_wetted_area
 
     def compute_partials(self, inputs, J, discrete_inputs=None):
         num_engines = self.options[Aircraft.Engine.NUM_ENGINES]
@@ -133,12 +118,36 @@ class NacelleWettedArea(om.ExplicitComponent):
 
         J[Aircraft.Nacelle.WETTED_AREA, Aircraft.Engine.SCALE_FACTOR] = deriv_area_thrust
 
-        J[Aircraft.Nacelle.TOTAL_WETTED_AREA, Aircraft.Nacelle.AVG_LENGTH] = deriv_total_len
 
-        J[Aircraft.Nacelle.TOTAL_WETTED_AREA, Aircraft.Nacelle.AVG_DIAMETER] = deriv_total_diam
+class NacelleTotalWettedArea(om.ExplicitComponent):
+    """
+    Sums the wetted area of all Nacelles.
 
-        J[Aircraft.Nacelle.TOTAL_WETTED_AREA, Aircraft.Nacelle.WETTED_AREA_SCALER] = (
-            deriv_total_scaler
+    This is separated so that individual nacelle areas can be overrriden without breaking the
+    summation. Note that this contributes to the total wetted area, which is used by the mass
+    subsystem to calculate the weight of the paint.
+    """
+
+    def initialize(self):
+        add_aviary_option(self, Aircraft.Engine.NUM_ENGINES)
+
+    def setup(self):
+        num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
+        add_aviary_input(self, Aircraft.Nacelle.WETTED_AREA, shape=num_engine_type, units='ft**2')
+        add_aviary_output(self, Aircraft.Nacelle.TOTAL_WETTED_AREA, units='ft**2')
+
+    def setup_partials(self):
+        num_engines = self.options[Aircraft.Engine.NUM_ENGINES]
+
+        self.declare_partials(
+            Aircraft.Nacelle.TOTAL_WETTED_AREA,
+            Aircraft.Nacelle.WETTED_AREA,
+            val=num_engines,
         )
 
-        J[Aircraft.Nacelle.TOTAL_WETTED_AREA, Aircraft.Engine.SCALE_FACTOR] = deriv_total_thrust
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        num_engines = self.options[Aircraft.Engine.NUM_ENGINES]
+        wetted_area = inputs[Aircraft.Nacelle.WETTED_AREA]
+
+        total_wetted_area = sum(num_engines * wetted_area)
+        outputs[Aircraft.Nacelle.TOTAL_WETTED_AREA] = total_wetted_area

--- a/aviary/subsystems/geometry/flops_based/test/test_nacelle.py
+++ b/aviary/subsystems/geometry/flops_based/test/test_nacelle.py
@@ -5,7 +5,10 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
-from aviary.subsystems.geometry.flops_based.nacelle import NacelleWettedArea
+from aviary.subsystems.geometry.flops_based.nacelle import (
+    NacelleWettedArea,
+    NacelleTotalWettedArea,
+)
 from aviary.utils.test_utils.variable_test import assert_match_varnames
 from aviary.validation_cases.validation_tests import get_flops_options
 from aviary.variable_info.variables import Aircraft
@@ -28,6 +31,12 @@ class NacelleTest(unittest.TestCase):
 
         prob.model.add_subsystem(
             'nacelles', NacelleWettedArea(**options), promotes_outputs=['*'], promotes_inputs=['*']
+        )
+        prob.model.add_subsystem(
+            'nacelles_total',
+            NacelleTotalWettedArea(**options),
+            promotes_outputs=['*'],
+            promotes_inputs=['*'],
         )
 
         prob.model_options['*'] = options
@@ -66,6 +75,12 @@ class NacelleTest(unittest.TestCase):
 
         prob.model.add_subsystem(
             'nacelles', NacelleWettedArea(), promotes_outputs=['*'], promotes_inputs=['*']
+        )
+        prob.model.add_subsystem(
+            'nacelles_total',
+            NacelleTotalWettedArea(**options),
+            promotes_outputs=['*'],
+            promotes_inputs=['*'],
         )
 
         prob.model_options['*'] = options

--- a/aviary/subsystems/geometry/flops_based/test/test_prep_geom.py
+++ b/aviary/subsystems/geometry/flops_based/test/test_prep_geom.py
@@ -16,7 +16,10 @@ from aviary.subsystems.geometry.flops_based.characteristic_lengths import (
     WingCharacteristicLength,
 )
 from aviary.subsystems.geometry.flops_based.fuselage import FuselagePrelim
-from aviary.subsystems.geometry.flops_based.nacelle import NacelleWettedArea
+from aviary.subsystems.geometry.flops_based.nacelle import (
+    NacelleWettedArea,
+    NacelleTotalWettedArea,
+)
 from aviary.subsystems.geometry.flops_based.prep_geom import _FuselageRatios, PrepGeom
 from aviary.subsystems.geometry.flops_based.wetted_area_total import (
     BWBWingWettedArea,
@@ -459,6 +462,12 @@ class NacellesTest(unittest.TestCase):
         options[Aircraft.Engine.NUM_ENGINES] = np.array([2])
 
         prob.model.add_subsystem('nacelles', NacelleWettedArea(**options), promotes=['*'])
+        prob.model.add_subsystem(
+            'nacelles_total',
+            NacelleTotalWettedArea(**options),
+            promotes_outputs=['*'],
+            promotes_inputs=['*'],
+        )
 
         prob.setup(check=False, force_alloc_complex=True)
 

--- a/aviary/subsystems/geometry/flops_based/wetted_area_total.py
+++ b/aviary/subsystems/geometry/flops_based/wetted_area_total.py
@@ -3,7 +3,10 @@ import openmdao.api as om
 from numpy import pi
 
 from aviary.subsystems.geometry.flops_based.canard import CanardWettedArea
-from aviary.subsystems.geometry.flops_based.nacelle import NacelleWettedArea
+from aviary.subsystems.geometry.flops_based.nacelle import (
+    NacelleWettedArea,
+    NacelleTotalWettedArea,
+)
 from aviary.subsystems.geometry.flops_based.utils import (
     Names,
     calc_fuselage_adjustment,
@@ -73,6 +76,13 @@ class WettedAreaGroup(om.Group):
             'nacelles_swet',
             NacelleWettedArea(),
             promotes_inputs=['aircraft*'],
+            promotes_outputs=['*'],
+        )
+
+        self.add_subsystem(
+            'nacelles_total_swet',
+            NacelleTotalWettedArea(),
+            promotes_inputs=['*'],
             promotes_outputs=['*'],
         )
 


### PR DESCRIPTION
### Summary

Moved the total nacelle wetted area calc into its own component, so that overriding an individual nacelle wetted area doesn't break the total area.

### Related Issues

- Resolves #1209

### Backwards incompatibilities

None

### AI Usage

Disclose any AI usage in this PR, including models used and files affected.