### PR TITLE
skip solved2dof benchmarks when pyOptSparse is unavailable

### DIFF
--- a/aviary/validation_cases/benchmark_tests/test_bench_solved2dof.py
+++ b/aviary/validation_cases/benchmark_tests/test_bench_solved2dof.py
@@ -4,13 +4,14 @@ import aviary.api as av
 from aviary.models.missions.solved2dof_default import phase_info
 from aviary.models.missions.solved2dof_landing_default import phase_info as phase_info_landing
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 
 
 @use_tempdirs
 class TestBenchSolved2DOF(unittest.TestCase):
     """Run the model in serial that is setup in ProblemPhaseTestCase class."""
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_bench_Solved2DOF(self):
         subsystem_options = {
             'aerodynamics': {
@@ -106,6 +107,7 @@ class TestBenchSolved2DOF(unittest.TestCase):
         assert_near_equal(prob.get_val(av.Mission.FINAL_TIME, units='s'), 108.84030411, tol)
         assert_near_equal(prob.get_val(av.Mission.FUEL_MASS, units='lbm'), 459.3830223, tol)
 
+    @require_pyoptsparse(optimizer='IPOPT')
     def test_bench_Solved2DOF_landing(self):
         # This problem solves better with a reduced ref for objective time, therefore need to call add_objectve()
         subsystem_options = {


### PR DESCRIPTION
Both tests in test_bench_solved2dof.py drive the problem with IPOPT, which requires pyOptSparse, but the file never imported or applied @require_pyoptsparse. Without pyOptSparse installed they raise "ImportError: pyOptSparseDriver is not available" and fail, rather than skipping the way every other pyOptSparse-dependent benchmark does.

This is the only benchmark file that uses a pyOptSparse optimizer without the decorator; the 20 others already guard their IPOPT/SNOPT tests this way.

### Summary
aviary/validation_cases/benchmark_tests/test_bench_solved2dof.py runs both of its benchmarks with the IPOPT optimizer (optimizer='IPOPT' in test_bench_Solved2DOF, add_driver('IPOPT', ...) in test_bench_Solved2DOF_landing), which requires pyOptSparse. The file never imported or applied @require_pyoptsparse, so in an environment without pyOptSparse both tests fail:

ImportError: pyOptSparseDriver is not available, pyOptsparse is not installed.
This is the only benchmark file that uses a pyOptSparse optimizer without the decorator. The other 20 benchmark files already guard their IPOPT/SNOPT tests this way, and test_subsystems_within_a_mission.py correctly needs no guard because it uses SLSQP. This was not a regression: IPOPT has been used here since the file was added in 529de2f, and the decorator was never present.

This PR adds @require_pyoptsparse(optimizer='IPOPT') to both tests so they skip cleanly, matching the existing convention in test_bench_GwGm.py.

Effect on a full testflo . run without pyOptSparse: 2 failed / 46 skipped becomes 0 failed / 48 skipped. On a machine that does have pyOptSparse with IPOPT, behavior is unchanged: require_pyoptsparse returns the test object untouched when the import and OPT(optimizer) both succeed, so these benchmarks still run and still assert as before.

### Related Issues
Resolves #
Backwards incompatibilities
None. No source behavior changes; this only affects test collection when an optional dependency is missing.

### AI Usage
This change was assisted with Claude (Opus 5) via Claude Code. The AI model didn't code anything, but instead helped me get an idea of what I need to do.