### PR TITLE
Replacing function get_option_defaults() in GASP based mass by AviaryValues()

### DIFF
--- a/aviary/subsystems/mass/gasp_based/avionics.py
+++ b/aviary/subsystems/mass/gasp_based/avionics.py
@@ -3,7 +3,7 @@ import openmdao.api as om
 
 from aviary.constants import GRAV_ENGLISH_LBM
 from aviary.variable_info.functions import add_aviary_input, add_aviary_option, add_aviary_output
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 class AvionicsMass(om.ExplicitComponent):

--- a/aviary/subsystems/mass/gasp_based/test/test_air_conditioning.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_air_conditioning.py
@@ -5,8 +5,8 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.air_conditioning import ACMass, BWBACMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -15,35 +15,35 @@ class ACMassTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
-        self.prob = om.Problem()
-        self.prob.model.add_subsystem(
+        prob = self.prob = om.Problem()
+        prob.model.add_subsystem(
             'ac',
             ACMass(),
             promotes=['*'],
         )
 
-        self.prob.model.set_input_defaults(
+        prob.model.set_input_defaults(
             Aircraft.AirConditioning.MASS_COEFFICIENT, val=1.65, units='unitless'
         )  # large_single_aisle_1_GASP
-        self.prob.model.set_input_defaults(
+        prob.model.set_input_defaults(
             Aircraft.Design.GROSS_MASS, val=175400, units='lbm'
         )  # large_single_aisle_1_GASP
-        self.prob.model.set_input_defaults(
+        prob.model.set_input_defaults(
             Aircraft.Fuselage.LENGTH, val=129.4, units='ft'
         )  # dont know where from
-        self.prob.model.set_input_defaults(
+        prob.model.set_input_defaults(
             Aircraft.Fuselage.PRESSURE_DIFFERENTIAL, val=7.5, units='psi'
         )  # large_single_aisle_1_GASP
-        self.prob.model.set_input_defaults(
+        prob.model.set_input_defaults(
             Aircraft.Fuselage.AVG_DIAMETER, val=13.1, units='ft'
         )  # dont know where from
 
-        setup_model_options(self.prob, options)
+        setup_model_options(prob, options)
 
-        self.prob.setup(check=False, force_alloc_complex=True)
+        prob.setup(check=False, force_alloc_complex=True)
 
     def test_case1(self):
         """case gross_wt_initial > 3500.0"""
@@ -94,35 +94,33 @@ class ACMassTestCase2(unittest.TestCase):
         ac.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
-        self.prob = om.Problem()
-        self.prob.model.add_subsystem(
+        prob = self.prob = om.Problem()
+        prob.model.add_subsystem(
             'ac',
             ACMass(),
             promotes=['*'],
         )
 
-        self.prob.model.set_input_defaults(
+        prob.model.set_input_defaults(
             Aircraft.AirConditioning.MASS_COEFFICIENT, val=1.65, units='unitless'
         )
-        self.prob.model.set_input_defaults(Aircraft.Design.GROSS_MASS, val=175400, units='lbm')
-        self.prob.model.set_input_defaults(Aircraft.Fuselage.LENGTH, val=129.4, units='ft')
-        self.prob.model.set_input_defaults(
-            Aircraft.Fuselage.PRESSURE_DIFFERENTIAL, val=7.5, units='psi'
-        )
-        self.prob.model.set_input_defaults(Aircraft.Fuselage.AVG_DIAMETER, val=13.1, units='ft')
+        prob.model.set_input_defaults(Aircraft.Design.GROSS_MASS, val=175400, units='lbm')
+        prob.model.set_input_defaults(Aircraft.Fuselage.LENGTH, val=129.4, units='ft')
+        prob.model.set_input_defaults(Aircraft.Fuselage.PRESSURE_DIFFERENTIAL, val=7.5, units='psi')
+        prob.model.set_input_defaults(Aircraft.Fuselage.AVG_DIAMETER, val=13.1, units='ft')
 
-        setup_model_options(self.prob, options)
+        setup_model_options(prob, options)
 
-        self.prob.setup(check=False, force_alloc_complex=True)
-        self.prob.run_model()
+        prob.setup(check=False, force_alloc_complex=True)
+        prob.run_model()
 
         tol = 1e-7
-        assert_near_equal(self.prob[Aircraft.AirConditioning.MASS], 1203.68740336, tol)
+        assert_near_equal(prob[Aircraft.AirConditioning.MASS], 1203.68740336, tol)
 
-        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        partial_data = prob.check_partials(out_stream=None, method='cs')
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
@@ -133,7 +131,7 @@ class BWBACMassTestCase1(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         prob = self.prob = om.Problem()
@@ -192,7 +190,7 @@ class BWBACMassTestCase2(unittest.TestCase):
         ac.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         prob = self.prob = om.Problem()
@@ -220,16 +218,16 @@ class BWBACMassTestCase2(unittest.TestCase):
             Aircraft.Fuselage.HYDRAULIC_DIAMETER, 19.365, units='ft'
         )  # dont know where from
 
-        setup_model_options(self.prob, options)
+        setup_model_options(prob, options)
 
-        self.prob.setup(check=False, force_alloc_complex=True)
+        prob.setup(check=False, force_alloc_complex=True)
 
-        self.prob.run_model()
+        prob.run_model()
 
         tol = 1e-7
-        assert_near_equal(self.prob[Aircraft.AirConditioning.MASS], 1183.24239307, tol)
+        assert_near_equal(prob[Aircraft.AirConditioning.MASS], 1183.24239307, tol)
 
-        partial_data = self.prob.check_partials(out_stream=None, method='cs')
+        partial_data = prob.check_partials(out_stream=None, method='cs')
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 

--- a/aviary/subsystems/mass/gasp_based/test/test_anti_icing.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_anti_icing.py
@@ -5,8 +5,8 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.anti_icing import AntiIcingMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -15,7 +15,7 @@ class AntiIcingTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case where SMOOTH_MASS_DISCONTINUITIES is false."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=False, units='unitless')
 
         self.prob = om.Problem()
@@ -68,7 +68,7 @@ class AntiIcingTestCase2(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         self.prob = om.Problem()
@@ -116,7 +116,7 @@ class AntiIcingTestCase3(unittest.TestCase):
     """this is the large single aisle 1 V3 test case where SMOOTH_MASS_DISCONTINUITIES is true."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         self.prob = om.Problem()

--- a/aviary/subsystems/mass/gasp_based/test/test_apu.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_apu.py
@@ -5,8 +5,8 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.apu import APUMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -15,7 +15,7 @@ class ApuTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -45,7 +45,7 @@ class ApuTestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -84,7 +84,7 @@ class ApuTestCase3(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=5, units='unitless'
         )  # large_single_aisle_1_GASP.csv

--- a/aviary/subsystems/mass/gasp_based/test/test_avionics.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_avionics.py
@@ -5,9 +5,9 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.avionics import AvionicsMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 @use_tempdirs
@@ -15,7 +15,7 @@ class AvionicsTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -53,7 +53,7 @@ class AvionicsTestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -100,7 +100,7 @@ class AvionicsTestCase3(unittest.TestCase):
     """this is a mix of BWB conditions with lower passengers and discontinuities off test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=5, units='unitless'
         )  # large_single_aisle_1_GASP.csv

--- a/aviary/subsystems/mass/gasp_based/test/test_cargo_containers.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_cargo_containers.py
@@ -5,8 +5,8 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.cargo_containers import CargoContainerMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -15,7 +15,7 @@ class CargoTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, val=0, units='lbm'
         )  # generic_BWB_GASP
@@ -49,7 +49,7 @@ class CargoTestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, val=0, units='lbm'
         )  # generic_BWB_GASP
@@ -92,7 +92,7 @@ class CargoTestCase3(unittest.TestCase):
     """BWB Parameters."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, val=0, units='lbm'
         )  # generic_BWB_GASP
@@ -126,7 +126,7 @@ class CargoTestCase4(unittest.TestCase):
     """Non zero Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER case"""
 
     def setUp(self):
-        self.options = options = get_option_defaults()
+        self.options = options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, val=0.11, units='lbm')
 

--- a/aviary/subsystems/mass/gasp_based/test/test_control.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_control.py
@@ -7,8 +7,8 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary import constants
 from aviary.subsystems.mass.gasp_based.control import ControlMassGroup
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -128,7 +128,7 @@ class BWBControlMassTestCase(unittest.TestCase):
 @use_tempdirs
 class ControlGroupTestCase1(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -203,7 +203,7 @@ class ControlGroupTestCase2(unittest.TestCase):
         constants.GRAV_ENGLISH_LBM = 1.1
         control.GRAV_ENGLISH_LBM = 1.1
 
-        options = get_option_defaults()
+        options = AviaryValues()
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_crew.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_crew.py
@@ -5,9 +5,9 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.crew import CabinCrewMass, FlightCrewMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.enums import GASPEngineType
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -16,7 +16,7 @@ class CrewTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless'
         )  # arbitrarily set
@@ -61,7 +61,7 @@ class CrewTestCase2(unittest.TestCase):
     """Gravity Modification Test."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless'
         )  # arbitrarily set
@@ -115,7 +115,7 @@ class CrewTestCase3(unittest.TestCase):
     """BWB Parameters."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.RECIP_CARB], units='unitless'
         )  # arbitrarily set

--- a/aviary/subsystems/mass/gasp_based/test/test_design_load.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_design_load.py
@@ -14,8 +14,8 @@ from aviary.subsystems.mass.gasp_based.design_load import (
     LoadParameters,
     LoadSpeeds,
 )
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Mission
 
 
@@ -51,7 +51,7 @@ class LoadSpeedsTestCase1(unittest.TestCase):
 
 class LoadSpeedsTestCase2(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=0, units='unitless')
 
         self.prob = om.Problem()
@@ -87,7 +87,7 @@ class LoadSpeedsTestCase2(unittest.TestCase):
 
 class LoadSpeedsTestCase3(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.LOADING_ABOVE_20, val=False, units='unitless')
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=1, units='unitless')
 
@@ -124,7 +124,7 @@ class LoadSpeedsTestCase3(unittest.TestCase):
 
 class LoadSpeedsTestCase4(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=2, units='unitless')
 
         self.prob = om.Problem()
@@ -160,7 +160,7 @@ class LoadSpeedsTestCase4(unittest.TestCase):
 
 class LoadSpeedsTestCase5(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.LOADING_ABOVE_20, val=False, units='unitless')
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=4, units='unitless')
 
@@ -196,7 +196,7 @@ class LoadSpeedsTestCase6smooth(
     unittest.TestCase
 ):  # this is the large single aisle 1 V3 test case (LoadSpeedsTestCase1) with smooth functions
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         self.prob = om.Problem()
@@ -229,7 +229,7 @@ class LoadSpeedsTestCase6smooth(
 
 class LoadSpeedsTestCase7smooth(unittest.TestCase):  # TestCase2 with smooth functions
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=0, units='unitless')
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
@@ -266,7 +266,7 @@ class LoadSpeedsTestCase7smooth(unittest.TestCase):  # TestCase2 with smooth fun
 
 class LoadSpeedsTestCase8smooth(unittest.TestCase):  # TestCase3 with smooth functions
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.LOADING_ABOVE_20, val=False, units='unitless')
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=1, units='unitless')
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
@@ -304,7 +304,7 @@ class LoadSpeedsTestCase8smooth(unittest.TestCase):  # TestCase3 with smooth fun
 
 class LoadSpeedsTestCase9smooth(unittest.TestCase):  # TestCase4 with smooth functions
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=2, units='unitless')
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
@@ -341,7 +341,7 @@ class LoadSpeedsTestCase9smooth(unittest.TestCase):  # TestCase4 with smooth fun
 
 class LoadSpeedsTestCase10smooth(unittest.TestCase):  # TestCase5 with smooth functions
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.LOADING_ABOVE_20, val=False, units='unitless')
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=4, units='unitless')
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
@@ -377,7 +377,7 @@ class LoadSpeedsTestCase10smooth(unittest.TestCase):  # TestCase5 with smooth fu
 # this is the large single aisle 1 V3 test case
 class LoadParametersTestCase1(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=37500, units='ft')
 
         self.prob = om.Problem()
@@ -404,7 +404,7 @@ class LoadParametersTestCase1(unittest.TestCase):
 
 class LoadParametersTestCase2(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=2, units='unitless')
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=30000, units='ft')
 
@@ -432,7 +432,7 @@ class LoadParametersTestCase2(unittest.TestCase):
 
 class LoadParametersTestCase3(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=4, units='unitless')
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=22000, units='ft')
 
@@ -461,7 +461,7 @@ class LoadParametersTestCase3(unittest.TestCase):
 # this is the large single aisle 1 V3 test case
 class LoadParametersTestCase4smooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=37500, units='ft')
 
@@ -493,7 +493,7 @@ class LoadParametersTestCase4smooth(unittest.TestCase):
 
 class LoadParametersTestCase5smooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=2, units='unitless')
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=30000, units='ft')
@@ -526,7 +526,7 @@ class LoadParametersTestCase5smooth(unittest.TestCase):
 
 class LoadParametersTestCase6smooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=4, units='unitless')
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=22000, units='ft')
@@ -617,7 +617,7 @@ class LoadFactorsTestCase1(unittest.TestCase):
 
 class LoadFactorsTestCase2(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.ULF_CALCULATED_FROM_MANEUVER, val=True, units='unitless')
 
         self.prob = om.Problem()
@@ -657,7 +657,7 @@ class LoadFactorsTestCase2(unittest.TestCase):
 # this is the large single aisle 1 V3 test case
 class LoadFactorsTestCase3smooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
 
         self.prob = om.Problem()
@@ -704,7 +704,7 @@ class LoadFactorsTestCase3smooth(unittest.TestCase):
 
 class LoadFactorsTestCase4smooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.ULF_CALCULATED_FROM_MANEUVER, val=True, units='unitless')
 
         self.prob = om.Problem()
@@ -748,7 +748,7 @@ class LoadFactorsTestCase4smooth(unittest.TestCase):
 # this is the large single aisle 1 V3 test case
 class DesignLoadGroupTestCase1(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=37500, units='ft')
 
         self.prob = om.Problem()
@@ -790,7 +790,7 @@ class DesignLoadGroupTestCase1(unittest.TestCase):
 # this is the large single aisle 1 V3 test case
 class DesignLoadGroupTestCase2smooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=37500, units='ft')
 
@@ -836,7 +836,7 @@ class BWBLoadSpeedsTestCATD3(unittest.TestCase):
     """PART25_STRUCTURAL_CATEGORY = 3."""
 
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=False, units='unitless'
         )  # default
@@ -934,7 +934,7 @@ class BWBLoadSpeedsTestCATD0(unittest.TestCase):
     """PART25_STRUCTURAL_CATEGORY = 0."""
 
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=0, units='unitless')
         self.options.set_val(
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=False, units='unitless'
@@ -1029,7 +1029,7 @@ class BWBLoadSpeedsTestCATD1(unittest.TestCase):
     """PART25_STRUCTURAL_CATEGORY = 1."""
 
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=1, units='unitless')
         self.options.set_val(
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=False, units='unitless'
@@ -1127,7 +1127,7 @@ class BWBLoadSpeedsTestCATD1(unittest.TestCase):
 
 class BWBLoadSpeedsTestCATD2(unittest.TestCase):
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=2, units='unitless')
         self.options.set_val(
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=False, units='unitless'
@@ -1225,7 +1225,7 @@ class BWBLoadSpeedsTestCATD2(unittest.TestCase):
 
 class BWBLoadSpeedsTestCATD4(unittest.TestCase):
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         # In this case, the value of PART25_STRUCTURAL_CATEGORY is used as max_maneuver_factor
         self.options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, val=4, units='unitless')
         self.options.set_val(
@@ -1398,7 +1398,7 @@ class BWBLoadFactorsTestCaseSmooth(unittest.TestCase):
     """Test for smoothing technique"""
 
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless'
         )
@@ -1433,7 +1433,7 @@ class BWBLoadFactorsTestCaseSmooth(unittest.TestCase):
 @use_tempdirs
 class BWBDesignLoadGroupTestCaseNonsmooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=37500, units='ft')
 
         prob = self.prob = om.Problem()
@@ -1468,7 +1468,7 @@ class BWBDesignLoadGroupTestCaseNonsmooth(unittest.TestCase):
 
 class BWBDesignLoadGroupTestCaseSmooth(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=True, units='unitless')
         options.set_val(Aircraft.Design.CRUISE_ALTITUDE, val=37500, units='ft')
         options.set_val(Mission.SEA_LEVEL_DENSITY, val=0.0023769, units='slug/ft**3')

--- a/aviary/subsystems/mass/gasp_based/test/test_electrical.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_electrical.py
@@ -5,8 +5,8 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.electrical import ElectricalMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -15,7 +15,7 @@ class ElectricalTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, val=2, units='unitless')
 
@@ -51,7 +51,7 @@ class ElectricalTestCase2(unittest.TestCase):
     """Gravity Modification"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, val=2, units='unitless')
 
@@ -97,7 +97,7 @@ class ElectricalTestCase3(unittest.TestCase):
     """BWB Parameters"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, val=2, units='unitless')
 

--- a/aviary/subsystems/mass/gasp_based/test/test_emergency_equipment.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_emergency_equipment.py
@@ -2,18 +2,21 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.emergency_equipment import EmergencyEquipment
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
+from aviary.variable_info.options import AviaryValues
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class ElectricalTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -40,7 +43,7 @@ class ElectricalTestCase2(unittest.TestCase):
     """Gravity Modification"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -76,7 +79,7 @@ class ElectricalTestCase3(unittest.TestCase):
     """BWB Parameters"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless'
         )  # large_single_aisle_1_GASP.csv

--- a/aviary/subsystems/mass/gasp_based/test/test_engine.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_engine.py
@@ -7,8 +7,8 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary import constants
 from aviary.subsystems.mass.gasp_based.engine import EngineMassGroup
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import extract_options, setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -17,9 +17,10 @@ class EngineTestCase1(unittest.TestCase):  # this is the large single aisle 1 V3
     """HAS_HYBRID_SYSTEM = False"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2])
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -90,9 +91,10 @@ class EngineTestCase2(unittest.TestCase):
     """HAS_HYBRID_SYSTEM = True"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=True, units='unitless')
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2])
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -169,9 +171,10 @@ class EngineGroupTestCase1(unittest.TestCase):
     """HAS_HYBRID_SYSTEM = False (large single aisle 1 V3)"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2])
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -244,9 +247,10 @@ class EngineGroupTestCase2(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2])
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -326,7 +330,7 @@ class EngineGroupTestCase2(unittest.TestCase):
 @use_tempdirs
 class EngineTestCaseMultiEngine(unittest.TestCase):
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
 
         options.set_val(Aircraft.Engine.NUM_ENGINES, np.array([2, 4]))
@@ -409,7 +413,7 @@ class EngineTestCaseMultiEngine2(unittest.TestCase):
         engine.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
 
         options.set_val(Aircraft.Engine.NUM_ENGINES, np.array([2, 4]))
@@ -488,9 +492,10 @@ class BWBEngineTestCase(unittest.TestCase):
     "GASP BWB model"
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.04373)
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2])
 
         prob = self.prob = om.Problem()
         self.prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_engine_oil.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_engine_oil.py
@@ -2,19 +2,21 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.engine_oil import EngineOilMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.enums import GASPEngineType, Verbosity
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Settings
 
 
+@use_tempdirs
 class ElectricalTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless'
         )  # arbitrarily set
@@ -71,7 +73,7 @@ class ElectricalTestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless'
         )  # arbitrarily set
@@ -114,11 +116,12 @@ class ElectricalTestCase2(unittest.TestCase):
         assert_check_partials(partial_data, atol=8e-12, rtol=1e-12)
 
 
+@use_tempdirs
 class ElectricalTestCase3(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.RECIP_CARB], units='unitless'
         )  # arbitrarily set

--- a/aviary/subsystems/mass/gasp_based/test/test_engine_oil.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_engine_oil.py
@@ -8,7 +8,6 @@ from aviary.subsystems.mass.gasp_based.engine_oil import EngineOilMass
 from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.enums import GASPEngineType, Verbosity
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Settings
 
 

--- a/aviary/subsystems/mass/gasp_based/test/test_engine_oil.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_engine_oil.py
@@ -2,19 +2,22 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.engine_oil import EngineOilMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.enums import GASPEngineType, Verbosity
 from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Settings
 
 
+@use_tempdirs
 class TestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless'
         )  # arbitrarily set
@@ -92,7 +95,7 @@ class TestCase2(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless'
         )  # arbitrarily set
@@ -139,7 +142,7 @@ class TestCase3(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.Engine.TYPE, val=[GASPEngineType.RECIP_CARB], units='unitless'
         )  # arbitrarily set
@@ -147,6 +150,7 @@ class TestCase3(unittest.TestCase):
             Aircraft.Propulsion.TOTAL_NUM_ENGINES, val=2, units='unitless'
         )  # large_single_aisle_1_GASP.csv
         options.set_val(Settings.VERBOSITY, val=0, units='unitless')  # arbitrarily set
+        options.set_val(Aircraft.Engine.NUM_ENGINES, val=[2], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_equipment_and_operating_items.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_equipment_and_operating_items.py
@@ -14,6 +14,7 @@ from aviary.subsystems.mass.gasp_based.mass_summation import (
     SystemsEquipmentMass,
     OperatingItemsMass,
 )
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Mission, Settings
@@ -23,7 +24,7 @@ class EquipmentMassSummationTest(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         # options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         # options.set_val(Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless')
 

--- a/aviary/subsystems/mass/gasp_based/test/test_equipment_and_operating_items.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_equipment_and_operating_items.py
@@ -15,8 +15,8 @@ from aviary.subsystems.mass.gasp_based.mass_summation import (
     OperatingItemsMass,
 )
 from aviary.utils.aviary_values import AviaryValues
+from aviary.variable_info.enums import AircraftTypes, GASPEngineType
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Mission, Settings
 
 
@@ -65,9 +65,16 @@ class EquipMassGroupTest(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -132,7 +139,7 @@ class OperatingItemsMassSumTest(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         # options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         # options.set_val(Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless')
 
@@ -183,9 +190,11 @@ class UsefulMassGroupTest(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Settings.VERBOSITY, val=0, units='unitless')
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -238,9 +247,19 @@ class FixedEquipAndUsefulMassGroupTest(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Design.TYPE, val=AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, 0.0, units='lbm')
+        options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, 180, units='unitless')
+        options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -332,9 +351,19 @@ class BWBFixedEquipMassGroupTest(unittest.TestCase):
     """Created based on GASP BWB model."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
         options.set_val(Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Design.TYPE, val=AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, 0.0, units='lbm')
+        options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, 180, units='unitless')
+        options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(
@@ -396,9 +425,18 @@ class BWBOperatingItemsMassSumTest(unittest.TestCase):
     """Created based on GASP BWB model."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
         options.set_val(Settings.VERBOSITY, 0)
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Design.TYPE, val=AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, 0.0, units='lbm')
+        options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(
@@ -446,10 +484,18 @@ class BWBFixedEquipAndUsefulMassGroupTest(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
         options.set_val(Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless')
         options.set_val(Aircraft.Design.TYPE, val='BWB', units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, 0.0, units='lbm')
+        options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_fixed.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fixed.py
@@ -17,6 +17,7 @@ from aviary.subsystems.mass.gasp_based.fixed import (
     VerticalTailMass,
 )
 from aviary.utils.aviary_values import AviaryValues
+from aviary.variable_info.enums import FlapType
 from aviary.variable_info.functions import extract_options, setup_model_options
 from aviary.variable_info.options import AviaryValues
 from aviary.variable_info.variables import Aircraft, Mission, Settings
@@ -29,7 +30,8 @@ class MassParametersTestCase1(unittest.TestCase):
     def setUp(self):
         options = AviaryValues()
         options.set_val(Settings.VERBOSITY, 0)
-        options.set_val(Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED, val=True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -636,6 +638,7 @@ class GearTestCase1(unittest.TestCase):  # this is the large single aisle 1 V3 t
 class GearTestCase2(unittest.TestCase):
     def setUp(self):
         options = AviaryValues()
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
         self.prob = om.Problem()
         self.prob.model.add_subsystem('gear_mass', LandingGearMassGroup(), promotes=['*'])
 
@@ -726,6 +729,14 @@ class FixedMassGroupTestCase1(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Settings.VERBOSITY, 0)
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
+        options.set_val(Aircraft.Wing.FLAP_TYPE, FlapType.DOUBLE_SLOTTED, units='unitless')
+        options.set_val(Aircraft.Wing.NUM_FLAP_SEGMENTS, 2, units='unitless')
+        options.set_val(Mission.SEA_LEVEL_DENSITY, 1.225, units='kg/m**3')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -953,9 +964,15 @@ class FixedMassGroupTestCase2(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, val=0, units='unitless')
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
-        options.set_val(Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED, val=False, units='unitless')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14)
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=True, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
+        options.set_val(Aircraft.Wing.FLAP_TYPE, FlapType.DOUBLE_SLOTTED, units='unitless')
+        options.set_val(Aircraft.Wing.NUM_FLAP_SEGMENTS, 2, units='unitless')
+        options.set_val(Mission.SEA_LEVEL_DENSITY, 1.225, units='kg/m**3')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1671,6 +1688,13 @@ class BWBFixedMassGroupTestCase1(unittest.TestCase):
         options.set_val(Settings.VERBOSITY, 0)
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.04373)
         options.set_val(Mission.SEA_LEVEL_DENSITY, 0.0023769, units='slug/ft**3')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
+        options.set_val(Aircraft.Wing.FLAP_TYPE, FlapType.DOUBLE_SLOTTED, units='unitless')
+        options.set_val(Aircraft.Wing.NUM_FLAP_SEGMENTS, 2, units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_fixed.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fixed.py
@@ -18,7 +18,7 @@ from aviary.subsystems.mass.gasp_based.fixed import (
 )
 from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import extract_options, setup_model_options
-from aviary.variable_info.options import get_option_defaults
+from aviary.variable_info.options import AviaryValues
 from aviary.variable_info.variables import Aircraft, Mission, Settings
 
 
@@ -27,7 +27,7 @@ class MassParametersTestCase1(unittest.TestCase):
     """this is large single aisle 1 v3 bug fixed test case."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Settings.VERBOSITY, 0)
         options.set_val(Aircraft.Strut.DIMENSIONAL_LOCATION_SPECIFIED, val=True, units='unitless')
 
@@ -80,7 +80,7 @@ class MassParametersTestCase1(unittest.TestCase):
 @use_tempdirs
 class MassParametersTestCase2(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, val=0, units='unitless')
 
         self.prob = om.Problem()
@@ -128,7 +128,7 @@ class MassParametersTestCase2(unittest.TestCase):
 @use_tempdirs
 class MassParametersTestCase3(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, val=3, units='unitless')
 
         self.prob = om.Problem()
@@ -176,7 +176,7 @@ class MassParametersTestCase3(unittest.TestCase):
 @use_tempdirs
 class MassParametersTestCase4(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, val=4, units='unitless')
 
         self.prob = om.Problem()
@@ -224,7 +224,7 @@ class MassParametersTestCase4(unittest.TestCase):
 @use_tempdirs
 class MassParametersTestCase5(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, val=4, units='unitless')
 
         self.prob = om.Problem()
@@ -273,7 +273,7 @@ class MassParametersTestCase5(unittest.TestCase):
 @use_tempdirs
 class PayloadGroupTestCase(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
 
@@ -486,7 +486,7 @@ class HighLiftTestCase(unittest.TestCase):
     def setUp(self):
         self.prob = om.Problem()
 
-        aviary_options = get_option_defaults()
+        aviary_options = AviaryValues()
         aviary_options.set_val(Aircraft.Wing.NUM_FLAP_SEGMENTS, val=2)
 
         self.prob.model.add_subsystem('HL', HighLiftMass(), promotes=['*'])
@@ -543,7 +543,7 @@ class HighLiftTestCase2(unittest.TestCase):
     def setUp(self):
         self.prob = om.Problem()
 
-        aviary_options = get_option_defaults()
+        aviary_options = AviaryValues()
         aviary_options.set_val(Aircraft.Wing.NUM_FLAP_SEGMENTS, val=2)
 
         self.prob.model.add_subsystem('HL', HighLiftMass(), promotes=['*'])
@@ -635,7 +635,7 @@ class GearTestCase1(unittest.TestCase):  # this is the large single aisle 1 V3 t
 @use_tempdirs
 class GearTestCase2(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         self.prob = om.Problem()
         self.prob.model.add_subsystem('gear_mass', LandingGearMassGroup(), promotes=['*'])
 
@@ -676,7 +676,7 @@ class GearTestCase2(unittest.TestCase):
 @use_tempdirs
 class GearTestCaseMultiengine(unittest.TestCase):
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
 
         options.set_val(Aircraft.Engine.NUM_ENGINES, np.array([2, 4]))
 
@@ -720,7 +720,7 @@ class GearTestCaseMultiengine(unittest.TestCase):
 @use_tempdirs
 class FixedMassGroupTestCase1(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
@@ -948,7 +948,7 @@ class FixedMassGroupTestCase1(unittest.TestCase):
 @use_tempdirs
 class FixedMassGroupTestCase2(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, val=0, units='unitless')
@@ -1396,7 +1396,7 @@ class BWBMassParametersTestCase(unittest.TestCase):
     """GASP BWB model"""
 
     def setUp(self):
-        self.options = options = get_option_defaults()
+        self.options = options = AviaryValues()
         options.set_val(Settings.VERBOSITY, 0)
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 0, units='unitless')
 
@@ -1464,7 +1464,7 @@ class BWBPayloadGroupTestCase(unittest.TestCase):
     "GASP BWB model"
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=150, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
 
@@ -1568,7 +1568,7 @@ class BWBHighLiftTestCase(unittest.TestCase):
     def setUp(self):
         prob = self.prob = om.Problem()
 
-        aviary_options = get_option_defaults()
+        aviary_options = AviaryValues()
         aviary_options.set_val(Aircraft.Wing.FLAP_TYPE, val=4)
         aviary_options.set_val(Aircraft.Wing.NUM_FLAP_SEGMENTS, val=2)
         aviary_options.set_val(Mission.SEA_LEVEL_DENSITY, 0.0023769, units='slug/ft**3')
@@ -1663,7 +1663,7 @@ class BWBGearTestCase(unittest.TestCase):
 @use_tempdirs
 class BWBFixedMassGroupTestCase1(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Design.TYPE, val='BWB', units='unitless')
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=150, units='unitless')

--- a/aviary/subsystems/mass/gasp_based/test/test_fuel.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fuel.py
@@ -15,7 +15,6 @@ from aviary.subsystems.mass.gasp_based.fuel import (
 from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.enums import Verbosity
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft, Mission, Settings
 
 

--- a/aviary/subsystems/mass/gasp_based/test/test_fuel_capacity.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_fuel_capacity.py
@@ -5,8 +5,9 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.fuel_capacity import TrappedFuelCapacity
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
+from aviary.variable_info.options import AviaryValues
 from aviary.variable_info.variables import Aircraft
 
 
@@ -15,7 +16,7 @@ class TrappedFuelCapacityCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = self.options = get_option_defaults()
+        options = self.options = AviaryValues()
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -66,7 +67,7 @@ class TrappedFuelCapacityCase2(unittest.TestCase):
     """Gravity Modification"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -112,7 +113,7 @@ class TrappedFuelCapacityCase3(unittest.TestCase):
     """BWB Parameters"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_furnishings.py
@@ -5,8 +5,9 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.furnishings import BWBFurnishingMass, FurnishingMass
+from aviary.utils.aviary_values import AviaryValues
+from aviary.variable_info.enums import GASPEngineType
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -15,9 +16,10 @@ class FurnishingMassTestCase1(unittest.TestCase):
     """Created based on EquipMassTestCase1"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.Furnishings.USE_EMPIRICAL_EQUATION, val=True, units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -70,13 +72,14 @@ class FurnishingMassTestCase2(unittest.TestCase):
         furnishings.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
         options.set_val(
             Aircraft.Furnishings.USE_EMPIRICAL_EQUATION, val=True, units='unitless'
         )  # arbitrary
+        options.set_val(Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -112,11 +115,12 @@ class FurnishingMassTestCase3(unittest.TestCase):
     """
 
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=49, units='unitless')
         self.options.set_val(
             Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, val=False, units='unitless'
         )
+        self.options.set_val(Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -182,11 +186,12 @@ class BWBFurnishingMassTestCase1(unittest.TestCase):
     """
 
     def setUp(self):
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
         self.options.set_val(
             Aircraft.Furnishings.USE_EMPIRICAL_EQUATION, val=True, units='unitless'
         )
+        self.options.set_val(Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(
@@ -289,8 +294,9 @@ class BWBFurnishingMassTestCase2(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(
@@ -348,11 +354,12 @@ class BWBFurnishingMassTestCase3(unittest.TestCase):
         USE_EMPIRICAL_EQUATION = True
         SMOOTH_MASS_DISCONTINUITIES = False
         """
-        self.options = get_option_defaults()
+        self.options = AviaryValues()
         self.options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
         self.options.set_val(
             Aircraft.Furnishings.USE_EMPIRICAL_EQUATION, val=True, units='unitless'
         )
+        self.options.set_val(Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(
@@ -398,8 +405,9 @@ class BWBFurnishingMassTestCase4(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, val=[GASPEngineType.TURBOJET], units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(
@@ -436,3 +444,6 @@ class BWBFurnishingMassTestCase4(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    # test = FurnishingMassTestCase2()
+    # test.setUp()
+    # test.test_case1()

--- a/aviary/subsystems/mass/gasp_based/test/test_hydraulics.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_hydraulics.py
@@ -2,6 +2,8 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
+
 
 from aviary.subsystems.mass.gasp_based.hydraulics import HydraulicsMass
 from aviary.utils.aviary_values import AviaryValues
@@ -9,6 +11,7 @@ from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class HydraulicsTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_hydraulics.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_hydraulics.py
@@ -4,8 +4,8 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from aviary.subsystems.mass.gasp_based.hydraulics import HydraulicsMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -13,7 +13,7 @@ class HydraulicsTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless'
         )  # large single aisle GASP
@@ -56,7 +56,7 @@ class HydraulicsTestCase2(unittest.TestCase):
     """BWB Parameters"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.LandingGear.FIXED_GEAR, val=False, units='unitless'
         )  # large single aisle GASP

--- a/aviary/subsystems/mass/gasp_based/test/test_instruments.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_instruments.py
@@ -2,6 +2,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
 
 from aviary.subsystems.mass.gasp_based.instruments import InstrumentMass
 from aviary.utils.aviary_values import AviaryValues
@@ -10,6 +11,7 @@ from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class InstrumentTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_instruments.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_instruments.py
@@ -4,17 +4,17 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from aviary.subsystems.mass.gasp_based.instruments import InstrumentMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.enums import GASPEngineType
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 class InstrumentTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -61,7 +61,7 @@ class InstrumentTestCase2(unittest.TestCase):
     """BWB Parameters"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless'
         )  # large_single_aisle_1_GASP.csv

--- a/aviary/subsystems/mass/gasp_based/test/test_mass_premission.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_mass_premission.py
@@ -12,8 +12,8 @@ from aviary.validation_cases.validation_data.test_data.V3_bug_fixed_IO import (
     V3_bug_fixed_non_metadata,
     V3_bug_fixed_options,
 )
+from aviary.variable_info.enums import AircraftTypes, GASPEngineType
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variable_meta_data import CoreMetaData
 from aviary.variable_info.variables import Aircraft, Mission
 
@@ -133,7 +133,7 @@ class MassPremissionTestCase2(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
@@ -150,6 +150,20 @@ class MassPremissionTestCase2(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.SEAT_PITCH_ECONOMY, 29, units='inch')
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Wing.HAS_FOLD, val=False, units='unitless')
+        options.set_val(Aircraft.Wing.HAS_STRUT, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -390,18 +404,119 @@ class MassPremissionTestCase2(unittest.TestCase):
         self.prob.setup(check=False, force_alloc_complex=True)
 
     def test_case1(self):
-        self.prob.run_model()
+        prob = self.prob
+        prob.run_model()
 
         tol = 5e-4
         # size values:
-        assert_near_equal(self.prob['size.cabin_height'], 13.1, tol)
-        assert_near_equal(self.prob['size.cabin_len'], 72.1, tol)
-        assert_near_equal(self.prob['size.nose_height'], 8.6, tol)
+        # FuselageParameters
+        assert_near_equal(prob['size.cabin_height'], 13.1, tol)
+        assert_near_equal(prob['size.cabin_len'], 72.1, tol)
+        assert_near_equal(prob['size.nose_height'], 8.6, tol)
+        # FuselageSize
+        assert_near_equal(prob[Aircraft.Fuselage.LENGTH], 129.49722222, tol)
+        assert_near_equal(prob[Aircraft.Fuselage.WETTED_AREA], 4000.00108449, tol)
+        assert_near_equal(prob[Aircraft.TailBoom.LENGTH], 129.49722222, tol)
+        assert_near_equal(prob[Aircraft.Fuselage.CABIN_AREA], 1068.92361111, tol)
+        # WingSize
+        assert_near_equal(prob[Aircraft.Wing.AREA], 1370.3125, tol)
+        assert_near_equal(prob[Aircraft.Wing.SPAN], 117.81878299, tol)
+        # WingParameters
+        assert_near_equal(prob[Aircraft.Wing.CENTER_CHORD], 17.48974356, tol)
+        assert_near_equal(prob[Aircraft.Wing.AVERAGE_CHORD], 12.61453233, tol)
+        assert_near_equal(prob[Aircraft.Wing.ROOT_CHORD], 16.40711451, tol)
+        assert_near_equal(prob[Aircraft.Wing.THICKNESS_TO_CHORD_UNWEIGHTED], 0.13965584, tol)
+        assert_near_equal(prob[Aircraft.Wing.LEADING_EDGE_SWEEP], 0.47639483, tol)
+        # WingVolume
+        assert_near_equal(prob[Aircraft.Fuel.WING_VOLUME_GEOMETRIC_MAX], 1114.00563103, tol)
+        # GASPEngineDiameter
+        assert_near_equal(prob[Aircraft.Nacelle.AVG_DIAMETER], 7.351408, tol)
+        # GASPEngineLength
+        assert_near_equal(prob[Aircraft.Nacelle.AVG_LENGTH], 14.702816, tol)
+        # GASPEngineSurfaceArea
+        assert_near_equal(prob[Aircraft.Nacelle.SURFACE_AREA], 339.5634375, tol)
+        # LoadSpeeds
+        assert_near_equal(prob['max_airspeed'], 350.0, tol)
+        assert_near_equal(prob['vel_c'], 350.0, tol)
+        assert_near_equal(prob['max_maneuver_factor'], 2.5, tol)
+        assert_near_equal(prob['min_dive_vel'], 420.0, tol)
+        # MassParameters
+        assert_near_equal(prob[Aircraft.Wing.MATERIAL_FACTOR], 1.22128833, tol)
+        assert_near_equal(prob['c_strut_braced'], 1, tol)
+        assert_near_equal(prob['c_gear_loc'], 1, tol)
+        assert_near_equal(prob[Aircraft.Propulsion.ENGINE_POSITION_FACTOR], 0.95, tol)
+        assert_near_equal(prob['half_sweep'], 0.39471574, tol)
+        # PayloadGroup
+        assert_near_equal(prob[Aircraft.CrewPayload.PASSENGER_PAYLOAD_MASS], 36000.0, tol)
+        assert_near_equal(prob[Aircraft.CrewPayload.TOTAL_PAYLOAD_MASS], 36000.0, tol)
+        assert_near_equal(prob['payload_mass_des'], 36000.0, tol)
+        assert_near_equal(prob['payload_mass_max'], 46040.0, tol)
+        # ACMass
+        assert_near_equal(prob[Aircraft.AirConditioning.MASS], 1324.55345246, tol)
+        # FurnishingMass
+        assert_near_equal(prob[Aircraft.Furnishings.MASS], 13268.77210825, tol)
+        # AntiIcingMass
+        assert_near_equal(prob[Aircraft.AntiIcing.MASS], 683.47110765, tol)
+        # APUMass
+        assert_near_equal(prob[Aircraft.APU.MASS], 1077.969377, tol)
+        # AvionicsMass
+        assert_near_equal(prob[Aircraft.Avionics.MASS], 1514.0, tol)
+        # ElectricalMass
+        assert_near_equal(prob[Aircraft.Electrical.MASS], 170.0, tol)
+        # HydraulicsMass
+        assert_near_equal(prob[Aircraft.Hydraulics.MASS], 1479.33343636, tol)
+        # InstrumentMass
+        assert_near_equal(prob[Aircraft.Instruments.MASS], 547.49288363, tol)
+        # OxygenSystemMass
+        assert_near_equal(prob[Aircraft.OxygenSystem.MASS], 50.0, tol)
+        # WingMassSolve
+        assert_near_equal(prob['isolated_wing_mass'], 15652.61578394, tol)
+        # StrutAndFoldMass
+        assert_near_equal(prob[Aircraft.Strut.MASS], 0.0, tol)
+        assert_near_equal(prob[Aircraft.Wing.FOLD_MASS], 0, tol)
+        # WingMassTotal
+        assert_near_equal(prob[Aircraft.Wing.MASS], 15652.61578394, tol)
+        # FuelSysAndFullFuselageMass
+        assert_near_equal(prob['fus_mass_full'], 101584.83829383, tol)
+        # FuselageMass
+        assert_near_equal(prob[Aircraft.Fuselage.MASS], 18614.6407651, tol)
+        # FuelMass
+        assert_near_equal(prob['fuel_mass'], 43756.89535681, tol)
+        assert_near_equal(prob['fuel_mass_required'], 43756.89535681, tol)
+        assert_near_equal(prob['fuel_mass_min'], 33716.89535681, tol)
+        # FuelComponents
+        assert_near_equal(prob[Aircraft.Fuel.UNUSABLE_FUEL_MASS], 619.8317956, tol)
+        # BodyTankCalculations
+        assert_near_equal(prob[Aircraft.Fuel.AUXILIARY_FUEL_MASS_CAPACITY], 0, tol)
+        assert_near_equal(prob['extra_fuel_volume'], 0, tol)
+        assert_near_equal(prob['max_extra_fuel_mass'], 0, tol)
+        assert_near_equal(prob['wingfuel_mass_min'], 33716.89535681, tol)
+        assert_near_equal(prob[Aircraft.Fuel.TOTAL_CAPACITY], 44376.72715242, tol)
+        # EmpennageMass
+        assert_near_equal(prob[Aircraft.Design.EMPENNAGE_MASS], 4574.10130526, tol)
+        # StructureMass
+        assert_near_equal(prob[Aircraft.Design.STRUCTURE_MASS], 50136.9197232, tol)
+        # PropulsionMass
+        assert_near_equal(prob[Aircraft.Propulsion.MASS], 16164.80430963, tol)
+        # SystemsEquipmentMass
+        assert_near_equal(prob[Aircraft.Design.SYSTEMS_AND_EQUIPMENT_MASS], 23934.94881476, tol)
+        # EmptyMass
+        assert_near_equal(prob[Aircraft.Design.EMPTY_MASS], 90236.67284758, tol)
+        # OperatingItemsMass
+        assert_near_equal(prob[Mission.OPERATING_ITEMS_MASS], 5406.4317956, tol)
+        # OperatingMass
+        assert_near_equal(prob[Mission.OPERATING_MASS], 95643.10464319, tol)
+        # ZeroFuelMass
+        assert_near_equal(prob[Mission.ZERO_FUEL_MASS], 131643.10464319, tol)
+        # UsefulLoadMass
+        assert_near_equal(prob[Aircraft.Design.USEFUL_LOAD_MASS], 85163.32715242, tol)
 
-        assert_near_equal(self.prob[Aircraft.Wing.CENTER_CHORD], 17.49, tol)
-        assert_near_equal(self.prob[Aircraft.Wing.ROOT_CHORD], 16.41, tol)
+        # assert_near_equal(prob[Aircraft], 14, tol)
+
+        assert_near_equal(prob[Aircraft.Wing.CENTER_CHORD], 17.49, tol)
+        assert_near_equal(prob[Aircraft.Wing.ROOT_CHORD], 16.41, tol)
         assert_near_equal(
-            self.prob[Aircraft.Wing.THICKNESS_TO_CHORD_UNWEIGHTED], 0.1397, tol
+            prob[Aircraft.Wing.THICKNESS_TO_CHORD_UNWEIGHTED], 0.1397, tol
         )  # not exact GASP value from the output file, likely due to rounding error
 
         # note: this is not the value in the GASP output, because the output calculates
@@ -488,7 +603,8 @@ class MassPremissionTestCase3(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
+
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
@@ -505,6 +621,19 @@ class MassPremissionTestCase3(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.SEAT_PITCH_ECONOMY, 29, units='inch')
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Wing.HAS_FOLD, val=False, units='unitless')
+        options.set_val(Aircraft.Wing.HAS_STRUT, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -834,7 +963,7 @@ class MassPremissionTestCase4(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
@@ -851,6 +980,19 @@ class MassPremissionTestCase4(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.SEAT_PITCH_ECONOMY, 29, units='inch')
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Wing.HAS_FOLD, val=False, units='unitless')
+        options.set_val(Aircraft.Wing.HAS_STRUT, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1188,7 +1330,7 @@ class MassSummationTestCase5(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
@@ -1205,6 +1347,20 @@ class MassSummationTestCase5(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.SEAT_PITCH_ECONOMY, 29, units='inch')
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Wing.HAS_FOLD, val=False, units='unitless')
+        options.set_val(Aircraft.Wing.HAS_STRUT, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1537,7 +1693,7 @@ class MassSummationTestCase6(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless')
         options.set_val(Aircraft.CrewPayload.NUM_PASSENGERS, val=180, units='unitless')
@@ -1554,6 +1710,19 @@ class MassSummationTestCase6(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.SEAT_PITCH_ECONOMY, 29, units='inch')
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.14, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Wing.HAS_FOLD, val=False, units='unitless')
+        options.set_val(Aircraft.Wing.HAS_STRUT, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -1887,7 +2056,7 @@ class MassSummationTestCase7(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=154, units='unitless')
@@ -1904,6 +2073,18 @@ class MassSummationTestCase7(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.SEAT_PITCH_ECONOMY, 29, units='inch')
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.165, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Wing.HAS_STRUT, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Design.SMOOTH_MASS_DISCONTINUITIES, False, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -2259,7 +2440,7 @@ class MassSummationTestCase8(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=False, units='unitless')
@@ -2279,6 +2460,16 @@ class MassSummationTestCase8(unittest.TestCase):
         options.set_val(Aircraft.CrewPayload.Design.SEAT_PITCH_ECONOMY, 44.2, units='inch')
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.163, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -2631,7 +2822,7 @@ class MassSummationTestCase9(unittest.TestCase):
     """
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
         options.set_val(Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=154, units='unitless')
@@ -2651,6 +2842,16 @@ class MassSummationTestCase9(unittest.TestCase):
         options.set_val(Aircraft.Fuselage.SEAT_WIDTH_ECONOMY, 20.2, units='inch')
         options.set_val(Aircraft.Engine.ADDITIONAL_MASS_FRACTION, 0.163, units='unitless')
         options.set_val(Aircraft.Electrical.HAS_HYBRID_SYSTEM, val=True, units='unitless')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.COMPUTE_VTAIL_VOLUME_COEFF, val=False, units='unitless')
+        options.set_val(Aircraft.Design.TYPE, AircraftTypes.TRANSPORT, units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 2, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -3019,7 +3220,7 @@ class BWBMassSummationTestCase(unittest.TestCase):
     """GASP BWB model."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         # options from SizeGroup
         options.set_val(Aircraft.Design.TYPE, val='BWB', units='unitless')
         options.set_val(Aircraft.Design.COMPUTE_HTAIL_VOLUME_COEFF, val=False, units='unitless')
@@ -3049,6 +3250,18 @@ class BWBMassSummationTestCase(unittest.TestCase):
         options.set_val(Aircraft.Engine.NUM_FUSELAGE_ENGINES, 2, units='unitless')
         options.set_val(Aircraft.Propulsion.TOTAL_NUM_WING_ENGINES, 0, units='unitless')
         options.set_val(Aircraft.CrewPayload.ULD_MASS_PER_PASSENGER, 0.0667, units='lbm')
+
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
+        options.set_val(Aircraft.Engine.TYPE, [GASPEngineType.TURBOJET], units='unitless')
+        options.set_val(Aircraft.Design.PART25_STRUCTURAL_CATEGORY, 3, units='unitless')
+        options.set_val(Aircraft.Wing.LOADING_ABOVE_20, True, units='unitless')
+        options.set_val(Aircraft.BWB.DETAILED_WING_PROVIDED, True, units='unitless')
+        options.set_val(Aircraft.BWB.MAX_BAY_WIDTH, 0.0, units='ft')
+        options.set_val(Aircraft.BWB.MAX_NUM_BAYS, 0, units='unitless')
+        options.set_val(Aircraft.Design.ULF_CALCULATED_FROM_MANEUVER, False, units='unitless')
+        options.set_val(Mission.SEA_LEVEL_DENSITY, 1.225, units='kg/m**3')
+        options.set_val(Aircraft.Furnishings.USE_EMPIRICAL_EQUATION, True, units='unitless')
+        options.set_val(Aircraft.Propulsion.TOTAL_NUM_ENGINES, 2, units='unitless')
 
         prob = self.prob = om.Problem()
         prob.model.add_subsystem(

--- a/aviary/subsystems/mass/gasp_based/test/test_oxygen_system.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_oxygen_system.py
@@ -4,16 +4,16 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from aviary.subsystems.mass.gasp_based.oxygen_system import OxygenSystemMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 class OxygenSystemTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -50,7 +50,7 @@ class OxygenSystemTestCase2(unittest.TestCase):
     """Gravity Modification"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -96,7 +96,7 @@ class OxygenSystemTestCase3(unittest.TestCase):
     """BWB Parameters"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless'
         )  # large_single_aisle_1_GASP.csv

--- a/aviary/subsystems/mass/gasp_based/test/test_passenger_service.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_passenger_service.py
@@ -4,8 +4,8 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 
 from aviary.subsystems.mass.gasp_based.passenger_service import PassengerServiceMass
+from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
 from aviary.variable_info.variables import Aircraft
 
 
@@ -13,7 +13,7 @@ class PassengerServiceTestCase1(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=180, units='unitless'
         )  # large_single_aisle_1_GASP.csv
@@ -53,7 +53,7 @@ class PassengerServiceTestCase2(unittest.TestCase):
     """BWB Parameters"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(
             Aircraft.CrewPayload.Design.NUM_PASSENGERS, val=150, units='unitless'
         )  # large_single_aisle_1_GASP.csv

--- a/aviary/subsystems/mass/gasp_based/test/test_wing.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_wing.py
@@ -17,6 +17,7 @@ from aviary.variable_info.functions import setup_model_options
 from aviary.variable_info.variables import Aircraft
 
 
+@use_tempdirs
 class WingMassSolveTestCase(unittest.TestCase):
     """this is the large single aisle 1 V3 test case."""
 

--- a/aviary/subsystems/mass/gasp_based/test/test_wing.py
+++ b/aviary/subsystems/mass/gasp_based/test/test_wing.py
@@ -14,8 +14,7 @@ from aviary.subsystems.mass.gasp_based.wing import (
 )
 from aviary.utils.aviary_values import AviaryValues
 from aviary.variable_info.functions import setup_model_options
-from aviary.variable_info.options import get_option_defaults
-from aviary.variable_info.variables import Aircraft, Mission
+from aviary.variable_info.variables import Aircraft
 
 
 class WingMassSolveTestCase(unittest.TestCase):
@@ -170,7 +169,7 @@ class TotalWingMassTestCase2(unittest.TestCase):
     """Has fold and no strut."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
 
         self.prob = om.Problem()
@@ -210,7 +209,7 @@ class TotalWingMassTestCase3(unittest.TestCase):
     """Has strut and no fold."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
 
         self.prob = om.Problem()
@@ -244,7 +243,7 @@ class TotalWingMassTestCase4(unittest.TestCase):
     """Has fold and strut."""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
 
@@ -331,7 +330,7 @@ class TotalWingMassTestCase6(unittest.TestCase):
         wing.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -376,7 +375,7 @@ class TotalWingMassTestCase7(unittest.TestCase):
         wing.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
         prob = om.Problem()
         prob.model.add_subsystem(
@@ -417,7 +416,7 @@ class TotalWingMassTestCase8(unittest.TestCase):
         wing.GRAV_ENGLISH_LBM = 1.0
 
     def test_case1(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
         prob = om.Problem()
@@ -492,8 +491,9 @@ class WingMassGroupTestCase1(unittest.TestCase):
 
 class WingMassGroupTestCase2(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -551,8 +551,9 @@ class WingMassGroupTestCase2(unittest.TestCase):
 
 class WingMassGroupTestCase3(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem(
@@ -604,9 +605,10 @@ class WingMassGroupTestCase3(unittest.TestCase):
 
 class WingMassGroupTestCase4(unittest.TestCase):
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         options.set_val(Aircraft.Wing.HAS_STRUT, val=True, units='unitless')
+        options.set_val(Aircraft.Engine.NUM_ENGINES, [2], units='unitless')
 
         self.prob = om.Problem()
         self.prob.model.add_subsystem('group', WingMassGroup(), promotes=['*'])
@@ -800,7 +802,7 @@ class BWBWingMassGroupTest(unittest.TestCase):
     """this is the large single aisle 1 V3 test case"""
 
     def setUp(self):
-        options = get_option_defaults()
+        options = AviaryValues()
         options.set_val(Aircraft.Wing.HAS_FOLD, val=True, units='unitless')
         options.set_val(Aircraft.Engine.NUM_ENGINES, val=[2], units='unitless')
 
@@ -854,3 +856,6 @@ class BWBWingMassGroupTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    test = WingMassGroupTestCase2()
+    test.setUp()
+    # test.test_case1()

--- a/aviary/subsystems/mass/gasp_based/wing.py
+++ b/aviary/subsystems/mass/gasp_based/wing.py
@@ -402,12 +402,7 @@ class BWBWingMassSolve(om.ImplicitComponent):
     (but excluding struts and fold effects) using a nonlinear solver.
     """
 
-    def initialize(self):
-        add_aviary_option(self, Aircraft.Engine.NUM_ENGINES)
-
     def setup(self):
-        num_engine_type = len(self.options[Aircraft.Engine.NUM_ENGINES])
-
         add_aviary_input(self, Aircraft.Design.GROSS_MASS, units='lbm')
         add_aviary_input(self, Aircraft.Wing.HIGH_LIFT_MASS, units='lbm')
         self.add_input(


### PR DESCRIPTION
### Summary

Replaced all of `get_option_defaults()` functions in GASP based mass subsystem unit tests by `AviaryValues()` and individual settings of each needed options.

This is part of issue #1251.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### AI Usage

None