### PR TITLE
Support `needs_mission_solver` in custom engine models.

### DIFF
--- a/aviary/mission/base_ode.py
+++ b/aviary/mission/base_ode.py
@@ -101,12 +101,13 @@ class BaseODE(om.Group):
 
             if subsystem_mission is not None:
                 target = self
-                needs_sovler = subsystem.needs_mission_solver(
+                needs_solver = subsystem.needs_mission_solver(
                     aviary_inputs=aviary_options,
+                    user_options=user_options,
                     subsystem_options=subsystem_options,
                 )
 
-                if needs_sovler and solver_group is not None:
+                if needs_solver and solver_group is not None:
                     target = solver_group
                     use_mission_solver = True
 

--- a/aviary/mission/test/test_external_subsystems_in_mission.py
+++ b/aviary/mission/test/test_external_subsystems_in_mission.py
@@ -155,7 +155,7 @@ class ExternNoSolve(om.ExplicitComponent):
 class NoSolverBuilder(SubsystemBuilder):
     """Mission only. No solver."""
 
-    def needs_mission_solver(self, aviary_inputs, subsystem_options):
+    def needs_mission_solver(self, aviary_inputs, user_options, subsystem_options):
         return False
 
     def build_mission(self, num_nodes, aviary_inputs, user_options, subsystem_options):
@@ -165,7 +165,7 @@ class NoSolverBuilder(SubsystemBuilder):
 class SolverBuilder(SubsystemBuilder):
     """Mission only. Solver."""
 
-    def needs_mission_solver(self, aviary_inputs, subsystem_options):
+    def needs_mission_solver(self, aviary_inputs, user_options, subsystem_options):
         return True
 
     def build_mission(self, num_nodes, aviary_inputs, user_options, subsystem_options):

--- a/aviary/models/external_subsystems/simple_aero/simple_aero_builder.py
+++ b/aviary/models/external_subsystems/simple_aero/simple_aero_builder.py
@@ -84,7 +84,7 @@ class SimpleAeroBuilder(SubsystemBuilder):
         }
         return params
 
-    def needs_mission_solver(self, aviary_inputs, subsystem_options):
+    def needs_mission_solver(self, aviary_inputs, user_options, subsystem_options):
         """
         Return True if the mission subsystem needs to be in the solver loop in mission, otherwise
         return False. Aviary will only place it in the solver loop when True. The default is

--- a/aviary/subsystems/propulsion/engine_deck.py
+++ b/aviary/subsystems/propulsion/engine_deck.py
@@ -836,6 +836,22 @@ class EngineDeck(EngineModel):
 
         return engine
 
+    def needs_mission_solver(self, aviary_inputs, user_options, subsystem_options):
+        """
+        Return True if the mission subsystem needs to be in the solver loop in mission, otherwise
+        return False. Aviary will only place it in the solver loop when True. The default is
+        True.
+
+        Parameters
+        ----------
+        aviary_inputs : dict
+            Dictionary containing the aircraft definition.
+        subsystem_options : dict
+            Dictionary of optional arguments for this subsystem in this phase.
+
+        """
+        return True
+
     def build_mission(self, num_nodes, aviary_inputs, user_options, subsystem_options) -> om.Group:
         """
         Creates interpolator objects to be added to mission-level propulsion subsystem.
@@ -1688,9 +1704,9 @@ class EngineDeck(EngineModel):
 # UTILITY FUNCTIONS #
 #####################
 """
-Functions that do not directly use attributes of EngineDeck (do not require self) are located here. 
-These functions are currently only used for EngineDecks and are not applicable to other 
-EngineModels. If any of these functions become useful to other EngineModels besides EngineDeck, move 
+Functions that do not directly use attributes of EngineDeck (do not require self) are located here.
+These functions are currently only used for EngineDecks and are not applicable to other
+EngineModels. If any of these functions become useful to other EngineModels besides EngineDeck, move
 them to propulsion utils.
 """
 

--- a/aviary/subsystems/propulsion/engine_deck.py
+++ b/aviary/subsystems/propulsion/engine_deck.py
@@ -850,6 +850,7 @@ class EngineDeck(EngineModel):
             Dictionary of optional arguments for this subsystem in this phase.
 
         """
+        # The engine is generally part of the throttle balance loop if throttle is being solved.
         return True
 
     def build_mission(self, num_nodes, aviary_inputs, user_options, subsystem_options) -> om.Group:

--- a/aviary/subsystems/propulsion/propulsion_builder.py
+++ b/aviary/subsystems/propulsion/propulsion_builder.py
@@ -90,6 +90,19 @@ class CorePropulsionBuilder(PropulsionBuilder):
 
         self.engine_models = engine_models
 
+    def needs_mission_solver(self, aviary_inputs, user_options, subsystem_options):
+        """Call needs_mission_solver() on all engine models and return combined result."""
+        needs_solver = False
+        for engine in self.engine_models:
+            engine_needs_solver = engine.needs_mission_solver(
+                aviary_inputs=aviary_inputs,
+                user_options=user_options,
+                subsystem_options=subsystem_options,
+            )
+            needs_solver = needs_solver or engine_needs_solver
+
+        return needs_solver
+
     def build_pre_mission(self, aviary_inputs, subsystem_options):
         return PropulsionPreMission(
             aviary_options=aviary_inputs,

--- a/aviary/subsystems/propulsion/test/test_custom_engine_model.py
+++ b/aviary/subsystems/propulsion/test/test_custom_engine_model.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import unittest
 
 import dymos as dm
@@ -7,6 +8,7 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.core.aviary_problem import AviaryProblem
+from aviary.models.external_subsystems.simple_aero.simple_aero_builder import SimpleAeroBuilder
 from aviary.subsystems.propulsion.engine_model import EngineModel
 from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.variables import Dynamic
@@ -141,40 +143,46 @@ class SimpleTestEngine(EngineModel):
         return initial_guesses_dict
 
 
+class NoSolverengine(SimpleTestEngine):
+    def needs_mission_solver(self, aviary_inputs, user_options, subsystem_options):
+        return False
+
+
+phase_info = {
+    'pre_mission': {
+        'include_takeoff': False,
+        'optimize_mass': True,
+    },
+    'cruise': {
+        'subsystem_options': {'aerodynamics': {'method': 'computed'}},
+        'user_options': {
+            'num_segments': 2,
+            'order': 3,
+            'mach_optimize': False,
+            'mach_polynomial_order': 1,
+            'mach_initial': (0.72, 'unitless'),
+            'mach_final': (0.72, 'unitless'),
+            'mach_bounds': ((0.7, 0.74), 'unitless'),
+            'altitude_optimize': False,
+            'altitude_polynomial_order': 1,
+            'altitude_initial': (35000.0, 'ft'),
+            'altitude_final': (35000.0, 'ft'),
+            'altitude_bounds': ((23000.0, 38000.0), 'ft'),
+            'throttle_enforcement': 'boundary_constraint',
+            'time_initial': (0.0, 'min'),
+            'time_duration_bounds': ((10.0, 30.0), 'min'),
+        },
+        'initial_guesses': {'time': ([0, 30], 'min')},
+    },
+    'post_mission': {
+        'include_landing': False,
+    },
+}
+
+
 @use_tempdirs
 class CustomEngineTest(unittest.TestCase):
-    def test_custom_engine(self):
-        phase_info = {
-            'pre_mission': {
-                'include_takeoff': False,
-                'optimize_mass': True,
-            },
-            'cruise': {
-                'subsystem_options': {'aerodynamics': {'method': 'computed'}},
-                'user_options': {
-                    'num_segments': 2,
-                    'order': 3,
-                    'mach_optimize': False,
-                    'mach_polynomial_order': 1,
-                    'mach_initial': (0.72, 'unitless'),
-                    'mach_final': (0.72, 'unitless'),
-                    'mach_bounds': ((0.7, 0.74), 'unitless'),
-                    'altitude_optimize': False,
-                    'altitude_polynomial_order': 1,
-                    'altitude_initial': (35000.0, 'ft'),
-                    'altitude_final': (35000.0, 'ft'),
-                    'altitude_bounds': ((23000.0, 38000.0), 'ft'),
-                    'throttle_enforcement': 'boundary_constraint',
-                    'time_initial': (0.0, 'min'),
-                    'time_duration_bounds': ((10.0, 30.0), 'min'),
-                },
-                'initial_guesses': {'time': ([0, 30], 'min')},
-            },
-            'post_mission': {
-                'include_landing': False,
-            },
-        }
-
+    def tzzest_custom_engine(self):
         prob = AviaryProblem(reports=False)
 
         # Load aircraft and options data from user
@@ -210,6 +218,35 @@ class CustomEngineTest(unittest.TestCase):
         tol = 1.0e-4
 
         assert_near_equal(prob.get_val('traj.cruise.rhs_all.y'), 4.0, tol)
+
+    def test_no_solver_loop(self):
+        local_phase_info = deepcopy(phase_info)
+        local_phase_info['cruise']['user_options']['throttle_enforcement'] = 'control'
+        local_phase_info['cruise']['subsystem_options']['aerodynamics'] = {
+            'method': 'external',
+        }
+        prob = AviaryProblem(reports=False)
+
+        prob.load_inputs(
+            'validation_cases/validation_data/test_models/aircraft_for_bench_FwFm.csv',
+            local_phase_info,
+        )
+
+        # Replace both engine and aero with external builders that don't requires solvers.
+        prob.load_external_subsystems([NoSolverengine(), SimpleAeroBuilder()])
+
+        prob.check_and_preprocess_inputs()
+        prob.build_model()
+        prob.add_driver('SLSQP', verbosity=0)
+        prob.add_design_variables()
+        prob.add_objective('fuel_burned')
+
+        prob.setup()
+
+        prob.final_setup()
+
+        subsolver = prob.model.traj.phases.cruise.rhs_all.solver_sub.nonlinear_solver
+        self.assertTrue(isinstance(subsolver, om.NonlinearRunOnce))
 
 
 if __name__ == '__main__':

--- a/aviary/subsystems/propulsion/test/test_custom_engine_model.py
+++ b/aviary/subsystems/propulsion/test/test_custom_engine_model.py
@@ -182,7 +182,7 @@ phase_info = {
 
 @use_tempdirs
 class CustomEngineTest(unittest.TestCase):
-    def tzzest_custom_engine(self):
+    def test_custom_engine(self):
         prob = AviaryProblem(reports=False)
 
         # Load aircraft and options data from user

--- a/aviary/subsystems/propulsion/turboprop_model.py
+++ b/aviary/subsystems/propulsion/turboprop_model.py
@@ -95,10 +95,11 @@ class TurbopropModel(EngineModel):
         if propeller_model is None:
             self.propeller_model = PropellerBuilder(name='propeller')
 
-    def needs_mission_solver(self, aviary_inputs=None, subsystem_options=None):
+    def needs_mission_solver(self, aviary_inputs=None, user_options=None, subsystem_options=None):
         if self.shaft_power_model is not None:
             shp_solver = self.shaft_power_model.needs_mission_solver(
                 aviary_inputs=aviary_inputs,
+                user_options=user_options,
                 subsystem_options=subsystem_options,
             )
         else:
@@ -106,6 +107,7 @@ class TurbopropModel(EngineModel):
         if self.gearbox_model is not None:
             gearbox_solver = self.gearbox_model.needs_mission_solver(
                 aviary_inputs=aviary_inputs,
+                user_options=user_options,
                 subsystem_options=subsystem_options,
             )
         else:
@@ -113,6 +115,7 @@ class TurbopropModel(EngineModel):
         if self.propeller_model is not None:
             prop_solver = self.propeller_model.needs_mission_solver(
                 aviary_inputs=aviary_inputs,
+                user_options=user_options,
                 subsystem_options=subsystem_options,
             )
         else:

--- a/aviary/subsystems/subsystem_builder.py
+++ b/aviary/subsystems/subsystem_builder.py
@@ -33,7 +33,7 @@ class SubsystemBuilder(ABC):
             meta_data = self._default_metadata
         self.meta_data = meta_data
 
-    def needs_mission_solver(self, aviary_inputs, subsystem_options):
+    def needs_mission_solver(self, aviary_inputs, user_options, subsystem_options):
         """
         Return True if the mission subsystem needs to be in the solver loop in mission, otherwise
         return False. Aviary will only place it in the solver loop when True. The default is
@@ -43,6 +43,8 @@ class SubsystemBuilder(ABC):
         ----------
         aviary_inputs : dict
             Dictionary containing the aircraft definition.
+        user_options : dict
+            Dictionary of user options for this phase.
         subsystem_options : dict
             Dictionary of optional arguments for this subsystem in this phase.
 


### PR DESCRIPTION
### Summary

Added support for setting `needs_mission_solver` on a custom engine model, so that it can be left out of the solver loop when requested, provided that throttle is a control. 

Also modified the arguments for `needs_mission_solver` so that user_options are also passed.

### Related Issues

- Resolves #1242

### Backwards incompatibilities

The arguments for `needs_mission_solver` now include "user_options".

### AI Usage

Disclose any AI usage in this PR, including models used and files affected.