### PR TITLE
Reinstall Aviary from target tag before building docs

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -93,6 +93,20 @@ jobs:
                             # versions.json ends up empty.
           path: src
 
+      # Re-install Aviary from the tag checkout in ./src/. prepare_docs_environment
+      # already did `pip install -e .` at the workspace root, but that installed
+      # whatever ref its own internal actions/checkout landed there (the workflow
+      # ref, typically main) -- NOT the tag we're publishing. Without this
+      # override, Sphinx autodoc imports resolve against the wrong version and
+      # any modules that were renamed/moved between the tag and main fail to
+      # import, filling the build with "no module named ..." warnings.
+      - name: Reinstall Aviary from target tag
+        shell: bash -l {0}
+        working-directory: src
+        run: |
+          eval "$(pixi shell-hook -e py313 --manifest-path=${{ env.PIXI_MANIFEST }})"
+          pip install -e .[all]
+
       - name: Build docs
         id: build_docs
         shell: bash -l {0}


### PR DESCRIPTION
prepare_docs_environment does `pip install -e .[all]` at the workspace root, but its internal actions/checkout puts the WORKFLOW's ref there (typically main), not the tag we're publishing. Sphinx autodoc then imports against wrong-version aviary and warns on every module that was renamed or moved between the tag and main:

  WARNING: Failed to import aviary.utils.option_to_var.
  WARNING: Failed to import aviary.core.post_mission_group.
  WARNING: Failed to import aviary.core.pre_mission_group.

Added an explicit `pip install -e .[all]` from ./src/ after the tag checkout so autodoc sees the same version whose docs it's building.

### Summary

Summary of PR.

### Related Issues

- Resolves #966 

### Backwards incompatibilities

None

### AI Usage

Claude Code was used to help guide the solution to this problem.