### PR TITLE
Gravity v3 - FLOPS Gravity, Earth Radius values updated

### DIFF
--- a/aviary/api.py
+++ b/aviary/api.py
@@ -58,7 +58,6 @@ from aviary.constants import (
     GRAV_ENGLISH_FLOPS,
     GRAV_ENGLISH_GASP,
     GRAV_ENGLISH_LBM,
-    GRAV_METRIC_FLOPS,
     GRAV_METRIC_GASP,
     PSLS_PSF,
     RADIUS_EARTH_METRIC,

--- a/aviary/api.py
+++ b/aviary/api.py
@@ -55,7 +55,6 @@ from aviary.utils.functions import (
 )
 from aviary.utils.options import list_options
 from aviary.constants import (
-    GRAV_ENGLISH_FLOPS,
     GRAV_ENGLISH_GASP,
     GRAV_ENGLISH_LBM,
     GRAV_METRIC_GASP,

--- a/aviary/api.py
+++ b/aviary/api.py
@@ -59,7 +59,6 @@ from aviary.constants import (
     GRAV_ENGLISH_LBM,
     GRAV_METRIC_GASP,
     PSLS_PSF,
-    RADIUS_EARTH_METRIC,
     RHO_SEA_LEVEL_ENGLISH,
     RHO_SEA_LEVEL_METRIC,
     TSLS_DEGR,

--- a/aviary/constants.py
+++ b/aviary/constants.py
@@ -16,6 +16,7 @@ GRAV_VENUS = (
 )  # Venus Global Reference Atmospheric Model (Venus-GRAM): User Guide, NASA/TM-20210022168
 
 RADIUS_EARTH = (6371009, 'm')  # Source: GRS80, mean earth radius (rounded to nearest meter)
+# convert_geopotential_altitude() is a python utility function that require RADIUS_EARTH to be specified in meters!
 
 RADIUS_MARS = (
     3386200,
@@ -37,4 +38,3 @@ RHO_SEA_LEVEL_METRIC = 1.225  # kg/m^3
 PSLS_PSF = 2116.22
 # sea level standard temperature in deg R
 TSLS_DEGR = 518.67
-RADIUS_EARTH_METRIC = 6367533.0  # m (meridional)

--- a/aviary/constants.py
+++ b/aviary/constants.py
@@ -28,7 +28,6 @@ RADIUS_VENUS = (
 
 # GNS = 9.8236930  # grav_accel_at_surface_earth # TODO: Remove this from other parts of Aviary
 GRAV_METRIC_GASP = 9.81  # m/s^2
-GRAV_METRIC_FLOPS = 9.80665  # m/s^2
 GRAV_ENGLISH_GASP = 32.2  # ft/s^2
 GRAV_ENGLISH_FLOPS = 32.17399  # ft/s^2
 GRAV_ENGLISH_LBM = 1.0  # lbf/lbm

--- a/aviary/constants.py
+++ b/aviary/constants.py
@@ -29,7 +29,6 @@ RADIUS_VENUS = (
 # GNS = 9.8236930  # grav_accel_at_surface_earth # TODO: Remove this from other parts of Aviary
 GRAV_METRIC_GASP = 9.81  # m/s^2
 GRAV_ENGLISH_GASP = 32.2  # ft/s^2
-GRAV_ENGLISH_FLOPS = 32.17399  # ft/s^2
 GRAV_ENGLISH_LBM = 1.0  # lbf/lbm
 # See issue 1169 for the value of RHO_SEA_LEVEL_ENGLISH
 RHO_SEA_LEVEL_ENGLISH = 0.0023769  # slug/ft^3

--- a/aviary/mission/energy_state/ode/landing_eom.py
+++ b/aviary/mission/energy_state/ode/landing_eom.py
@@ -3,7 +3,6 @@
 import numpy as np
 import openmdao.api as om
 
-from aviary.constants import GRAV_METRIC_FLOPS as grav_metric
 from aviary.mission.energy_state.ode.takeoff_eom import (
     Accelerations,
     DistanceRates,
@@ -11,7 +10,7 @@ from aviary.mission.energy_state.ode.takeoff_eom import (
     VelocityRate,
 )
 from aviary.utils.aviary_values import AviaryValues
-from aviary.variable_info.functions import add_aviary_input
+from aviary.variable_info.functions import add_aviary_input, add_aviary_option
 from aviary.variable_info.variables import Dynamic, Mission
 
 
@@ -19,35 +18,20 @@ class FlareEOM(om.Group):
     """Define a group for calculating equations of motion from start of flare to touchdown."""
 
     def initialize(self):
-        options = self.options
-
-        options.declare('num_nodes', default=1, types=int, lower=0)
-
-        options.declare(
-            'aviary_options',
-            types=AviaryValues,
-            desc='collection of Aircraft/Mission specific options',
-        )
+        self.options.declare('num_nodes', default=1, types=int, lower=0)
 
     def setup(self):
-        options = self.options
-
-        nn = options['num_nodes']
-        aviary_options = options['aviary_options']
-
-        kwargs = {'num_nodes': nn, 'climbing': True}
+        nn = self.options['num_nodes']
 
         inputs = [Dynamic.Mission.FLIGHT_PATH_ANGLE, Dynamic.Mission.VELOCITY]
         outputs = [Dynamic.Mission.DISTANCE_RATE, Dynamic.Mission.ALTITUDE_RATE]
 
         self.add_subsystem(
             'distance_rates',
-            DistanceRates(**kwargs),
+            DistanceRates(num_nodes= nn, climbing=True),
             promotes_inputs=inputs,
             promotes_outputs=outputs,
         )
-
-        kwargs = {'num_nodes': nn, 'aviary_options': aviary_options}
 
         inputs = [
             Dynamic.Vehicle.MASS,
@@ -61,7 +45,7 @@ class FlareEOM(om.Group):
         outputs = ['forces_horizontal', 'forces_vertical']
 
         self.add_subsystem(
-            'sum_forces', FlareSumForces(**kwargs), promotes_inputs=inputs, promotes_outputs=outputs
+            'sum_forces', FlareSumForces(num_nodes = nn), promotes_inputs=inputs, promotes_outputs=outputs
         )
 
         inputs = ['forces_horizontal', 'forces_vertical', Dynamic.Vehicle.MASS]
@@ -120,7 +104,7 @@ class FlareEOM(om.Group):
 
         self.add_subsystem(
             'glide_slope_forces',
-            GlideSlopeForces(**kwargs),
+            GlideSlopeForces(num_nodes=nn),
             promotes_inputs=inputs,
             promotes_outputs=outputs,
         )
@@ -145,27 +129,19 @@ class GlideSlopeForces(om.ExplicitComponent):
     """Define a component for calculating forces for evaluation of glide slope criteria."""
 
     def initialize(self):
-        options = self.options
+        self.options.declare('num_nodes', default=1, types=int, lower=0)
 
-        options.declare('num_nodes', default=1, types=int, lower=0)
-
-        options.declare(
-            'aviary_options',
-            types=AviaryValues,
-            desc='collection of Aircraft/Mission specific options',
-        )
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
+        add_aviary_option(self, Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, units='rad')
+        add_aviary_option(self, Mission.Takeoff.THRUST_INCIDENCE, units='rad')
 
     def setup(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
 
         add_aviary_input(self, Dynamic.Vehicle.MASS, shape=nn, units='kg')
         add_aviary_input(self, Dynamic.Vehicle.LIFT, shape=nn, units='N')
         add_aviary_input(self, Dynamic.Vehicle.DRAG, shape=nn, units='N')
-
         add_aviary_input(self, Dynamic.Vehicle.ANGLE_OF_ATTACK, shape=nn, units='rad')
-
         add_aviary_input(self, Dynamic.Mission.FLIGHT_PATH_ANGLE, shape=nn, units='rad')
 
         self.add_output(
@@ -184,21 +160,16 @@ class GlideSlopeForces(om.ExplicitComponent):
         )
 
     def setup_partials(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
 
         rows_cols = np.arange(nn)
 
         self.declare_partials('*', '*', rows=rows_cols, cols=rows_cols)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
-        options = self.options
-
-        aviary_options: AviaryValues = options['aviary_options']
-
-        alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+        alpha0 = self.options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
+        t_inc = self.options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         mass = inputs[Dynamic.Vehicle.MASS]
         lift = inputs[Dynamic.Vehicle.LIFT]
@@ -230,12 +201,9 @@ class GlideSlopeForces(om.ExplicitComponent):
         outputs['required_thrust'] = (f_h + f_v) / (2.0)
 
     def compute_partials(self, inputs, J, discrete_inputs=None):
-        options = self.options
-
-        aviary_options: AviaryValues = options['aviary_options']
-
-        alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+        alpha0 = self.options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
+        t_inc = self.options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         mass = inputs[Dynamic.Vehicle.MASS]
         lift = inputs[Dynamic.Vehicle.LIFT]
@@ -302,28 +270,20 @@ class FlareSumForces(om.ExplicitComponent):
     """
 
     def initialize(self):
-        options = self.options
-
-        options.declare('num_nodes', default=1, types=int, lower=0)
-
-        options.declare(
-            'aviary_options',
-            types=AviaryValues,
-            desc='collection of Aircraft/Mission specific options',
-        )
+        self.options.declare('num_nodes', default=1, types=int, lower=0)
+        
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
+        add_aviary_option(self, Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, units='rad')
+        add_aviary_option(self, Mission.Takeoff.THRUST_INCIDENCE, units='rad')
 
     def setup(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
 
         add_aviary_input(self, Dynamic.Vehicle.MASS, shape=nn, units='kg')
         add_aviary_input(self, Dynamic.Vehicle.LIFT, shape=nn, units='N')
         add_aviary_input(self, Dynamic.Vehicle.Propulsion.THRUST_TOTAL, shape=nn, units='N')
         add_aviary_input(self, Dynamic.Vehicle.DRAG, shape=nn, units='N')
-
         add_aviary_input(self, Dynamic.Vehicle.ANGLE_OF_ATTACK, shape=nn, units='rad')
-
         add_aviary_input(self, Dynamic.Mission.FLIGHT_PATH_ANGLE, shape=nn, units='rad')
 
         self.add_output(
@@ -341,9 +301,9 @@ class FlareSumForces(om.ExplicitComponent):
         )
 
     def setup_partials(self):
-        options = self.options
+        nn = self.options['num_nodes']
 
-        nn = options['num_nodes']
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         rows_cols = np.arange(nn)
 
@@ -368,12 +328,9 @@ class FlareSumForces(om.ExplicitComponent):
         self.declare_partials('*', wrt, rows=rows_cols, cols=rows_cols)
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
-        options = self.options
-
-        aviary_options: AviaryValues = options['aviary_options']
-
-        alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+        alpha0 = self.options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
+        t_inc = self.options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         mass = inputs[Dynamic.Vehicle.MASS]
         lift = inputs[Dynamic.Vehicle.LIFT]
@@ -406,12 +363,8 @@ class FlareSumForces(om.ExplicitComponent):
         outputs['forces_vertical'] = f_v
 
     def compute_partials(self, inputs, J, discrete_inputs=None):
-        options = self.options
-
-        aviary_options: AviaryValues = options['aviary_options']
-
-        alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+        alpha0 = self.options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
+        t_inc = self.options[Mission.Takeoff.THRUST_INCIDENCE][0]
 
         lift = inputs[Dynamic.Vehicle.LIFT]
         thrust = inputs[Dynamic.Vehicle.Propulsion.THRUST_TOTAL]
@@ -470,10 +423,10 @@ class GroundSumForces(om.ExplicitComponent):
             desc='current friction coefficient, either rolling friction or breaking friction',
         )
 
-    def setup(self):
-        options = self.options
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
 
-        nn = options['num_nodes']
+    def setup(self):
+        nn = self.options['num_nodes']
 
         add_aviary_input(self, Dynamic.Vehicle.MASS, shape=nn, units='kg')
         add_aviary_input(self, Dynamic.Vehicle.LIFT, shape=nn, units='N')
@@ -495,9 +448,9 @@ class GroundSumForces(om.ExplicitComponent):
         )
 
     def setup_partials(self):
-        options = self.options
+        nn = self.options['num_nodes']
 
-        nn = options['num_nodes']
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         rows_cols = np.arange(nn)
 
@@ -544,6 +497,8 @@ class GroundSumForces(om.ExplicitComponent):
         nn = options['num_nodes']
         friction_coefficient = options['friction_coefficient']
 
+        grav_metric = self.options[Mission.GRAVITY][0]
+
         mass = inputs[Dynamic.Vehicle.MASS]
         lift = inputs[Dynamic.Vehicle.LIFT]
         thrust = inputs[Dynamic.Vehicle.Propulsion.THRUST_TOTAL]
@@ -566,6 +521,8 @@ class GroundSumForces(om.ExplicitComponent):
 
         nn = options['num_nodes']
         friction_coefficient = options['friction_coefficient']
+
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         mass = inputs[Dynamic.Vehicle.MASS]
         lift = inputs[Dynamic.Vehicle.LIFT]

--- a/aviary/mission/energy_state/ode/landing_eom.py
+++ b/aviary/mission/energy_state/ode/landing_eom.py
@@ -28,7 +28,7 @@ class FlareEOM(om.Group):
 
         self.add_subsystem(
             'distance_rates',
-            DistanceRates(num_nodes= nn, climbing=True),
+            DistanceRates(num_nodes=nn, climbing=True),
             promotes_inputs=inputs,
             promotes_outputs=outputs,
         )
@@ -45,7 +45,10 @@ class FlareEOM(om.Group):
         outputs = ['forces_horizontal', 'forces_vertical']
 
         self.add_subsystem(
-            'sum_forces', FlareSumForces(num_nodes = nn), promotes_inputs=inputs, promotes_outputs=outputs
+            'sum_forces',
+            FlareSumForces(num_nodes=nn),
+            promotes_inputs=inputs,
+            promotes_outputs=outputs,
         )
 
         inputs = ['forces_horizontal', 'forces_vertical', Dynamic.Vehicle.MASS]
@@ -271,7 +274,7 @@ class FlareSumForces(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', default=1, types=int, lower=0)
-        
+
         add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
         add_aviary_option(self, Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, units='rad')
         add_aviary_option(self, Mission.Takeoff.THRUST_INCIDENCE, units='rad')

--- a/aviary/mission/energy_state/ode/landing_ode.py
+++ b/aviary/mission/energy_state/ode/landing_ode.py
@@ -29,9 +29,7 @@ class FlareODE(_BaseODE):
     """Define the ODE for the flare phase of landing."""
 
     def setup(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
         self.add_subsystem(name='atmosphere', subsys=Atmosphere(num_nodes=nn), promotes=['*'])
 
         # NOTE: the following are potentially significant differences in implementation
@@ -55,11 +53,9 @@ class FlareODE(_BaseODE):
 
         self.add_subsystems()
 
-        kwargs = {'num_nodes': nn, 'aviary_options': options['aviary_options']}
-
         self.add_subsystem(
             'landing_eom',
-            FlareEOM(**kwargs),
+            FlareEOM(num_nodes=nn),
             promotes_inputs=[
                 Dynamic.Mission.FLIGHT_PATH_ANGLE,
                 Dynamic.Mission.VELOCITY,

--- a/aviary/mission/energy_state/ode/required_thrust.py
+++ b/aviary/mission/energy_state/ode/required_thrust.py
@@ -1,9 +1,8 @@
 import numpy as np
 import openmdao.api as om
-from aviary.variable_info.functions import add_aviary_input
+from aviary.variable_info.functions import add_aviary_input, add_aviary_option
 
-from aviary.constants import GRAV_METRIC_FLOPS as gravity
-from aviary.variable_info.variables import Dynamic
+from aviary.variable_info.variables import Dynamic, Mission
 
 
 class RequiredThrust(om.ExplicitComponent):
@@ -14,6 +13,7 @@ class RequiredThrust(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
 
     def setup(self):
         nn = self.options['num_nodes']
@@ -49,28 +49,30 @@ class RequiredThrust(om.ExplicitComponent):
         self.declare_partials('thrust_required', Dynamic.Vehicle.MASS, rows=ar, cols=ar)
 
     def compute(self, inputs, outputs):
+        grav_metric = self.options[Mission.GRAVITY][0]
         drag = inputs[Dynamic.Vehicle.DRAG]
         altitude_rate = inputs[Dynamic.Mission.ALTITUDE_RATE]
         velocity = inputs[Dynamic.Mission.VELOCITY]
         velocity_rate = inputs[Dynamic.Mission.VELOCITY_RATE]
         mass = inputs[Dynamic.Vehicle.MASS]
 
-        thrust_required = drag + (altitude_rate * gravity / velocity + velocity_rate) * mass
+        thrust_required = drag + (altitude_rate * grav_metric / velocity + velocity_rate) * mass
 
         outputs['thrust_required'] = thrust_required
 
     def compute_partials(self, inputs, partials):
+        grav_metric = self.options[Mission.GRAVITY][0]
         altitude_rate = inputs[Dynamic.Mission.ALTITUDE_RATE]
         velocity = inputs[Dynamic.Mission.VELOCITY]
         velocity_rate = inputs[Dynamic.Mission.VELOCITY_RATE]
         mass = inputs[Dynamic.Vehicle.MASS]
 
         partials['thrust_required', Dynamic.Vehicle.DRAG] = 1.0
-        partials['thrust_required', Dynamic.Mission.ALTITUDE_RATE] = gravity / velocity * mass
+        partials['thrust_required', Dynamic.Mission.ALTITUDE_RATE] = grav_metric / velocity * mass
         partials['thrust_required', Dynamic.Mission.VELOCITY] = (
-            -altitude_rate * gravity / velocity**2 * mass
+            -altitude_rate * grav_metric / velocity**2 * mass
         )
         partials['thrust_required', Dynamic.Mission.VELOCITY_RATE] = mass
         partials['thrust_required', Dynamic.Vehicle.MASS] = (
-            altitude_rate * gravity / velocity + velocity_rate
+            altitude_rate * grav_metric / velocity + velocity_rate
         )

--- a/aviary/mission/energy_state/ode/takeoff_eom.py
+++ b/aviary/mission/energy_state/ode/takeoff_eom.py
@@ -3,9 +3,8 @@
 import numpy as np
 import openmdao.api as om
 
-from aviary.constants import GRAV_METRIC_FLOPS as grav_metric
 from aviary.utils.aviary_values import AviaryValues
-from aviary.variable_info.functions import add_aviary_input, add_aviary_output
+from aviary.variable_info.functions import add_aviary_input, add_aviary_output, add_aviary_option
 from aviary.variable_info.variables import Dynamic, Mission
 
 
@@ -16,14 +15,11 @@ class StallSpeed(om.ExplicitComponent):
     """
 
     def initialize(self):
-        options = self.options
-
-        options.declare('num_nodes', default=1, types=int, lower=0)
+        self.options.declare('num_nodes', default=1, types=int, lower=0)
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
 
     def setup(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
 
         add_aviary_input(self, Dynamic.Vehicle.MASS, shape=nn, units='kg')
 
@@ -48,9 +44,7 @@ class StallSpeed(om.ExplicitComponent):
         )
 
     def setup_partials(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
         rows_cols = np.arange(nn)
 
         self.declare_partials(
@@ -63,6 +57,7 @@ class StallSpeed(om.ExplicitComponent):
         self.declare_partials('stall_speed', ['area', 'lift_coefficient_max'])
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        grav_metric = self.options[Mission.GRAVITY][0]
         mass = inputs['mass']
         density = inputs[Dynamic.Atmosphere.DENSITY]
         area = inputs['area']
@@ -74,6 +69,7 @@ class StallSpeed(om.ExplicitComponent):
         outputs['stall_speed'] = stall_speed
 
     def compute_partials(self, inputs, J, discrete_inputs=None):
+        grav_metric = self.options[Mission.GRAVITY][0]
         mass = inputs['mass']
         density = inputs[Dynamic.Atmosphere.DENSITY]
         area = inputs['area']
@@ -118,10 +114,10 @@ class TakeoffEOM(om.Group):
         )
 
         options.declare(
-            'aviary_options',
-            types=AviaryValues,
-            desc='collection of Aircraft/Mission specific options',
-        )
+             'aviary_options',
+             types=AviaryValues,
+             desc='collection of Aircraft/Mission specific options',
+         )
 
     def setup(self):
         options = self.options
@@ -132,14 +128,12 @@ class TakeoffEOM(om.Group):
         aviary_options = options['aviary_options']
         mu = aviary_options.get_val(friction_key)
 
-        kwargs = {'num_nodes': nn, 'climbing': climbing}
-
         inputs = [Dynamic.Mission.FLIGHT_PATH_ANGLE, Dynamic.Mission.VELOCITY]
         outputs = [Dynamic.Mission.DISTANCE_RATE, Dynamic.Mission.ALTITUDE_RATE]
 
         self.add_subsystem(
             'distance_rates',
-            DistanceRates(**kwargs),
+            DistanceRates(num_nodes=nn, climbing=climbing),
             promotes_inputs=inputs,
             promotes_outputs=outputs,
         )
@@ -148,7 +142,6 @@ class TakeoffEOM(om.Group):
             'num_nodes': nn,
             'climbing': climbing,
             'friction_coefficient': mu,
-            'aviary_options': aviary_options,
         }
 
         self.add_subsystem(
@@ -181,7 +174,7 @@ class TakeoffEOM(om.Group):
 
         self.add_subsystem(
             'climb_gradient_forces',
-            ClimbGradientForces(num_nodes=nn, aviary_options=aviary_options),
+            ClimbGradientForces(num_nodes=nn),
             promotes=['*'],
         )
 
@@ -527,11 +520,9 @@ class SumForces(om.ExplicitComponent):
             desc='current friction coefficient, either rolling friction or braking friction',
         )
 
-        options.declare(
-            'aviary_options',
-            types=AviaryValues,
-            desc='collection of Aircraft/Mission specific options',
-        )
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
+        add_aviary_option(self, Mission.Takeoff.THRUST_INCIDENCE, units='rad')
+        add_aviary_option(self, Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, units='rad')
 
     def setup(self):
         options = self.options
@@ -566,6 +557,9 @@ class SumForces(om.ExplicitComponent):
 
         nn = options['num_nodes']
         climbing = options['climbing']
+        grav_metric = options[Mission.GRAVITY][0]
+        t_inc = options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        mu = options['friction_coefficient']
 
         rows_cols = np.arange(nn)
 
@@ -591,9 +585,6 @@ class SumForces(om.ExplicitComponent):
             self.declare_partials('*', wrt, rows=rows_cols, cols=rows_cols)
 
         else:
-            aviary_options: AviaryValues = options['aviary_options']
-
-            mu = options['friction_coefficient']
             val = -grav_metric * mu
 
             self.declare_partials(
@@ -612,7 +603,7 @@ class SumForces(om.ExplicitComponent):
                 cols=rows_cols,
             )
 
-            t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+            
             val = np.cos(t_inc) + np.sin(t_inc) * mu
 
             self.declare_partials(
@@ -643,9 +634,9 @@ class SumForces(om.ExplicitComponent):
         options = self.options
 
         climbing = options['climbing']
-        aviary_options: AviaryValues = options['aviary_options']
-
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+        grav_metric = options[Mission.GRAVITY][0]
+        t_inc = options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        alpha0 = options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
 
         mass = inputs[Dynamic.Vehicle.MASS]
         lift = inputs[Dynamic.Vehicle.LIFT]
@@ -659,7 +650,6 @@ class SumForces(om.ExplicitComponent):
             #    - section: "COMPUTE TRAJECTORY FROM LIFTOFF UNTIL OBSTACLE HEIGHT IS
             #      REACHED"
             #    - variables: FORCH, FORCV
-            alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
 
             alpha = inputs[Dynamic.Vehicle.ANGLE_OF_ATTACK]
             gamma = inputs[Dynamic.Mission.FLIGHT_PATH_ANGLE]
@@ -696,15 +686,12 @@ class SumForces(om.ExplicitComponent):
         options = self.options
 
         climbing = options['climbing']
+        t_inc = options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        alpha0 = options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
 
         if not climbing:
             # see setup_partials()
             return
-
-        aviary_options: AviaryValues = options['aviary_options']
-
-        alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
 
         lift = inputs[Dynamic.Vehicle.LIFT]
         thrust = inputs[Dynamic.Vehicle.Propulsion.THRUST_TOTAL]
@@ -749,20 +736,14 @@ class ClimbGradientForces(om.ExplicitComponent):
     """
 
     def initialize(self):
-        options = self.options
-
-        options.declare('num_nodes', default=1, types=int, lower=0)
-
-        options.declare(
-            'aviary_options',
-            types=AviaryValues,
-            desc='collection of Aircraft/Mission specific options',
-        )
+        self.options.declare('num_nodes', default=1, types=int, lower=0)
+        
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
+        add_aviary_option(self, Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, units='rad')
+        add_aviary_option(self, Mission.Takeoff.THRUST_INCIDENCE, units='rad')
 
     def setup(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
 
         add_aviary_input(self, Dynamic.Vehicle.MASS, shape=nn, units='kg')
         add_aviary_input(self, Dynamic.Vehicle.LIFT, shape=nn, units='N')
@@ -789,9 +770,7 @@ class ClimbGradientForces(om.ExplicitComponent):
         )
 
     def setup_partials(self):
-        options = self.options
-
-        nn = options['num_nodes']
+        nn = self.options['num_nodes']
 
         rows_cols = np.arange(nn)
 
@@ -832,12 +811,9 @@ class ClimbGradientForces(om.ExplicitComponent):
         )
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
-        options = self.options
-
-        aviary_options: AviaryValues = options['aviary_options']
-
-        alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+        alpha0 = self.options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
+        t_inc = self.options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         mass = inputs[Dynamic.Vehicle.MASS]
         lift = inputs[Dynamic.Vehicle.LIFT]
@@ -866,12 +842,9 @@ class ClimbGradientForces(om.ExplicitComponent):
         outputs['climb_gradient_forces_vertical'] = f_v
 
     def compute_partials(self, inputs, J, discrete_inputs=None):
-        options = self.options
-
-        aviary_options: AviaryValues = options['aviary_options']
-
-        alpha0 = aviary_options.get_val(Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, 'rad')
-        t_inc = aviary_options.get_val(Mission.Takeoff.THRUST_INCIDENCE, 'rad')
+        alpha0 = self.options[Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY][0]
+        t_inc = self.options[Mission.Takeoff.THRUST_INCIDENCE][0]
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         mass = inputs[Dynamic.Vehicle.MASS]
         thrust = inputs[Dynamic.Vehicle.Propulsion.THRUST_TOTAL]

--- a/aviary/mission/energy_state/ode/takeoff_eom.py
+++ b/aviary/mission/energy_state/ode/takeoff_eom.py
@@ -114,10 +114,10 @@ class TakeoffEOM(om.Group):
         )
 
         options.declare(
-             'aviary_options',
-             types=AviaryValues,
-             desc='collection of Aircraft/Mission specific options',
-         )
+            'aviary_options',
+            types=AviaryValues,
+            desc='collection of Aircraft/Mission specific options',
+        )
 
     def setup(self):
         options = self.options
@@ -603,7 +603,6 @@ class SumForces(om.ExplicitComponent):
                 cols=rows_cols,
             )
 
-            
             val = np.cos(t_inc) + np.sin(t_inc) * mu
 
             self.declare_partials(
@@ -737,7 +736,7 @@ class ClimbGradientForces(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', default=1, types=int, lower=0)
-        
+
         add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
         add_aviary_option(self, Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY, units='rad')
         add_aviary_option(self, Mission.Takeoff.THRUST_INCIDENCE, units='rad')

--- a/aviary/mission/energy_state/ode/test/test_landing_eom.py
+++ b/aviary/mission/energy_state/ode/test/test_landing_eom.py
@@ -23,6 +23,7 @@ from aviary.variable_info.variables import Dynamic, Mission
 from aviary.variable_info.functions import setup_model_options
 from aviary.utils.aviary_values import AviaryValues
 
+
 @use_tempdirs
 class FlareEOMTest(unittest.TestCase):
     """Test against data of detailed_landing_flare from models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py."""
@@ -106,15 +107,13 @@ class OtherTest(unittest.TestCase):
         tol = 1e-6
         options = {
             Mission.GRAVITY: (9.80665, 'm/s**2'),
-            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0, 'rad'),
             Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
         }
         prob = om.Problem()
 
         # use data from detailed_landing_flare in models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py
-        prob.model.add_subsystem(
-            'glide', GlideSlopeForces(num_nodes=2, **options), promotes=['*']
-        )
+        prob.model.add_subsystem('glide', GlideSlopeForces(num_nodes=2, **options), promotes=['*'])
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.array([106292, 106292]), units='lbm')
         prob.model.set_input_defaults(
             Dynamic.Vehicle.DRAG, np.array([47447.13138523, 44343.01567596]), units='N'
@@ -145,13 +144,11 @@ class OtherTest(unittest.TestCase):
         tol = 1e-6
         options = {
             Mission.GRAVITY: (9.80665, 'm/s**2'),
-            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0, 'rad'),
             Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
         }
         prob = om.Problem()
-        prob.model.add_subsystem(
-            'flare', FlareSumForces(num_nodes=2, **options), promotes=['*']
-        )
+        prob.model.add_subsystem('flare', FlareSumForces(num_nodes=2, **options), promotes=['*'])
 
         # use data from detailed_landing_flare in models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.array([106292, 106292]), units='lbm')
@@ -190,9 +187,7 @@ class OtherTest(unittest.TestCase):
             'friction_coefficient': (0.025),
         }
         prob = om.Problem()
-        prob.model.add_subsystem(
-            'ground', GroundSumForces(num_nodes=2, **options), promotes=['*']
-        )
+        prob.model.add_subsystem('ground', GroundSumForces(num_nodes=2, **options), promotes=['*'])
 
         # use data from detailed_landing_flare in models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.array([106292, 106292]), units='lbm')

--- a/aviary/mission/energy_state/ode/test/test_landing_eom.py
+++ b/aviary/mission/energy_state/ode/test/test_landing_eom.py
@@ -19,8 +19,9 @@ from aviary.subsystems.propulsion.utils import build_engine_deck
 from aviary.utils.preprocessors import preprocess_options
 from aviary.utils.test_utils.variable_test import assert_match_varnames
 from aviary.validation_cases.validation_tests import do_validation_test
-from aviary.variable_info.variables import Dynamic
-
+from aviary.variable_info.variables import Dynamic, Mission
+from aviary.variable_info.functions import setup_model_options
+from aviary.utils.aviary_values import AviaryValues
 
 @use_tempdirs
 class FlareEOMTest(unittest.TestCase):
@@ -37,10 +38,12 @@ class FlareEOMTest(unittest.TestCase):
 
         prob.model.add_subsystem(
             'landing_flare_eom',
-            FlareEOM(num_nodes=nn, aviary_options=aviary_options),
+            FlareEOM(num_nodes=nn),
             promotes_inputs=['*'],
             promotes_outputs=['*'],
         )
+
+        setup_model_options(prob, AviaryValues(aviary_options))
 
         prob.setup(check=False, force_alloc_complex=True)
 
@@ -101,12 +104,16 @@ class OtherTest(unittest.TestCase):
         # test on single component GlideSlopeForces
 
         tol = 1e-6
-        aviary_options = inputs
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
+        }
         prob = om.Problem()
 
         # use data from detailed_landing_flare in models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py
         prob.model.add_subsystem(
-            'glide', GlideSlopeForces(num_nodes=2, aviary_options=aviary_options), promotes=['*']
+            'glide', GlideSlopeForces(num_nodes=2, **options), promotes=['*']
         )
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.array([106292, 106292]), units='lbm')
         prob.model.set_input_defaults(
@@ -136,10 +143,14 @@ class OtherTest(unittest.TestCase):
         # test on single component FlareSumForces
 
         tol = 1e-6
-        aviary_options = inputs
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
+        }
         prob = om.Problem()
         prob.model.add_subsystem(
-            'flare', FlareSumForces(num_nodes=2, aviary_options=aviary_options), promotes=['*']
+            'flare', FlareSumForces(num_nodes=2, **options), promotes=['*']
         )
 
         # use data from detailed_landing_flare in models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py
@@ -174,9 +185,13 @@ class OtherTest(unittest.TestCase):
         # test on single component GroundSumForces
 
         tol = 1e-6
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+            'friction_coefficient': (0.025),
+        }
         prob = om.Problem()
         prob.model.add_subsystem(
-            'ground', GroundSumForces(num_nodes=2, friction_coefficient=0.025), promotes=['*']
+            'ground', GroundSumForces(num_nodes=2, **options), promotes=['*']
         )
 
         # use data from detailed_landing_flare in models/aircraft/advanced_single_aisle/advanced_single_aisle_data.py

--- a/aviary/mission/energy_state/ode/test/test_landing_ode.py
+++ b/aviary/mission/energy_state/ode/test/test_landing_ode.py
@@ -29,6 +29,7 @@ class FlareODETest(unittest.TestCase):
         time, _ = detailed_landing_flare.get_item('time')
         nn = len(time)
         aviary_options = inputs
+        aviary_options.set_val(Aircraft.Engine.NUM_ENGINES, [2])
 
         engines = [build_engine_deck(aviary_options)]
 
@@ -50,7 +51,7 @@ class FlareODETest(unittest.TestCase):
 
         prob.model.set_input_defaults(Aircraft.Wing.AREA, val=1.0, units='ft**2')
 
-        setup_model_options(prob, AviaryValues({Aircraft.Engine.NUM_ENGINES: ([2], 'unitless')}))
+        setup_model_options(prob, AviaryValues(aviary_options))
 
         prob.setup(check=False, force_alloc_complex=True)
 

--- a/aviary/mission/energy_state/ode/test/test_mission_eom.py
+++ b/aviary/mission/energy_state/ode/test/test_mission_eom.py
@@ -12,6 +12,7 @@ from aviary.variable_info.variables import Dynamic, Mission
 from aviary.variable_info.functions import setup_model_options
 from aviary.utils.aviary_values import AviaryValues
 
+
 @use_tempdirs
 class MissionEOMTest(unittest.TestCase):
     """Test energy-method equations of motion."""

--- a/aviary/mission/energy_state/ode/test/test_mission_eom.py
+++ b/aviary/mission/energy_state/ode/test/test_mission_eom.py
@@ -8,8 +8,9 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.mission.energy_state.ode.mission_EOM import MissionEOM
 from aviary.utils.test_utils.variable_test import assert_match_varnames
-from aviary.variable_info.variables import Dynamic
-
+from aviary.variable_info.variables import Dynamic, Mission
+from aviary.variable_info.functions import setup_model_options
+from aviary.utils.aviary_values import AviaryValues
 
 @use_tempdirs
 class MissionEOMTest(unittest.TestCase):
@@ -48,6 +49,13 @@ class MissionEOMTest(unittest.TestCase):
             np.array([40799.6009633346, 11500.32, 42308.2709683461]),
             units='lbf',
         )
+
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+        }
+
+        setup_model_options(prob, AviaryValues(options))
+
         prob.setup(check=False, force_alloc_complex=True)
 
     def test_case(self):

--- a/aviary/mission/energy_state/ode/test/test_required_thrust.py
+++ b/aviary/mission/energy_state/ode/test/test_required_thrust.py
@@ -19,7 +19,9 @@ class RequiredThrustTest(unittest.TestCase):
         options = {
             Mission.GRAVITY: (9.80665, 'm/s**2'),
         }
-        prob.model.add_subsystem('req_thrust', RequiredThrust(num_nodes=2, **options), promotes=['*'])
+        prob.model.add_subsystem(
+            'req_thrust', RequiredThrust(num_nodes=2, **options), promotes=['*']
+        )
         prob.model.set_input_defaults(
             Dynamic.Vehicle.DRAG, np.array([47447.13138523, 44343.01567596]), units='N'
         )

--- a/aviary/mission/energy_state/ode/test/test_required_thrust.py
+++ b/aviary/mission/energy_state/ode/test/test_required_thrust.py
@@ -7,7 +7,7 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.mission.energy_state.ode.required_thrust import RequiredThrust
 from aviary.utils.test_utils.variable_test import assert_match_varnames
-from aviary.variable_info.variables import Dynamic
+from aviary.variable_info.variables import Dynamic, Mission
 
 
 @use_tempdirs
@@ -16,7 +16,10 @@ class RequiredThrustTest(unittest.TestCase):
 
     def setUp(self):
         prob = self.prob = om.Problem()
-        prob.model.add_subsystem('req_thrust', RequiredThrust(num_nodes=2), promotes=['*'])
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+        }
+        prob.model.add_subsystem('req_thrust', RequiredThrust(num_nodes=2, **options), promotes=['*'])
         prob.model.set_input_defaults(
             Dynamic.Vehicle.DRAG, np.array([47447.13138523, 44343.01567596]), units='N'
         )

--- a/aviary/mission/energy_state/ode/test/test_takeoff_eom.py
+++ b/aviary/mission/energy_state/ode/test/test_takeoff_eom.py
@@ -29,6 +29,7 @@ from aviary.utils.preprocessors import preprocess_options
 
 inputs.set_val(Aircraft.Engine.NUM_ENGINES, np.array([2]))
 
+
 @use_tempdirs
 class TakeoffEOMTest(unittest.TestCase):
     """Test detailed takeoff equation of motion."""
@@ -267,7 +268,7 @@ class TakeoffEOMTest(unittest.TestCase):
         prob = om.Problem()
         options = {
             Mission.GRAVITY: (9.80665, 'm/s**2'),
-            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0, 'rad'),
             Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
         }
         prob.model.add_subsystem(
@@ -303,7 +304,7 @@ class TakeoffEOMTest(unittest.TestCase):
         prob = om.Problem()
         options = {
             Mission.GRAVITY: (9.80665, 'm/s**2'),
-            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0, 'rad'),
             Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
         }
         prob.model.add_subsystem(
@@ -339,7 +340,7 @@ class TakeoffEOMTest(unittest.TestCase):
         prob = om.Problem()
         options = {
             Mission.GRAVITY: (9.80665, 'm/s**2'),
-            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0, 'rad'),
             Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
         }
         prob.model.add_subsystem(

--- a/aviary/mission/energy_state/ode/test/test_takeoff_eom.py
+++ b/aviary/mission/energy_state/ode/test/test_takeoff_eom.py
@@ -24,9 +24,10 @@ from aviary.validation_cases.validation_data.test_data.advanced_single_aisle_dat
 from aviary.validation_cases.validation_tests import do_validation_test
 from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.variables import Aircraft, Dynamic, Mission
+from aviary.utils.aviary_values import AviaryValues
+from aviary.utils.preprocessors import preprocess_options
 
 inputs.set_val(Aircraft.Engine.NUM_ENGINES, np.array([2]))
-
 
 @use_tempdirs
 class TakeoffEOMTest(unittest.TestCase):
@@ -90,20 +91,23 @@ class TakeoffEOMTest(unittest.TestCase):
 
         time, _ = detailed_takeoff_climbing.get_item('time')
         nn = len(time)
-        aviary_options = inputs
         inputs.set_val(Aircraft.Engine.NUM_ENGINES, [2])
+
+        preprocess_options(inputs)
 
         prob.model.add_subsystem(
             'takeoff_eom',
             TakeoffEOM(
                 num_nodes=nn,
-                aviary_options=aviary_options,
                 climbing=climbing,
                 friction_key=Mission.Takeoff.ROLLING_FRICTION_COEFFICIENT,
+                aviary_options=inputs,
             ),
             promotes_inputs=['*'],
             promotes_outputs=['*'],
         )
+
+        setup_model_options(prob, AviaryValues(inputs))
 
         prob.setup(check=False, force_alloc_complex=True)
 
@@ -133,7 +137,12 @@ class TakeoffEOMTest(unittest.TestCase):
     def test_StallSpeed(self):
         tol = 1e-6
         prob = om.Problem()
-        prob.model.add_subsystem('stall_speed', StallSpeed(num_nodes=2), promotes=['*'])
+
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+        }
+
+        prob.model.add_subsystem('stall_speed', StallSpeed(num_nodes=2, **options), promotes=['*'])
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.ones(2), units='kg')
         prob.model.set_input_defaults(Dynamic.Atmosphere.DENSITY, np.array([1, 2]), units='kg/m**3')
         prob.model.set_input_defaults('area', 10, units='m**2')
@@ -256,10 +265,14 @@ class TakeoffEOMTest(unittest.TestCase):
         """Climbing = True."""
         tol = 1e-6
         prob = om.Problem()
-        aviary_options = inputs
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
+        }
         prob.model.add_subsystem(
             'sum1',
-            SumForces(num_nodes=2, climbing=True, aviary_options=aviary_options),
+            SumForces(num_nodes=2, climbing=True, **options),
             promotes=['*'],
         )
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.array([106292, 106292]), units='lbm')
@@ -288,10 +301,14 @@ class TakeoffEOMTest(unittest.TestCase):
         """Climbing = False."""
         tol = 1e-6
         prob = om.Problem()
-        aviary_options = inputs
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
+        }
         prob.model.add_subsystem(
             'sum2',
-            SumForces(num_nodes=2, climbing=False, aviary_options=aviary_options),
+            SumForces(num_nodes=2, climbing=False, **options),
             promotes=['*'],
         )
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.array([106292, 106292]), units='lbm')
@@ -320,10 +337,14 @@ class TakeoffEOMTest(unittest.TestCase):
         """Climbing = False."""
         tol = 1e-6
         prob = om.Problem()
-        aviary_options = inputs
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+            Mission.Takeoff.ANGLE_OF_ATTACK_RUNWAY: (0 , 'rad'),
+            Mission.Takeoff.THRUST_INCIDENCE: (0, 'rad'),
+        }
         prob.model.add_subsystem(
             'climb_grad',
-            ClimbGradientForces(num_nodes=2, aviary_options=aviary_options),
+            ClimbGradientForces(num_nodes=2, **options),
             promotes=['*'],
         )
         prob.model.set_input_defaults(Dynamic.Vehicle.MASS, np.array([106292, 106292]), units='lbm')

--- a/aviary/mission/energy_state/ode/test/test_takeoff_ode.py
+++ b/aviary/mission/energy_state/ode/test/test_takeoff_ode.py
@@ -94,6 +94,7 @@ class TakeoffODETest(unittest.TestCase):
         time, _ = detailed_takeoff_climbing.get_item('time')
         nn = len(time)
         aviary_options = inputs
+        aviary_options.set_val(Aircraft.Engine.NUM_ENGINES, [2])
         engines = [build_engine_deck(aviary_options)]
 
         preprocess_options(aviary_options, engine_models=engines)
@@ -116,7 +117,7 @@ class TakeoffODETest(unittest.TestCase):
 
         prob.model.set_input_defaults(Aircraft.Wing.AREA, val=1.0, units='ft**2')
 
-        setup_model_options(prob, AviaryValues({Aircraft.Engine.NUM_ENGINES: ([2], 'unitless')}))
+        setup_model_options(prob, AviaryValues(aviary_options))
 
         prob.setup(check=False, force_alloc_complex=True)
 

--- a/aviary/mission/ode/altitude_rate.py
+++ b/aviary/mission/ode/altitude_rate.py
@@ -1,10 +1,8 @@
 import numpy as np
 import openmdao.api as om
-from aviary.variable_info.functions import add_aviary_input, add_aviary_output
 
-import aviary.constants as constants
-from aviary.variable_info.variables import Dynamic
-from aviary.variable_info.functions import add_aviary_input, add_aviary_output
+from aviary.variable_info.variables import Dynamic, Mission
+from aviary.variable_info.functions import add_aviary_input, add_aviary_output, add_aviary_option
 
 
 class AltitudeRate(om.ExplicitComponent):
@@ -15,6 +13,8 @@ class AltitudeRate(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
+
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
 
     def setup(self):
         nn = self.options['num_nodes']
@@ -43,16 +43,6 @@ class AltitudeRate(om.ExplicitComponent):
             units='m/s',
         )
 
-    def compute(self, inputs, outputs):
-        gravity = constants.GRAV_METRIC_FLOPS
-        specific_power = inputs[Dynamic.Mission.SPECIFIC_ENERGY_RATE]
-        acceleration = inputs[Dynamic.Mission.VELOCITY_RATE]
-        velocity = inputs[Dynamic.Mission.VELOCITY]
-
-        outputs[Dynamic.Mission.ALTITUDE_RATE] = (
-            specific_power - (velocity * acceleration) / gravity
-        )
-
     def setup_partials(self):
         arange = np.arange(self.options['num_nodes'])
         self.declare_partials(
@@ -67,10 +57,20 @@ class AltitudeRate(om.ExplicitComponent):
             val=1,
         )
 
-    def compute_partials(self, inputs, J):
-        gravity = constants.GRAV_METRIC_FLOPS
+    def compute(self, inputs, outputs):
+        grav_metric = self.options[Mission.GRAVITY][0]
+        specific_power = inputs[Dynamic.Mission.SPECIFIC_ENERGY_RATE]
         acceleration = inputs[Dynamic.Mission.VELOCITY_RATE]
         velocity = inputs[Dynamic.Mission.VELOCITY]
 
-        J[Dynamic.Mission.ALTITUDE_RATE, Dynamic.Mission.VELOCITY_RATE] = -velocity / gravity
-        J[Dynamic.Mission.ALTITUDE_RATE, Dynamic.Mission.VELOCITY] = -acceleration / gravity
+        outputs[Dynamic.Mission.ALTITUDE_RATE] = (
+            specific_power - (velocity * acceleration) / grav_metric
+        )
+
+    def compute_partials(self, inputs, J):
+        grav_metric = self.options[Mission.GRAVITY][0]
+        acceleration = inputs[Dynamic.Mission.VELOCITY_RATE]
+        velocity = inputs[Dynamic.Mission.VELOCITY]
+
+        J[Dynamic.Mission.ALTITUDE_RATE, Dynamic.Mission.VELOCITY_RATE] = -velocity / grav_metric
+        J[Dynamic.Mission.ALTITUDE_RATE, Dynamic.Mission.VELOCITY] = -acceleration / grav_metric

--- a/aviary/mission/ode/specific_energy_rate.py
+++ b/aviary/mission/ode/specific_energy_rate.py
@@ -1,9 +1,8 @@
 import numpy as np
 import openmdao.api as om
 
-from aviary.constants import GRAV_METRIC_FLOPS as gravity
-from aviary.variable_info.functions import add_aviary_input, add_aviary_output
-from aviary.variable_info.variables import Dynamic
+from aviary.variable_info.variables import Dynamic, Mission
+from aviary.variable_info.functions import add_aviary_input, add_aviary_output, add_aviary_option
 
 
 class SpecificEnergyRate(om.ExplicitComponent):
@@ -14,6 +13,8 @@ class SpecificEnergyRate(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
+
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
 
     def setup(self):
         nn = self.options['num_nodes']
@@ -42,13 +43,6 @@ class SpecificEnergyRate(om.ExplicitComponent):
             units='m/s',
         )
 
-    def compute(self, inputs, outputs):
-        velocity = inputs[Dynamic.Mission.VELOCITY]
-        thrust = inputs[Dynamic.Vehicle.Propulsion.THRUST_TOTAL]
-        drag = inputs[Dynamic.Vehicle.DRAG]
-        weight = inputs[Dynamic.Vehicle.MASS] * gravity
-        outputs[Dynamic.Mission.SPECIFIC_ENERGY_RATE] = velocity * (thrust - drag) / weight
-
     def setup_partials(self):
         arange = np.arange(self.options['num_nodes'])
         self.declare_partials(
@@ -63,11 +57,22 @@ class SpecificEnergyRate(om.ExplicitComponent):
             cols=arange,
         )
 
-    def compute_partials(self, inputs, J):
+    def compute(self, inputs, outputs):
+        grav_metric = self.options[Mission.GRAVITY][0]
+
         velocity = inputs[Dynamic.Mission.VELOCITY]
         thrust = inputs[Dynamic.Vehicle.Propulsion.THRUST_TOTAL]
         drag = inputs[Dynamic.Vehicle.DRAG]
-        weight = inputs[Dynamic.Vehicle.MASS] * gravity
+        weight = inputs[Dynamic.Vehicle.MASS] * grav_metric
+        outputs[Dynamic.Mission.SPECIFIC_ENERGY_RATE] = velocity * (thrust - drag) / weight
+
+    def compute_partials(self, inputs, J):
+        grav_metric = self.options[Mission.GRAVITY][0]
+
+        velocity = inputs[Dynamic.Mission.VELOCITY]
+        thrust = inputs[Dynamic.Vehicle.Propulsion.THRUST_TOTAL]
+        drag = inputs[Dynamic.Vehicle.DRAG]
+        weight = inputs[Dynamic.Vehicle.MASS] * grav_metric
 
         J[Dynamic.Mission.SPECIFIC_ENERGY_RATE, Dynamic.Mission.VELOCITY] = (thrust - drag) / weight
         J[
@@ -76,5 +81,5 @@ class SpecificEnergyRate(om.ExplicitComponent):
         ] = velocity / weight
         J[Dynamic.Mission.SPECIFIC_ENERGY_RATE, Dynamic.Vehicle.DRAG] = -velocity / weight
         J[Dynamic.Mission.SPECIFIC_ENERGY_RATE, Dynamic.Vehicle.MASS] = (
-            -gravity * velocity * (thrust - drag) / (weight) ** 2
+            -grav_metric * velocity * (thrust - drag) / (weight) ** 2
         )

--- a/aviary/mission/ode/test/test_altitude_rate.py
+++ b/aviary/mission/ode/test/test_altitude_rate.py
@@ -7,7 +7,7 @@ from aviary.mission.ode.altitude_rate import AltitudeRate
 from aviary.utils.test_utils.variable_test import assert_match_varnames
 from aviary.validation_cases.validation_data.test_data.full_mission_test_data import data
 from aviary.validation_cases.validation_tests import do_validation_test
-from aviary.variable_info.variables import Dynamic
+from aviary.variable_info.variables import Dynamic, Mission
 
 
 @use_tempdirs
@@ -17,9 +17,13 @@ class AltitudeRateTest(unittest.TestCase):
 
         time, _ = data.get_item('time')
 
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+        }
+
         prob.model.add_subsystem(
             Dynamic.Mission.ALTITUDE_RATE,
-            AltitudeRate(num_nodes=len(time)),
+            AltitudeRate(num_nodes=len(time), **options),
             promotes_inputs=['*'],
             promotes_outputs=['*'],
         )

--- a/aviary/mission/ode/test/test_specific_energy_rate.py
+++ b/aviary/mission/ode/test/test_specific_energy_rate.py
@@ -7,7 +7,7 @@ from aviary.mission.ode.specific_energy_rate import SpecificEnergyRate
 from aviary.utils.test_utils.variable_test import assert_match_varnames
 from aviary.validation_cases.validation_data.test_data.full_mission_test_data import data
 from aviary.validation_cases.validation_tests import do_validation_test
-from aviary.variable_info.variables import Dynamic
+from aviary.variable_info.variables import Dynamic, Mission
 
 
 @use_tempdirs
@@ -17,9 +17,13 @@ class SpecificEnergyRateTest(unittest.TestCase):
 
         time, _ = data.get_item('time')
 
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+        }
+
         prob.model.add_subsystem(
             'specific_energy_rate',
-            SpecificEnergyRate(num_nodes=len(time)),
+            SpecificEnergyRate(num_nodes=len(time), **options),
             promotes_inputs=['*'],
             promotes_outputs=['*'],
         )

--- a/aviary/subsystems/aerodynamics/flops_based/lift.py
+++ b/aviary/subsystems/aerodynamics/flops_based/lift.py
@@ -2,10 +2,8 @@ import numpy as np
 import openmdao.api as om
 
 import aviary.constants as constants
-from aviary.variable_info.functions import add_aviary_input, add_aviary_output
-from aviary.variable_info.variables import Aircraft, Dynamic
-
-grav_metric = constants.GRAV_METRIC_FLOPS
+from aviary.variable_info.functions import add_aviary_input, add_aviary_output, add_aviary_option
+from aviary.variable_info.variables import Aircraft, Dynamic, Mission
 
 
 class SimpleLift(om.ExplicitComponent):
@@ -64,6 +62,7 @@ class LiftEqualsWeight(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_nodes', types=int)
+        add_aviary_option(self, Mission.GRAVITY, units='m/s**2')
 
     def setup(self):
         nn = self.options['num_nodes']
@@ -81,6 +80,7 @@ class LiftEqualsWeight(om.ExplicitComponent):
     def setup_partials(self):
         nn = self.options['num_nodes']
         row_col = np.arange(nn)
+        grav_metric = self.options[Mission.GRAVITY][0]
 
         self.declare_partials(
             Dynamic.Vehicle.LIFT, Dynamic.Vehicle.MASS, rows=row_col, cols=row_col, val=grav_metric
@@ -102,6 +102,8 @@ class LiftEqualsWeight(om.ExplicitComponent):
         )
 
     def compute(self, inputs, outputs):
+        grav_metric = self.options[Mission.GRAVITY][0]
+
         S = inputs[Aircraft.Wing.AREA]
         q = inputs[Dynamic.Atmosphere.DYNAMIC_PRESSURE]
         weight = grav_metric * inputs[Dynamic.Vehicle.MASS]
@@ -111,6 +113,8 @@ class LiftEqualsWeight(om.ExplicitComponent):
         outputs[Dynamic.Vehicle.LIFT] = weight
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
+        grav_metric = self.options[Mission.GRAVITY][0]
+        
         S = inputs[Aircraft.Wing.AREA]
         q = inputs[Dynamic.Atmosphere.DYNAMIC_PRESSURE]
         weight = grav_metric * inputs[Dynamic.Vehicle.MASS]

--- a/aviary/subsystems/aerodynamics/flops_based/lift.py
+++ b/aviary/subsystems/aerodynamics/flops_based/lift.py
@@ -114,7 +114,7 @@ class LiftEqualsWeight(om.ExplicitComponent):
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
         grav_metric = self.options[Mission.GRAVITY][0]
-        
+
         S = inputs[Aircraft.Wing.AREA]
         q = inputs[Dynamic.Atmosphere.DYNAMIC_PRESSURE]
         weight = grav_metric * inputs[Dynamic.Vehicle.MASS]

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_lift.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_lift.py
@@ -12,7 +12,7 @@ from aviary.validation_cases.validation_tests import (
     get_flops_inputs,
     print_case,
 )
-from aviary.variable_info.variables import Aircraft, Dynamic
+from aviary.variable_info.variables import Aircraft, Dynamic, Mission
 
 data_sets = get_flops_case_names(
     only=['LargeSingleAisle1FLOPS', 'LargeSingleAisle2FLOPS', 'advanced_single_aisle']
@@ -105,7 +105,10 @@ class LiftEqualsWeightTest(unittest.TestCase):
         q, _ = mission_data.get_item(Dynamic.Atmosphere.DYNAMIC_PRESSURE)
         nn = len(q)
 
-        model.add_subsystem('lift_equals_weight', LiftEqualsWeight(num_nodes=nn), promotes=['*'])
+        options = {
+            Mission.GRAVITY: (9.80665, 'm/s**2'),
+        }
+        model.add_subsystem('lift_equals_weight', LiftEqualsWeight(num_nodes=nn, **options), promotes=['*'])
 
         prob.setup(force_alloc_complex=True)
 

--- a/aviary/subsystems/aerodynamics/flops_based/test/test_lift.py
+++ b/aviary/subsystems/aerodynamics/flops_based/test/test_lift.py
@@ -108,7 +108,9 @@ class LiftEqualsWeightTest(unittest.TestCase):
         options = {
             Mission.GRAVITY: (9.80665, 'm/s**2'),
         }
-        model.add_subsystem('lift_equals_weight', LiftEqualsWeight(num_nodes=nn, **options), promotes=['*'])
+        model.add_subsystem(
+            'lift_equals_weight', LiftEqualsWeight(num_nodes=nn, **options), promotes=['*']
+        )
 
         prob.setup(force_alloc_complex=True)
 

--- a/aviary/subsystems/propulsion/utils.py
+++ b/aviary/subsystems/propulsion/utils.py
@@ -19,6 +19,7 @@ from aviary.variable_info.variable_meta_data import CoreMetaData
 from aviary.variable_info.variables import Aircraft, Dynamic, Mission
 import warnings
 
+
 class EngineModelVariables(Enum):
     """Define constants that map to supported variable names in an engine deck."""
 
@@ -98,9 +99,11 @@ def convert_geopotential_altitude(altitude):
         altitude = [altitude]
 
     g = constants.GRAV_EARTH
-    radius_earth = constants.RADIUS_EARTH[0] # meters
+    radius_earth = constants.RADIUS_EARTH[0]  # meters
     if constants.RADIUS_EARTH[1] != 'm':
-        warnings.warn('convert_geopotential_altitude() only functions properly when constants.RADIUS_EARTH is specified in meters!')
+        warnings.warn(
+            'convert_geopotential_altitude() only functions properly when constants.RADIUS_EARTH is specified in meters!'
+        )
     CM1 = 0.99850  # Center of mass (Earth)? Unknown
     OC2 = 26.76566e-10  # Unknown
     GNS = 9.8236930  # grav_accel_at_surface_earth?

--- a/aviary/subsystems/propulsion/utils.py
+++ b/aviary/subsystems/propulsion/utils.py
@@ -97,7 +97,7 @@ def convert_geopotential_altitude(altitude):
     except TypeError:
         altitude = [altitude]
 
-    g = constants.GRAV_METRIC_FLOPS
+    g = constants.GRAV_EARTH
     radius_earth = constants.RADIUS_EARTH_METRIC
     CM1 = 0.99850  # Center of mass (Earth)? Unknown
     OC2 = 26.76566e-10  # Unknown

--- a/aviary/subsystems/propulsion/utils.py
+++ b/aviary/subsystems/propulsion/utils.py
@@ -17,7 +17,7 @@ from aviary.utils.named_values import NamedValues
 from aviary.utils.utils import isiterable
 from aviary.variable_info.variable_meta_data import CoreMetaData
 from aviary.variable_info.variables import Aircraft, Dynamic, Mission
-
+import warnings
 
 class EngineModelVariables(Enum):
     """Define constants that map to supported variable names in an engine deck."""
@@ -98,7 +98,9 @@ def convert_geopotential_altitude(altitude):
         altitude = [altitude]
 
     g = constants.GRAV_EARTH
-    radius_earth = constants.RADIUS_EARTH_METRIC
+    radius_earth = constants.RADIUS_EARTH[0] # meters
+    if constants.RADIUS_EARTH[1] != 'm':
+        warnings.warn('convert_geopotential_altitude() only functions properly when constants.RADIUS_EARTH is specified in meters!')
     CM1 = 0.99850  # Center of mass (Earth)? Unknown
     OC2 = 26.76566e-10  # Unknown
     GNS = 9.8236930  # grav_accel_at_surface_earth?

--- a/aviary/variable_info/variable_meta_data.py
+++ b/aviary/variable_info/variable_meta_data.py
@@ -6902,7 +6902,7 @@ add_meta_data(
     'This ensures the gravity model matches the planet.',
     types=float,
     option=True,
-    # 
+    #
     units=Constants.GRAV_EARTH[1],
     default_value=Constants.GRAV_EARTH[0],
 )

--- a/aviary/variable_info/variable_meta_data.py
+++ b/aviary/variable_info/variable_meta_data.py
@@ -17,6 +17,7 @@ from aviary.variable_info.enums import (
     AtmosphereModel,
 )
 from aviary.variable_info.variables import Aircraft, Dynamic, Mission, Settings
+import aviary.constants as Constants
 
 # ---------------------------
 # Meta data associated with variables in the aircraft data hierarchy.
@@ -6896,11 +6897,14 @@ add_meta_data(
     Mission.GRAVITY,
     meta_data=_MetaData,
     historical_name={'GASP': None, 'FLOPS': None},
-    desc='Gravitational acceleration of the planet.',
+    desc='Gravitational acceleration of the planet. This model is updated'
+    'in preprocess_options() based on which atmosphere is selected.'
+    'This ensures the gravity model matches the planet.',
     types=float,
     option=True,
-    # The default gravity model is set based on Settings.ATMOSPHERE_MODEL
-    units='m/s**2',
+    # 
+    units=Constants.GRAV_EARTH[1],
+    default_value=Constants.GRAV_EARTH[0],
 )
 
 add_meta_data(


### PR DESCRIPTION
### Summary

Follow-on to PR #1227 and #1219

Replaces all references to: GRAV_METRIC_FLOPS, and RADIUS_EARTH_METRIC.
Turns these into options inputs for GRAV_EARTH and RADIUS_EARTH. 

GRAV_ENGLISH_FLOPS was unused and was simply removed.

### Related Issues

Partial fix for #1192 , but more work needs to be done to complete replace GASP GRAV constants.

### Backwards incompatibilities

None

### AI Usage

None.