### PR TITLE
Improve handling of multivalue defaults.

### DIFF
--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -170,9 +170,9 @@ class AviaryGroup(om.Group):
             kwargs = {'units': units}
 
             if key not in sbc_only_vars:
-
                 # If var has been declared with a shape, and isn't in the aviary_inputs, then
                 # take the default val and broadcast it.
+
                 if not val_in_csv_file and aviary_metadata[key]['multivalue']:
                     if key in shapes and np.isscalar(val):
                         scalar_val = val

--- a/aviary/core/aviary_group.py
+++ b/aviary/core/aviary_group.py
@@ -2,6 +2,7 @@ import inspect
 import sys
 import warnings
 from importlib.util import module_from_spec, spec_from_file_location
+import numpy as np
 from pathlib import Path
 
 import dymos as dm
@@ -112,6 +113,7 @@ class AviaryGroup(om.Group):
         # aviary_group's setup is not complete until after configure.
         sbc_vars = set()
         non_sbc_vars = set()
+        shapes = {}
         for sub in self.system_iter(recurse=False, typ=om.Group):
             pr2abs = sub._resolver.prom2abs_iter('input')
             if sub.pathname == 'traj':
@@ -135,6 +137,11 @@ class AviaryGroup(om.Group):
                 else:
                     non_sbc_vars.add(prom_name)
 
+                    # Find shaped inputs as well.
+                    shape = meta.get('shape')
+                    if np.prod(shape) > 1:
+                        shapes[prom_name] = shape
+
         sbc_only_vars = sbc_vars - non_sbc_vars
 
         for key in aviary_metadata:
@@ -150,16 +157,28 @@ class AviaryGroup(om.Group):
 
             if key in aviary_options:
                 val, units = aviary_options.get_item(key)
+                val_in_csv_file = True
             else:
                 val = aviary_metadata[key]['default_value']
                 units = aviary_metadata[key]['units']
+                val_in_csv_file = False
 
                 if val is None:
                     # optional, but no default value
                     continue
 
             kwargs = {'units': units}
+
             if key not in sbc_only_vars:
+
+                # If var has been declared with a shape, and isn't in the aviary_inputs, then
+                # take the default val and broadcast it.
+                if not val_in_csv_file and aviary_metadata[key]['multivalue']:
+                    if key in shapes and np.isscalar(val):
+                        scalar_val = val
+                        val = np.empty(shapes[key])
+                        val[:] = scalar_val
+
                 # Default val if var doesn't use shape_by_conn.
                 kwargs['val'] = val
 

--- a/aviary/interface/test/test_metadata_shapes.py
+++ b/aviary/interface/test/test_metadata_shapes.py
@@ -20,6 +20,47 @@ from aviary.variable_info.variables import Aircraft
 
 @use_tempdirs
 class TestShapebyConn(unittest.TestCase):
+    def test_multivalue_inputs(self):
+        # Make sure openmdao doesn't try to create a scalar IVC for a shaped input.
+
+        class ShapedComp(om.ExplicitComponent):
+
+            def setup(self):
+                add_aviary_input(self, Aircraft.Design.DRAG_POLAR, shape=(3, 4, 5))
+                self.add_output('z', np.ones(3))
+
+            def compute(self, inputs, outputs):
+                outputs['z'] = inputs[Aircraft.Design.DRAG_POLAR][0]
+
+
+        class ShapedBuilder(SubsystemBuilder):
+
+            def build_pre_mission(self, aviary_inputs, subsystem_options):
+                return ShapedComp()
+
+
+        local_phase_info = deepcopy(energy_phase_info)
+
+        prob = AviaryProblem(verbosity=1)
+
+        prob.load_inputs(
+            'validation_cases/validation_data/test_models/aircraft_for_bench_FwFm.csv',
+            local_phase_info,
+        )
+        prob.load_external_subsystems([ShapedBuilder()])
+
+        prob.check_and_preprocess_inputs()
+
+        prob.build_model()
+        prob.add_design_variables()
+        prob.add_objective()
+
+        prob.setup()
+        prob.final_setup()
+
+        polar = prob.get_val(Aircraft.Design.DRAG_POLAR)
+        self.assertEqual(polar.shape, (3, 4, 5))
+
     def test_shape_bug(self):
         # Verifies that shape_by_conn variables no longer raise an exception during
         # setup.

--- a/aviary/interface/test/test_metadata_shapes.py
+++ b/aviary/interface/test/test_metadata_shapes.py
@@ -24,7 +24,6 @@ class TestShapebyConn(unittest.TestCase):
         # Make sure openmdao doesn't try to create a scalar IVC for a shaped input.
 
         class ShapedComp(om.ExplicitComponent):
-
             def setup(self):
                 add_aviary_input(self, Aircraft.Design.DRAG_POLAR, shape=(3, 4, 5))
                 self.add_output('z', np.ones(3))
@@ -34,10 +33,8 @@ class TestShapebyConn(unittest.TestCase):
 
 
         class ShapedBuilder(SubsystemBuilder):
-
             def build_pre_mission(self, aviary_inputs, subsystem_options):
                 return ShapedComp()
-
 
         local_phase_info = deepcopy(energy_phase_info)
 

--- a/aviary/interface/test/test_metadata_shapes.py
+++ b/aviary/interface/test/test_metadata_shapes.py
@@ -31,7 +31,6 @@ class TestShapebyConn(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['z'] = inputs[Aircraft.Design.DRAG_POLAR][0]
 
-
         class ShapedBuilder(SubsystemBuilder):
             def build_pre_mission(self, aviary_inputs, subsystem_options):
                 return ShapedComp()


### PR DESCRIPTION
### Summary

For multiengine inputs, aviary creates a vector variable whole length is the number of engine types. If any of these inputs were user-facing, and not defined in the csv/aviary_inputs, then Aviary would apply a top level default value from the metadata that was a single-engine scalar value, thereby telling OpenMDAO that the source shape is 1. This of course caused connection errors.

This PR changes the logic in an aviary_group so that we set a default that has been broadcast to the correct shape.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### AI Usage

Disclose any AI usage in this PR, including models used and files affected.